### PR TITLE
Improve hp/sp bars

### DIFF
--- a/src/graphics/renderers/deferred/mod.rs
+++ b/src/graphics/renderers/deferred/mod.rs
@@ -43,6 +43,7 @@ use self::sprite::SpriteRenderer;
 use self::water::WaterRenderer;
 use self::water_light::WaterLightRenderer;
 use crate::graphics::{EntityRenderer as EntityRendererTrait, GeometryRenderer as GeometryRendererTrait, *};
+use crate::interface::Theme;
 use crate::loaders::{GameFileLoader, TextureLoader};
 use crate::network::EntityId;
 #[cfg(feature = "debug")]
@@ -373,28 +374,15 @@ impl DeferredRenderer {
         &self,
         render_target: &mut <Self as Renderer>::Target,
         position: Vector2<f32>,
+        size: Vector2<f32>,
         color: Color,
         maximum: f32,
         current: f32,
     ) {
-        const BAR_BG_WIDTH: f32 = 76.0;
-        const BAR_BG_HEIGHT: f32 = 12.0;
-        const BAR_WIDTH: f32 = 70.0;
-        const BAR_HEIGHT: f32 = 6.0;
-        let bg_offset = Vector2::new(BAR_BG_WIDTH / 2.0, 0.0);
-        let bar_offset = Vector2::new(BAR_WIDTH / 2.0, (BAR_HEIGHT - BAR_BG_HEIGHT) / 2.0);
-        self.render_rectangle(
-            render_target,
-            position - bg_offset,
-            Vector2::new(BAR_BG_WIDTH, BAR_BG_HEIGHT),
-            Color::monochrome(40),
-        );
-        self.render_rectangle(
-            render_target,
-            position - bar_offset,
-            Vector2::new((BAR_WIDTH / maximum) * current, BAR_HEIGHT),
-            color,
-        );
+        let bar_offset = Vector2::new(size.x / 2.0, 0.0);
+        let bar_size = Vector2::new((size.x / maximum) * current, size.y);
+
+        self.render_rectangle(render_target, position - bar_offset, bar_size, color);
     }
 
     #[cfg(feature = "debug")]

--- a/src/graphics/renderers/deferred/mod.rs
+++ b/src/graphics/renderers/deferred/mod.rs
@@ -377,18 +377,22 @@ impl DeferredRenderer {
         maximum: f32,
         current: f32,
     ) {
-        const BAR_SIZE: f32 = 70.0;
-        let offset = Vector2::new(BAR_SIZE / 2.0, 0.0);
+        const BAR_BG_WIDTH: f32 = 76.0;
+        const BAR_BG_HEIGHT: f32 = 12.0;
+        const BAR_WIDTH: f32 = 70.0;
+        const BAR_HEIGHT: f32 = 6.0;
+        let bg_offset = Vector2::new(BAR_BG_WIDTH / 2.0, 0.0);
+        let bar_offset = Vector2::new(BAR_WIDTH / 2.0, (BAR_HEIGHT - BAR_BG_HEIGHT) / 2.0);
         self.render_rectangle(
             render_target,
-            position - offset,
-            Vector2::new(BAR_SIZE, 5.0),
+            position - bg_offset,
+            Vector2::new(BAR_BG_WIDTH, BAR_BG_HEIGHT),
             Color::monochrome(40),
         );
         self.render_rectangle(
             render_target,
-            position - offset,
-            Vector2::new((BAR_SIZE / maximum) * current, 5.0),
+            position - bar_offset,
+            Vector2::new((BAR_WIDTH / maximum) * current, BAR_HEIGHT),
             color,
         );
     }

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -116,6 +116,10 @@ impl Interface {
         self.theme.save(&self.interface_settings.theme_file);
     }
 
+    pub fn get_theme(&self) -> &Theme {
+        &self.theme
+    }
+
     pub fn schedule_rerender(&mut self) {
         self.rerender = true;
     }

--- a/src/interface/theme.rs
+++ b/src/interface/theme.rs
@@ -320,6 +320,43 @@ impl Default for ProfilerTheme {
     }
 }
 
