### PR TITLE
Allow colors by default on windows (only disable terminal colors with plain feature)

### DIFF
--- a/src/debug/logging/colors.rs
+++ b/src/debug/logging/colors.rs
@@ -1,4 +1,4 @@
-#[cfg(any(target_os = "windows", feature = "plain"))]
+#[cfg(feature = "plain")]
 mod colors {
     pub const GREEN: &str = "";
     pub const RED: &str = "";
@@ -8,7 +8,7 @@ mod colors {
     pub const NONE: &str = "";
 }
 
-#[cfg(not(any(target_os = "windows", feature = "plain")))]
+#[cfg(not(feature = "plain"))]
 mod colors {
     pub const GREEN: &str = "\x1B[32m";
     pub const RED: &str = "\x1B[31m";


### PR DESCRIPTION
Since PowerShell + windows terminal supports the same colors as UNIX terminals we can have it as default and use the plain feature to remove the colors when needed.

This wasn't discussed before but I was testing some things on windows and noticed that colors were missing since the colors feature was disabled by default on windows. What do you think about it? @vE5li 