### PR TITLE
Fixed #57 caused by overflow in length_hint while reading sprite data

### DIFF
--- a/src/loaders/map/data.rs
+++ b/src/loaders/map/data.rs
@@ -77,7 +77,7 @@ pub struct GroundData {
     pub surface_count: i32,
     #[repeating(self.surface_count)]
     pub surfaces: Vec<Surface>,
-    #[repeating(self.width * self.height)]
+    #[repeating(self.width as usize * self.height as usize)]
     pub ground_tiles: Vec<GroundTile>,
 }
 

--- a/src/loaders/sprite/mod.rs
+++ b/src/loaders/sprite/mod.rs
@@ -93,7 +93,7 @@ struct PaletteImageData {
 struct RgbaImageData {
     pub width: u16,
     pub height: u16,
-    #[length_hint(self.width * self.height * 4)]
+    #[length_hint(self.width as u32 * self.height as u32 * 4)]
     pub data: Vec<u8>,
 }
 

--- a/src/loaders/sprite/mod.rs
+++ b/src/loaders/sprite/mod.rs
@@ -82,10 +82,10 @@ struct PaletteImageData {
     pub width: u16,
     pub height: u16,
     #[version_equals_or_above(2, 1)]
-    #[length_hint(self.width * self.height)]
+    #[length_hint(self.width as usize * self.height as usize)]
     pub encoded_data: Option<EncodedData>,
     #[version_smaller(2, 1)]
-    #[length_hint(self.width * self.height)]
+    #[length_hint(self.width as usize * self.height as usize)]
     pub raw_data: Option<Vec<u8>>,
 }
 
@@ -93,7 +93,7 @@ struct PaletteImageData {
 struct RgbaImageData {
     pub width: u16,
     pub height: u16,
-    #[length_hint(self.width as u32 * self.height as u32 * 4)]
+    #[length_hint(self.width as usize * self.height as usize * 4)]
     pub data: Vec<u8>,
 }
 


### PR DESCRIPTION
While reading some sprite data using `ByteConvertable` proc_macro, a helper attribute is used to give hints about the length of the buffer containing data of `RgbaImageData`. This hint was being calculated multiplying `width` and `height` attributes of said struct, both declared as u16, and causing a overflow while calculating the total size of the buffer.

In order to calculate the size of the buffer, both parameters are casted to u32 before the multiplication.