### PR TITLE
Move timers to timer module

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,6 @@ use std::io::Cursor;
 use std::rc::Rc;
 use std::sync::Arc;
 
-use chrono::prelude::*;
 use image::io::Reader as ImageReader;
 use image::{EncodableLayout, ImageFormat};
 use procedural::debug_condition;
@@ -347,13 +346,6 @@ fn main() {
     let mut entities = Vec::<Entity>::new();
     let mut player_inventory = Inventory::default();
 
-    // move
-    const TIME_FACTOR: f32 = 1000.0;
-    let local: DateTime<Local> = Local::now();
-    let mut day_timer = (local.hour() as f32 / TIME_FACTOR * 60.0 * 60.0) + (local.minute() as f32 / TIME_FACTOR * 60.0);
-    let mut animation_timer = 0.0;
-    //
-
     let welcome_message = ChatMessage::new("Welcome to Korangar!".to_string(), Color::rgb(220, 170, 220));
     let chat_messages = Rc::new(RefCell::new(vec![welcome_message]));
 
@@ -423,10 +415,9 @@ fn main() {
                 input_system.update_delta();
 
                 let delta_time = game_timer.update();
+                let day_timer = game_timer.get_day_timer();
+                let animation_timer = game_timer.get_animation_timer();
                 let client_tick = game_timer.get_client_tick();
-
-                day_timer += delta_time as f32 / TIME_FACTOR;
-                animation_timer += delta_time as f32;
 
                 networking_system.keep_alive(delta_time, client_tick);
 
@@ -725,13 +716,13 @@ fn main() {
                         #[cfg(feature = "debug")]
                         UserEvent::OpenTimeWindow => interface.open_window(&mut focus_state, &TimeWindow::default()),
                         #[cfg(feature = "debug")]
-                        UserEvent::SetDawn => day_timer = 0.0,
+                        UserEvent::SetDawn => game_timer.set_day_timer(0.0),
                         #[cfg(feature = "debug")]
-                        UserEvent::SetNoon => day_timer = std::f32::consts::FRAC_PI_2,
+                        UserEvent::SetNoon => game_timer.set_day_timer(std::f32::consts::FRAC_PI_2),
                         #[cfg(feature = "debug")]
-                        UserEvent::SetDusk => day_timer = std::f32::consts::PI,
+                        UserEvent::SetDusk => game_timer.set_day_timer(std::f32::consts::PI),
                         #[cfg(feature = "debug")]
-                        UserEvent::SetMidnight => day_timer = -std::f32::consts::FRAC_PI_2,
+                        UserEvent::SetMidnight => game_timer.set_day_timer(-std::f32::consts::FRAC_PI_2),
                         #[cfg(feature = "debug")]
                         UserEvent::OpenThemeViewerWindow => interface.open_theme_viewer_window(&mut focus_state),
                         #[cfg(feature = "debug")]

--- a/src/system/timer.rs
+++ b/src/system/timer.rs
@@ -1,26 +1,39 @@
 use std::time::Instant;
 
-use derive_new::new;
+use chrono::prelude::*;
 
 use crate::network::ClientTick;
 
-#[derive(new)]
 pub struct GameTimer {
-    #[new(value = "Instant::now()")]
     global_timer: Instant,
-    #[new(default)]
     previous_elapsed: f64,
-    #[new(default)]
     accumulate_second: f64,
-    #[new(default)]
     frame_counter: usize,
-    #[new(default)]
     frames_per_second: usize,
-    #[new(value = "ClientTick(0)")]
+    animation_timer: f32,
+    day_timer: f32,
     client_tick: ClientTick,
 }
 
+const TIME_FACTOR: f32 = 1000.0;
+
 impl GameTimer {
+    pub fn new() -> Self {
+        let local: DateTime<Local> = Local::now();
+        let day_timer = (local.hour() as f32 / TIME_FACTOR * 60.0 * 60.0) + (local.minute() as f32 / TIME_FACTOR * 60.0);
+
+        Self {
+            global_timer: Instant::now(),
+            previous_elapsed: Default::default(),
+            accumulate_second: Default::default(),
+            frame_counter: Default::default(),
+            frames_per_second: Default::default(),
+            animation_timer: Default::default(),
+            day_timer,
+            client_tick: ClientTick(0),
+        }
+    }
+
     pub fn set_client_tick(&mut self, client_tick: ClientTick) {
         self.client_tick = client_tick;
     }
@@ -29,12 +42,27 @@ impl GameTimer {
         self.client_tick
     }
 
+    #[cfg(feature = "debug")]
+    pub fn set_day_timer(&mut self, day_timer: f32) {
+        self.day_timer = day_timer;
+    }
+
+    pub fn get_day_timer(&self) -> f32 {
+        self.day_timer
+    }
+
+    pub fn get_animation_timer(&self) -> f32 {
+        self.animation_timer
+    }
+
     pub fn update(&mut self) -> f64 {
         let new_elapsed = self.global_timer.elapsed().as_secs_f64();
         let delta_time = new_elapsed - self.previous_elapsed;
 
         self.frame_counter += 1;
         self.accumulate_second += delta_time;
+        self.day_timer += delta_time as f32 / TIME_FACTOR;
+        self.animation_timer += delta_time as f32;
         self.previous_elapsed = new_elapsed;
 
         if self.accumulate_second > 1.0 {
@@ -48,7 +76,26 @@ impl GameTimer {
         delta_time
     }
 
+    #[cfg(feature = "debug")]
     pub fn last_frames_per_second(&self) -> usize {
         self.frames_per_second
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn update_sets_timers() {
+        let mut game_timer = GameTimer::new();
+        let day_timer = game_timer.get_day_timer();
+
+        let elapsed = game_timer.update();
+        let updated_game_timer = game_timer.get_day_timer();
+        let updated_animation_timer = game_timer.get_animation_timer();
+
+        assert_eq!(updated_game_timer, day_timer + elapsed as f32);
+        assert_eq!(updated_animation_timer, elapsed as f32);
     }
 }

--- a/src/system/timer.rs
+++ b/src/system/timer.rs
@@ -87,7 +87,21 @@ mod test {
     use super::*;
 
     #[test]
-    fn update_sets_timers() {
+    fn update_increments_client_tick() {
+        let mut game_timer = GameTimer::new();
+        let elapsed = game_timer.update();
+        assert_eq!(game_timer.client_tick.0, (elapsed * 1075.0) as u32);
+    }
+
+    #[test]
+    fn update_increments_frame_counter() {
+        let mut game_timer = GameTimer::new();
+        game_timer.update();
+        assert_eq!(game_timer.frame_counter, 1);
+    }
+
+    #[test]
+    fn update_increments_timers() {
         let mut game_timer = GameTimer::new();
         let day_timer = game_timer.get_day_timer();
 


### PR DESCRIPTION
Related to: https://github.com/vE5li/korangar/issues/4

Took the opportunity to move the `animation_timer` as well since it was only used and calculated in the main.rs file and was tightly coupled with the `GameTimer` module.

Also added some unit testing to the `GameTimer` module.