### PR TITLE
Scale entities down by 30 %

### DIFF
--- a/src/world/entity/mod.rs
+++ b/src/world/entity/mod.rs
@@ -728,7 +728,7 @@ impl Common {
             texture,
             self.position,
             Vector3::new(position.x, position.y, 0.0),
-            Vector2::from_value(1.0),
+            Vector2::from_value(0.7),
             Vector2::new(1, 1),
             Vector2::new(0, 0),
             mirror,


### PR DESCRIPTION
A hack to have better entities proportions with the current entity rendering system

1 : Official Client
2 : Korangar with the hack

![Screenshot_official_client](https://github.com/vE5li/korangar/assets/4411178/8a2fb99e-3412-41a6-b6fc-88fdc801ec6c)
![Screenshot_korangar_0 70_scale](https://github.com/vE5li/korangar/assets/4411178/de304e43-25ed-4499-b0db-e40e1a849d9f)
