### PR TITLE
Stop updating game-tick with server-tick

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -497,8 +497,9 @@ fn main() {
                             // cursor always look correct.
                             interface.set_start_time(game_timer.get_client_tick());
                         }
-                        NetworkEvent::UpdateClientTick(client_tick) => {
-                            game_timer.set_client_tick(client_tick);
+                        NetworkEvent::UpdateClientTick(_) => {
+                            // Ignored for now since server tick doesn't affect
+                            // client tick
                         }
                         NetworkEvent::ChatMessage(message) => {
                             chat_messages.borrow_mut().push(message);

--- a/src/main.rs
+++ b/src/main.rs
@@ -498,8 +498,8 @@ fn main() {
                             interface.set_start_time(game_timer.get_client_tick());
                         }
                         NetworkEvent::UpdateClientTick(_) => {
-                            // Ignored for now since server tick doesn't affect
-                            // client tick
+                            // Ignored for now since client tick shouldn't be
+                            // updated based on server tick
                         }
                         NetworkEvent::ChatMessage(message) => {
                             chat_messages.borrow_mut().push(message);

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -79,9 +79,7 @@ pub enum NetworkEvent {
     EntityMove(EntityId, Vector2<usize>, Vector2<usize>, ClientTick),
     /// Player was moved to a new position on a different map or the current map
     ChangeMap(String, Vector2<usize>),
-    /// Update the client side [tick
-    /// counter](crate::system::GameTimer::client_tick) to keep server and
-    /// client synchronized
+    /// Tick message from server
     UpdateClientTick(ClientTick),
     /// New chat message for the client
     ChatMessage(ChatMessage),

--- a/src/system/timer.rs
+++ b/src/system/timer.rs
@@ -71,7 +71,7 @@ impl GameTimer {
             self.frame_counter = 0;
         }
 
-        self.client_tick.0 += (delta_time * 1075.0) as u32;
+        self.client_tick.0 += (delta_time * 1000.0) as u32;
 
         delta_time
     }
@@ -90,7 +90,7 @@ mod test {
     fn update_increments_client_tick() {
         let mut game_timer = GameTimer::new();
         let elapsed = game_timer.update();
-        assert_eq!(game_timer.client_tick.0, (elapsed * 1075.0) as u32);
+        assert_eq!(game_timer.client_tick.0, (elapsed * 1000.0) as u32);
     }
 
     #[test]


### PR DESCRIPTION
This caused SOME of the instability and "rubber banding", especially with animations that are entirely client-side. 

This doesn't resolve all issues described in #6 since rubber banding between server-client can still happen for several other reasons. 

Leaving it as a draft still because I am still trying to compare if the animation speed is correct... it looks better compared to the actual client now but I am unsure if these changes won't affect anything else:

```
self.client_tick.0 += (delta_time * 1000.0) as u32;
```