+#[derive(Serialize, Deserialize, PrototypeElement)]
+pub struct StatusBarTheme {
+    pub background_color: Mutable<Color, Nothing>,
+    pub player_health_color: Mutable<Color, Nothing>,
+    pub enemy_health_color: Mutable<Color, Nothing>,
+    pub spell_point_color: Mutable<Color, Nothing>,
+    pub activity_point_color: Mutable<Color, Nothing>,
+    pub player_bar_width: MutableRange<f32, Rerender>,
+    pub enemy_bar_width: MutableRange<f32, Rerender>,
+    pub health_height: MutableRange<f32, Rerender>,
+    pub enemy_health_height: MutableRange<f32, Rerender>,
+    pub spell_point_height: MutableRange<f32, Rerender>,
+    pub activity_point_height: MutableRange<f32, Rerender>,
+    pub border_size: MutableRange<Vector2<f32>, Rerender>,
+    pub gap: MutableRange<f32, Rerender>,
+}
+
+impl Default for StatusBarTheme {
+    fn default() -> Self {
+        Self {
+            background_color: Mutable::new(Color::monochrome(40)),
+            player_health_color: Mutable::new(Color::rgb(67, 163, 83)),
+            enemy_health_color: Mutable::new(Color::rgb(206, 49, 116)),
+            spell_point_color: Mutable::new(Color::rgb(0, 129, 163)),
+            activity_point_color: Mutable::new(Color::rgb(218, 145, 81)),
+            player_bar_width: MutableRange::new(85.0, 20.0, 300.0),
+            enemy_bar_width: MutableRange::new(60.0, 20.0, 300.0),
+            health_height: MutableRange::new(8.0, 2.0, 30.0),
+            enemy_health_height: MutableRange::new(6.0, 2.0, 30.0),
+            spell_point_height: MutableRange::new(4.0, 2.0, 30.0),
+            activity_point_height: MutableRange::new(4.0, 2.0, 30.0),
+            border_size: MutableRange::new(Vector2::from_value(3.0), Vector2::from_value(0.0), Vector2::from_value(20.0)),
+            gap: MutableRange::new(1.0, 0.0, 10.0),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Default, PrototypeWindow)]
 #[window_title("Theme Viewer")]
 #[window_class("theme_viewer")]
@@ -344,6 +381,7 @@ pub struct Theme {
     pub chat: ChatTheme,
     pub cursor: CursorTheme,
     pub profiler: ProfilerTheme,
+    pub status_bar: StatusBarTheme,
 }
 
 impl Theme {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1202,14 +1202,18 @@ fn main() {
                     let entity = entities.iter().find(|entity| entity.get_entity_id() == entity_id);
 
                     if let Some(entity) = entity {
-                        entity.render_status(screen_target, &deferred_renderer, current_camera, window_size);
+                        entity.render_status(
+                            screen_target,
+                            &deferred_renderer,
+                            current_camera,
+                            interface.get_theme(),
+                            window_size,
+                        );
 
                         if let Some(name) = &entity.get_details() {
                             let name = name.split('#').next().unwrap();
                             interface.render_hover_text(screen_target, &deferred_renderer, name, input_system.get_mouse_position());
                         }
-
-                        entity.render_status(screen_target, &deferred_renderer, current_camera, window_size);
                     }
                 }
 
@@ -1217,7 +1221,13 @@ fn main() {
                     #[cfg(feature = "debug")]
                     profile_block!("render player status");
 
-                    entities[0].render_status(screen_target, &deferred_renderer, current_camera, window_size);
+                    entities[0].render_status(
+                        screen_target,
+                        &deferred_renderer,
+                        current_camera,
+                        interface.get_theme(),
+                        window_size,
+                    );
                 }
 
                 #[cfg(feature = "debug")]

--- a/src/world/entity/mod.rs
+++ b/src/world/entity/mod.rs
@@ -628,14 +628,14 @@ impl Player {
         );
         renderer.render_bar(
             render_target,
-            final_position + Vector2::new(0.0, 5.0),
+            final_position + Vector2::new(0.0, 9.0),
             Color::rgb(67, 129, 163),
             self.maximum_spell_points as f32,
             self.spell_points as f32,
         );
         renderer.render_bar(
             render_target,
-            final_position + Vector2::new(0.0, 10.0),
+            final_position + Vector2::new(0.0, 18.0),
             Color::rgb(163, 96, 67),
             self.maximum_activity_points as f32,
             self.activity_points as f32,


### PR DESCRIPTION
This is a proposed solution for #23 

Bars: 5px -> 6px 
Outline: 0px -> 3px

The PR tries to improve HP/SP mini-display with accessibility in mind:
- Bigger bars are easier to see, they help the player keep track of their resources.
- An outline greatly improves contrast between bars and what is happening on the screen.

![Screenshot_2023-07-20_22-28-29-2](https://github.com/vE5li/korangar/assets/4411178/d531365a-99ce-4562-b6ca-71a5cae3df01)

