### PR TITLE
No longer require wide_lines feature from graphics device

### DIFF
--- a/src/graphics/renderers/deferred/box/mod.rs
+++ b/src/graphics/renderers/deferred/box/mod.rs
@@ -84,16 +84,10 @@ impl BoxRenderer {
         vertex_shader: &EntryPoint,
         fragment_shader: &EntryPoint,
     ) -> Arc<GraphicsPipeline> {
-        let rasterization_state = RasterizationState {
-            line_width: StateMode::Fixed(3.0),
-            ..Default::default()
-        };
-
         PipelineBuilder::<_, { DeferredRenderer::lighting_subpass() }>::new([vertex_shader, fragment_shader])
             .vertex_input_state::<WaterVertex>(vertex_shader)
             .topology(PrimitiveTopology::LineList)
             .fixed_viewport(viewport)
-            .rasterization_state(rasterization_state)
             .build(device, subpass)
     }
 

--- a/src/graphics/renderers/deferred/box/mod.rs
+++ b/src/graphics/renderers/deferred/box/mod.rs
@@ -8,9 +8,8 @@ use procedural::profile;
 use vulkano::descriptor_set::WriteDescriptorSet;
 use vulkano::device::{Device, DeviceOwned};
 use vulkano::pipeline::graphics::input_assembly::PrimitiveTopology;
-use vulkano::pipeline::graphics::rasterization::RasterizationState;
 use vulkano::pipeline::graphics::viewport::Viewport;
-use vulkano::pipeline::{GraphicsPipeline, Pipeline, PipelineBindPoint, StateMode};
+use vulkano::pipeline::{GraphicsPipeline, Pipeline, PipelineBindPoint};
 use vulkano::render_pass::Subpass;
 use vulkano::shader::EntryPoint;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,8 +157,6 @@ fn main() {
         enabled_features: vulkano::device::Features {
             sampler_anisotropy: true,
             #[cfg(feature = "debug")]
-            wide_lines: true,
-            #[cfg(feature = "debug")]
             fill_mode_non_solid: true,
             ..Default::default()
         },


### PR DESCRIPTION
Since it is only used for slightly nicer rendering in debug boxes and it is a reoccuring problem for MacOS users i suggest we drop the feature requirement from the graphics device.
Relates to https://github.com/vE5li/korangar/issues/70