### PR TITLE
Rework `FromBytes` and `ToBytes` to allow easier conversion both ways

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,7 +1723,6 @@ name = "ragnarok_packets"
 version = "0.1.0"
 dependencies = [
  "bitflags 2.5.0",
- "derive-new",
  "korangar_interface",
  "ragnarok_bytes",
  "ragnarok_procedural",

--- a/korangar/src/interface/elements/containers/packet.rs
+++ b/korangar/src/interface/elements/containers/packet.rs
@@ -12,7 +12,7 @@ use korangar_interface::size_bound;
 use korangar_interface::state::{PlainRemote, Remote, RemoteClone};
 use ragnarok_bytes::{ByteStream, ConversionError, ConversionResult, FromBytes};
 use ragnarok_packets::handler::PacketCallback;
-use ragnarok_packets::{IncomingPacket, OutgoingPacket, PacketHeader};
+use ragnarok_packets::{Packet, PacketHeader};
 
 use crate::graphics::{InterfaceRenderer, Renderer};
 use crate::input::MouseInputMode;
@@ -26,12 +26,16 @@ struct UnknownPacket {
     pub bytes: Vec<u8>,
 }
 
-impl IncomingPacket for UnknownPacket {
+impl Packet for UnknownPacket {
     const HEADER: PacketHeader = PacketHeader(0);
     const IS_PING: bool = false;
 
     fn payload_from_bytes<Meta>(byte_stream: &mut ByteStream<Meta>) -> ConversionResult<Self> {
         let _ = byte_stream;
+        unimplemented!()
+    }
+
+    fn payload_to_bytes(&self) -> ConversionResult<Vec<u8>> {
         unimplemented!()
     }
 
@@ -67,12 +71,16 @@ struct ErrorPacket {
     pub error: Box<ConversionError>,
 }
 
-impl IncomingPacket for ErrorPacket {
+impl Packet for ErrorPacket {
     const HEADER: PacketHeader = PacketHeader(0);
     const IS_PING: bool = false;
 
     fn payload_from_bytes<Meta>(byte_stream: &mut ByteStream<Meta>) -> ConversionResult<Self> {
         let _ = byte_stream;
+        unimplemented!()
+    }
+
+    fn payload_to_bytes(&self) -> ConversionResult<Vec<u8>> {
         unimplemented!()
     }
 
@@ -188,7 +196,7 @@ impl PacketHistoryCallback {
 impl PacketCallback for PacketHistoryCallback {
     fn incoming_packet<Packet>(&self, packet: &Packet)
     where
-        Packet: IncomingPacket,
+        Packet: ragnarok_packets::Packet,
     {
         let mut lock = self.buffer_pointer.lock().unwrap();
 
@@ -201,7 +209,7 @@ impl PacketCallback for PacketHistoryCallback {
 
     fn outgoing_packet<Packet>(&self, packet: &Packet)
     where
-        Packet: OutgoingPacket,
+        Packet: ragnarok_packets::Packet,
     {
         let mut lock = self.buffer_pointer.lock().unwrap();
 

--- a/korangar/src/loaders/archive/native/builder.rs
+++ b/korangar/src/loaders/archive/native/builder.rs
@@ -57,15 +57,13 @@ impl Writable for NativeArchiveBuilder {
         let version = 0x200;
         let file_header = Header::new(file_table_offset, reserved_files, raw_file_count, version);
 
-        let mut bytes = Vec::new();
-
-        bytes.extend_from_slice(&file_header.to_bytes().unwrap());
+        let mut bytes = file_header.to_bytes().unwrap();
         bytes.extend_from_slice(&self.data);
 
         let mut file_table_data = Vec::new();
 
         for file_information in self.file_table.values() {
-            file_table_data.extend_from_slice(&file_information.to_bytes().unwrap());
+            file_table_data.extend(file_information.to_bytes().unwrap());
         }
 
         let compressed_file_information_data = compress(&file_table_data, Format::Zlib, CompressionLevel::Default).unwrap();
@@ -74,8 +72,8 @@ impl Writable for NativeArchiveBuilder {
             uncompressed_size: file_table_data.len() as u32,
         };
 
-        bytes.extend_from_slice(&file_table.to_bytes().unwrap());
-        bytes.extend_from_slice(&compressed_file_information_data);
+        bytes.extend(file_table.to_bytes().unwrap());
+        bytes.extend(compressed_file_information_data);
 
         std::fs::write(&self.os_file_path, bytes).expect("unable to write file");
     }

--- a/korangar/src/main.rs
+++ b/korangar/src/main.rs
@@ -675,7 +675,7 @@ fn main() {
                                 &map,
                                 saved_login_data.account_id,
                                 character_information,
-                                WorldPosition::new(0, 0),
+                                WorldPosition { x: 0, y: 0 },
                                 client_tick,
                             );
                             let player = Entity::Player(player);
@@ -1094,7 +1094,7 @@ fn main() {
                         },
                         UserEvent::RequestPlayerMove(destination) => {
                             if !entities.is_empty() {
-                                let _ = networking_system.player_move(WorldPosition::new(destination.x, destination.y));
+                                let _ = networking_system.player_move(WorldPosition { x: destination.x, y: destination.y });
                             }
                         }
                         UserEvent::RequestPlayerInteract(entity_id) => {

--- a/korangar_interface/src/lib.rs
+++ b/korangar_interface/src/lib.rs
@@ -492,16 +492,17 @@ where
 
     #[cfg_attr(feature = "debug", korangar_debug::profile)]
     pub fn close_window_with_class(&mut self, focus_state: &mut FocusState<App>, window_class: &str) {
-        let index_from_back = self
+        if let Some(index_from_back) = self
             .windows
             .iter()
             .rev()
             .map(|(window, ..)| window.get_window_class())
             .position(|class_option| class_option.contains(&window_class))
-            .unwrap();
-        let index = self.windows.len() - 1 - index_from_back;
+        {
+            let index = self.windows.len() - 1 - index_from_back;
 
-        self.close_window(focus_state, index);
+            self.close_window(focus_state, index);
+        }
     }
 
     #[cfg_attr(feature = "debug", korangar_debug::profile)]

--- a/ragnarok_bytes/src/lib.rs
+++ b/ragnarok_bytes/src/lib.rs
@@ -15,3 +15,107 @@ pub use self::fixed::{FixedByteSize, FixedByteSizeCollection};
 pub use self::from_bytes::{FromBytes, FromBytesExt};
 pub use self::stream::ByteStream;
 pub use self::to_bytes::{ToBytes, ToBytesExt};
+
+#[cfg(test)]
+mod conversion {
+    use crate::{ByteStream, FromBytes, ToBytes};
+
+    fn encode_decode<T: FromBytes + ToBytes>(input: &[u8]) {
+        let mut byte_stream = ByteStream::<()>::without_metadata(input);
+
+        let data = T::from_bytes(&mut byte_stream).unwrap();
+        let output = data.to_bytes().unwrap();
+
+        assert_eq!(input, output.as_slice());
+    }
+
+    #[test]
+    pub fn u8() {
+        encode_decode::<u8>(&[170]);
+    }
+
+    #[test]
+    pub fn u16() {
+        encode_decode::<u16>(&[170, 85]);
+    }
+
+    #[test]
+    pub fn u32() {
+        encode_decode::<u32>(&[170, 85, 170, 85]);
+    }
+
+    #[test]
+    pub fn u64() {
+        encode_decode::<u64>(&[170, 85, 170, 85, 170, 85, 170, 85]);
+    }
+
+    #[test]
+    pub fn i8() {
+        encode_decode::<i8>(&[170]);
+    }
+
+    #[test]
+    pub fn i16() {
+        encode_decode::<i16>(&[170, 85]);
+    }
+
+    #[test]
+    pub fn i32() {
+        encode_decode::<i32>(&[170, 85, 170, 85]);
+    }
+
+    #[test]
+    pub fn i64() {
+        encode_decode::<i64>(&[170, 85, 170, 85, 170, 85, 170, 85]);
+    }
+
+    #[test]
+    pub fn f32() {
+        encode_decode::<f32>(&[170, 85, 170, 85]);
+    }
+
+    #[test]
+    pub fn array() {
+        encode_decode::<[u8; 4]>(&[1, 2, 3, 4]);
+    }
+
+    #[test]
+    pub fn string() {
+        encode_decode::<String>(b"testing\0");
+    }
+
+    #[test]
+    pub fn vector() {
+        encode_decode::<Vec<u8>>(&[1, 2, 3, 4]);
+    }
+
+    #[cfg(feature = "cgmath")]
+    #[test]
+    pub fn vector2() {
+        encode_decode::<cgmath::Vector2<u8>>(&[1, 2]);
+    }
+
+    #[cfg(feature = "cgmath")]
+    #[test]
+    pub fn vector3() {
+        encode_decode::<cgmath::Vector3<u8>>(&[1, 2, 3]);
+    }
+
+    #[cfg(feature = "cgmath")]
+    #[test]
+    pub fn vector4() {
+        encode_decode::<cgmath::Vector4<u8>>(&[1, 2, 3, 4]);
+    }
+
+    #[cfg(feature = "cgmath")]
+    #[test]
+    pub fn quaternion() {
+        encode_decode::<cgmath::Quaternion<u8>>(&[1, 2, 3, 4]);
+    }
+
+    #[cfg(feature = "cgmath")]
+    #[test]
+    pub fn matrix3() {
+        encode_decode::<cgmath::Matrix3<u8>>(&[1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    }
+}

--- a/ragnarok_bytes/src/to_bytes/implement.rs
+++ b/ragnarok_bytes/src/to_bytes/implement.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "cgmath")]
-use cgmath::{Vector2, Vector3, Vector4};
+use cgmath::{Matrix3, Quaternion, Vector2, Vector3, Vector4};
 
 use crate::{ConversionResult, ConversionResultExt, ToBytes};
 
@@ -76,6 +76,19 @@ impl ToBytes for String {
     }
 }
 
+impl<T: ToBytes> ToBytes for Vec<T> {
+    fn to_bytes(&self) -> ConversionResult<Vec<u8>> {
+        let mut bytes = Vec::new();
+
+        for item in self.iter() {
+            let item = item.to_bytes().trace::<Self>()?;
+            bytes.extend(item);
+        }
+
+        Ok(bytes)
+    }
+}
+
 #[cfg(feature = "cgmath")]
 impl<T: ToBytes> ToBytes for Vector2<T> {
     fn to_bytes(&self) -> ConversionResult<Vec<u8>> {
@@ -104,6 +117,37 @@ impl<T: ToBytes> ToBytes for Vector4<T> {
         bytes.append(&mut self.y.to_bytes().trace::<Self>()?);
         bytes.append(&mut self.z.to_bytes().trace::<Self>()?);
         bytes.append(&mut self.w.to_bytes().trace::<Self>()?);
+        Ok(bytes)
+    }
+}
+
+#[cfg(feature = "cgmath")]
+impl<T: ToBytes> ToBytes for Quaternion<T> {
+    fn to_bytes(&self) -> ConversionResult<Vec<u8>> {
+        let mut bytes = self.v.x.to_bytes().trace::<Self>()?;
+        bytes.append(&mut self.v.y.to_bytes().trace::<Self>()?);
+        bytes.append(&mut self.v.z.to_bytes().trace::<Self>()?);
+        bytes.append(&mut self.s.to_bytes().trace::<Self>()?);
+
+        Ok(bytes)
+    }
+}
+
+#[cfg(feature = "cgmath")]
+impl<T: ToBytes> ToBytes for Matrix3<T> {
+    fn to_bytes(&self) -> ConversionResult<Vec<u8>> {
+        let mut bytes = self.x.x.to_bytes().trace::<Self>()?;
+        bytes.append(&mut self.x.y.to_bytes().trace::<Self>()?);
+        bytes.append(&mut self.x.z.to_bytes().trace::<Self>()?);
+
+        bytes.append(&mut self.y.x.to_bytes().trace::<Self>()?);
+        bytes.append(&mut self.y.y.to_bytes().trace::<Self>()?);
+        bytes.append(&mut self.y.z.to_bytes().trace::<Self>()?);
+
+        bytes.append(&mut self.z.x.to_bytes().trace::<Self>()?);
+        bytes.append(&mut self.z.y.to_bytes().trace::<Self>()?);
+        bytes.append(&mut self.z.z.to_bytes().trace::<Self>()?);
+
         Ok(bytes)
     }
 }

--- a/ragnarok_formats/src/action.rs
+++ b/ragnarok_formats/src/action.rs
@@ -1,5 +1,5 @@
 use cgmath::Vector2;
-use ragnarok_bytes::{ByteConvertable, FromBytes};
+use ragnarok_bytes::ByteConvertable;
 
 use crate::signature::Signature;
 use crate::version::{MinorFirst, Version};
@@ -37,48 +37,54 @@ pub struct AttachPoint {
 pub struct Motion {
     pub range1: [i32; 4], // maybe just skip this?
     pub range2: [i32; 4], // maybe just skip this?
+    #[new_derive]
     pub sprite_clip_count: u32,
-    #[repeating(self.sprite_clip_count)]
+    #[repeating(sprite_clip_count)]
     pub sprite_clips: Vec<SpriteClip>,
     #[version_equals_or_above(2, 0)]
     pub event_id: Option<i32>, // if version == 2.0 this maybe needs to be set to None ?
     // (after it is parsed)
     #[version_equals_or_above(2, 3)]
     pub attach_point_count: Option<u32>,
-    #[repeating(self.attach_point_count.unwrap_or_default())]
+    #[repeating_option(attach_point_count)]
     pub attach_points: Vec<AttachPoint>,
 }
 
 #[derive(Debug, Clone, ByteConvertable)]
 #[cfg_attr(feature = "interface", derive(korangar_interface::elements::PrototypeElement))]
 pub struct Action {
+    #[new_derive]
     pub motion_count: u32,
-    #[repeating(self.motion_count)]
+    #[repeating(motion_count)]
     pub motions: Vec<Motion>,
 }
 
-#[derive(Debug, Clone, FromBytes)]
+#[derive(Debug, Clone, ByteConvertable)]
 #[cfg_attr(feature = "interface", derive(korangar_interface::elements::PrototypeElement))]
 pub struct Event {
-    #[length_hint(40)]
+    #[length(40)]
     pub name: String,
 }
 
-#[derive(Debug, Clone, FromBytes)]
+#[derive(Debug, Clone, ByteConvertable)]
 #[cfg_attr(feature = "interface", derive(korangar_interface::elements::PrototypeElement))]
 pub struct ActionsData {
+    #[new_default]
     pub signature: Signature<b"AC">,
     #[version]
     pub version: Version<MinorFirst>,
+    // #[new_derive]
     pub action_count: u16,
+    #[new_default]
     pub reserved: [u8; 10],
-    #[repeating(self.action_count)]
+    #[repeating(action_count)]
     pub actions: Vec<Action>,
     #[version_equals_or_above(2, 1)]
+    #[new_derive]
     pub event_count: Option<u32>,
-    #[repeating(self.event_count.unwrap_or_default())]
+    #[repeating_option(event_count)]
     pub events: Vec<Event>,
     #[version_equals_or_above(2, 2)]
-    #[repeating(self.action_count)]
+    #[repeating(action_count)]
     pub delays: Option<Vec<f32>>,
 }

--- a/ragnarok_formats/src/archive.rs
+++ b/ragnarok_formats/src/archive.rs
@@ -5,27 +5,14 @@ use crate::signature::Signature;
 /// Represents the Header of the GRF file.
 #[derive(Clone, ByteConvertable, FixedByteSize)]
 pub struct Header {
+    #[new_default]
     pub signature: Signature<b"Master of Magic\0">,
+    #[new_default]
     pub encryption: [u8; 14],
     pub file_table_offset: u32,
     pub reserved_files: u32,
     pub file_count: u32,
     pub version: u32,
-}
-
-impl Header {
-    // TODO: This is temporary and can be removed after improving the
-    // ByteConvertable trait.
-    pub fn new(file_table_offset: u32, reserved_files: u32, file_count: u32, version: u32) -> Self {
-        Self {
-            signature: Signature,
-            encryption: Default::default(),
-            file_table_offset,
-            reserved_files,
-            file_count,
-            version,
-        }
-    }
 }
 
 impl Header {

--- a/ragnarok_formats/src/effect.rs
+++ b/ragnarok_formats/src/effect.rs
@@ -1,17 +1,17 @@
 use cgmath::Vector2;
-use ragnarok_bytes::FromBytes;
+use ragnarok_bytes::ByteConvertable;
 
 use crate::signature::Signature;
 use crate::version::{MajorFirst, Version};
 
-#[derive(Debug, FromBytes)]
+#[derive(Debug, ByteConvertable)]
 #[cfg_attr(feature = "interface", derive(korangar_interface::elements::PrototypeElement))]
 pub struct TextureName {
-    #[length_hint(128)]
+    #[length(128)]
     pub name: String,
 }
 
-#[derive(Debug, Clone, FromBytes)]
+#[derive(Debug, Clone, ByteConvertable)]
 #[cfg_attr(feature = "interface", derive(korangar_interface::elements::PrototypeElement))]
 pub struct Frame {
     pub frame_index: i32,
@@ -31,28 +31,34 @@ pub struct Frame {
     pub mt_present: i32,
 }
 
-#[derive(Debug, FromBytes)]
+#[derive(Debug, ByteConvertable)]
 #[cfg_attr(feature = "interface", derive(korangar_interface::elements::PrototypeElement))]
 pub struct LayerData {
+    #[new_derive]
     pub texture_count: i32,
-    #[repeating(self.texture_count)]
+    #[repeating(texture_count)]
     pub texture_names: Vec<TextureName>,
+    #[new_derive]
     pub frame_count: i32,
-    #[repeating(self.frame_count)]
+    #[repeating(frame_count)]
     pub frames: Vec<Frame>,
 }
 
-#[derive(Debug, FromBytes)]
+#[derive(Debug, ByteConvertable)]
 #[cfg_attr(feature = "interface", derive(korangar_interface::elements::PrototypeElement))]
 pub struct EffectData {
+    #[new_default]
     pub signature: Signature<b"STRM">,
     #[version]
     pub version: Version<MajorFirst>,
+    #[new_default]
     pub _skip0: [u8; 2],
     pub frames_per_second: u32,
     pub max_key: u32,
+    #[new_derive]
     pub layer_count: u32,
+    #[new_default]
     pub _skip1: [u8; 16],
-    #[repeating(self.layer_count)]
+    #[repeating(layer_count)]
     pub layers: Vec<LayerData>,
 }

--- a/ragnarok_formats/src/signature.rs
+++ b/ragnarok_formats/src/signature.rs
@@ -1,6 +1,6 @@
 use ragnarok_bytes::{ByteStream, ConversionError, ConversionResult, FixedByteSize, FromBytes, ToBytes};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Signature<const MAGIC: &'static [u8]>;
 
 impl<const MAGIC: &'static [u8]> FixedByteSize for Signature<MAGIC> {

--- a/ragnarok_packets/Cargo.toml
+++ b/ragnarok_packets/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 bitflags = { workspace = true }
-derive-new = { workspace = true }
 korangar_interface = { workspace = true, optional = true }
 ragnarok_bytes = { workspace = true, features = ["derive"] }
 ragnarok_procedural = { workspace = true }

--- a/ragnarok_packets/src/position.rs
+++ b/ragnarok_packets/src/position.rs
@@ -1,0 +1,125 @@
+use ragnarok_bytes::{ByteStream, ConversionResult, FromBytes, ToBytes};
+
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "interface", derive(korangar_interface::elements::PrototypeElement))]
+pub struct WorldPosition {
+    pub x: usize,
+    pub y: usize,
+}
+
+impl FromBytes for WorldPosition {
+    fn from_bytes<Meta>(byte_stream: &mut ByteStream<Meta>) -> ConversionResult<Self> {
+        let coordinates: Vec<usize> = byte_stream.slice::<Self>(3)?.iter().map(|byte| *byte as usize).collect();
+
+        let x = (coordinates[1] >> 6) | (coordinates[0] << 2);
+        let y = (coordinates[2] >> 4) | ((coordinates[1] & 0b111111) << 4);
+        //let direction = ...
+
+        Ok(Self { x, y })
+    }
+}
+
+impl ToBytes for WorldPosition {
+    fn to_bytes(&self) -> ConversionResult<Vec<u8>> {
+        let mut coordinates = vec![0, 0, 0];
+
+        coordinates[0] = (self.x >> 2) as u8;
+        coordinates[1] = ((self.x << 6) as u8) | (((self.y >> 4) & 0x3F) as u8);
+        coordinates[2] = (self.y << 4) as u8;
+
+        Ok(coordinates)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "interface", derive(korangar_interface::elements::PrototypeElement))]
+pub struct WorldPosition2 {
+    pub x1: usize,
+    pub y1: usize,
+    pub x2: usize,
+    pub y2: usize,
+}
+
+impl WorldPosition2 {
+    pub fn to_origin_destination(self) -> (WorldPosition, WorldPosition) {
+        (WorldPosition { x: self.x1, y: self.y1 }, WorldPosition {
+            x: self.x2,
+            y: self.y2,
+        })
+    }
+}
+
+impl FromBytes for WorldPosition2 {
+    fn from_bytes<Meta>(byte_stream: &mut ByteStream<Meta>) -> ConversionResult<Self> {
+        let coordinates: Vec<usize> = byte_stream.slice::<Self>(6)?.iter().map(|byte| *byte as usize).collect();
+
+        let x1 = (coordinates[1] >> 6) | (coordinates[0] << 2);
+        let y1 = (coordinates[2] >> 4) | ((coordinates[1] & 0b111111) << 4);
+        let x2 = (coordinates[3] >> 2) | ((coordinates[2] & 0b1111) << 6);
+        let y2 = coordinates[4] | ((coordinates[3] & 0b11) << 8);
+        //let direction = ...
+
+        Ok(Self { x1, y1, x2, y2 })
+    }
+}
+
+impl ToBytes for WorldPosition2 {
+    fn to_bytes(&self) -> ConversionResult<Vec<u8>> {
+        let mut bytes = vec![0; 6];
+
+        bytes[0] = (self.x1 >> 2) as u8;
+        bytes[1] = ((self.x1 << 6) as u8) | ((self.y1 >> 4) as u8);
+        bytes[2] = ((self.y1 << 4) as u8) | ((self.x2 >> 6) as u8);
+        bytes[3] = ((self.x2 << 2) as u8) | ((self.y2 >> 8) as u8);
+        bytes[4] = self.y2 as u8;
+
+        Ok(bytes)
+    }
+}
+
+#[cfg(test)]
+mod conversion {
+    use ragnarok_bytes::{FromBytes, ToBytes};
+
+    use crate::{WorldPosition, WorldPosition2};
+
+    #[test]
+    fn world_position() {
+        // Since we don't save the orientation when deserializing, this is a lossy
+        // operation. So we construct some test cases that igonore the bits in
+        // question.
+        let cases = [[255, 0, 0], [0, 255, 0], [0, 0, 240]];
+
+        for case in cases {
+            let mut byte_steam = ragnarok_bytes::ByteStream::<()>::without_metadata(&case);
+
+            let position = WorldPosition::from_bytes(&mut byte_steam).unwrap();
+            let output = position.to_bytes().unwrap();
+
+            assert_eq!(case.as_slice(), output.as_slice());
+        }
+    }
+
+    #[test]
+    fn world_position_2() {
+        // Since we don't save the orientation when deserializing, this is a lossy
+        // operation. So we construct some test cases that igonore the bits in
+        // question.
+        let cases = [
+            [255, 0, 0, 0, 0, 0],
+            [0, 255, 0, 0, 0, 0],
+            [0, 0, 255, 0, 0, 0],
+            [0, 0, 0, 255, 0, 0],
+            [0, 0, 0, 0, 255, 0],
+        ];
+
+        for case in cases {
+            let mut byte_steam = ragnarok_bytes::ByteStream::<()>::without_metadata(&case);
+
+            let position = WorldPosition2::from_bytes(&mut byte_steam).unwrap();
+            let output = position.to_bytes().unwrap();
+
+            assert_eq!(case.as_slice(), output.as_slice());
+        }
+    }
+}

--- a/ragnarok_procedural/src/fixed_size.rs
+++ b/ragnarok_procedural/src/fixed_size.rs
@@ -16,12 +16,12 @@ pub fn derive_fixed_byte_size_struct(data_struct: DataStruct, generics: Generics
     };
 
     let sizes = fields.into_iter().zip(types.iter()).map(|(mut field, field_type)| {
-        get_unique_attribute(&mut field.attrs, "length_hint")
+        get_unique_attribute(&mut field.attrs, "length")
             .map(|attribute| match attribute.meta {
                 syn::Meta::List(list) => list.tokens,
                 syn::Meta::Path(_) | syn::Meta::NameValue(_) => panic!("expected token stream in attribute"),
             })
-            .map(|length_hint| quote!((#length_hint) as usize))
+            .map(|length| quote!((#length) as usize))
             .unwrap_or(quote!(<#field_type as ragnarok_bytes::FixedByteSize>::size_in_bytes()))
     });
 

--- a/ragnarok_procedural/src/helper.rs
+++ b/ragnarok_procedural/src/helper.rs
@@ -1,84 +1,87 @@
-use proc_macro2::{Delimiter, Group, TokenStream, TokenTree};
+use std::collections::HashMap;
+
+use proc_macro2::{Delimiter, TokenStream};
 use quote::{format_ident, quote};
 use syn::{DataStruct, Field};
 
 use crate::utils::*;
 
-fn remove_self_from_stream(token_stream: TokenStream) -> TokenStream {
-    let mut new_stream = TokenStream::new();
-    let mut iterator = token_stream.into_iter();
-
-    while let Some(token) = iterator.next() {
-        if let TokenTree::Group(group) = &token {
-            let delimiter = group.delimiter();
-            let new_group_stream = remove_self_from_stream(group.stream());
-            let new_group = Group::new(delimiter, new_group_stream);
-            new_stream.extend_one(TokenTree::Group(new_group));
-            continue;
-        }
-
-        if let TokenTree::Ident(ident) = &token {
-            if &ident.to_string() == "self" {
-                // remove the '.' after self
-                iterator.next().expect("expected a token after self");
-                continue;
-            }
-        }
-
-        new_stream.extend_one(token);
-    }
-
-    new_stream
-}
-
-pub fn byte_convertable_helper(data_struct: DataStruct) -> (Vec<TokenStream>, Vec<TokenStream>, Vec<TokenStream>, Delimiter) {
+pub fn byte_convertable_helper(data_struct: DataStruct) -> (TokenStream, Vec<TokenStream>, Vec<TokenStream>, Vec<TokenStream>, Delimiter) {
     let mut from_bytes_implementations = vec![];
     let mut implemented_fields = vec![];
     let mut to_bytes_implementations = vec![];
-    let mut packet_length = None;
+    let mut deriveable_map: HashMap<syn::Ident, (syn::Ident, bool)> = HashMap::new();
 
-    let (fields, delimiter): (Vec<Field>, _) = match data_struct.fields {
+    let (mut fields, delimiter): (Vec<Field>, _) = match data_struct.fields {
         syn::Fields::Named(named_fields) => (named_fields.named.into_iter().collect(), Delimiter::Brace),
         syn::Fields::Unnamed(unnamed_fields) => (unnamed_fields.unnamed.into_iter().collect(), Delimiter::Parenthesis),
         syn::Fields::Unit => panic!("unit types are not supported"),
     };
 
-    for (counter, mut field) in fields.into_iter().enumerate() {
+    for (counter, field) in fields.iter_mut().enumerate() {
         let counter_ident = format_ident!("_{}", counter);
         let counter_index = syn::Index::from(counter);
-        let field_variable = field.ident.as_ref().map(|ident| quote!(#ident)).unwrap_or(quote!(#counter_ident));
+        let field_variable = field.ident.clone().unwrap_or(counter_ident);
         let field_identifier = field.ident.as_ref().map(|ident| quote!(#ident)).unwrap_or(quote!(#counter_index));
-        let field_type = field.ty;
+        let field_type = field.ty.clone();
 
         let is_version = get_unique_attribute(&mut field.attrs, "version").is_some();
-        let is_packet_length = get_unique_attribute(&mut field.attrs, "packet_length").is_some();
 
-        let length_hint = get_unique_attribute(&mut field.attrs, "length_hint")
-            .map(|attribute| match attribute.meta {
-                syn::Meta::List(list) => list.tokens,
-                syn::Meta::Path(_) | syn::Meta::NameValue(_) => panic!("expected token stream in attribute"),
-            })
-            .map(|length_hint| quote!((#length_hint) as usize));
+        let length = get_unique_attribute(&mut field.attrs, "length").map(|attribute| match attribute.meta {
+            syn::Meta::List(list) => list.tokens,
+            syn::Meta::Path(_) | syn::Meta::NameValue(_) => panic!("expected token stream in attribute"),
+        });
+        let length_remaining = get_unique_attribute(&mut field.attrs, "length_remaining").is_some();
+        let length_remaining_off_by_one = get_unique_attribute(&mut field.attrs, "length_remaining_off_by_one").is_some();
 
-        let from_length_hint = match length_hint.clone() {
-            Some(length_hint) => {
-                let length_hint = remove_self_from_stream(length_hint.clone());
-                quote!(ragnarok_bytes::FromBytesExt::from_n_bytes(byte_stream, #length_hint))
+        if (length.is_some() as usize) + (length_remaining as usize) + (length_remaining_off_by_one as usize) > 1 {
+            panic!("only one of `length`, `length_remaining`, or `length_remaining_off_by_one` can be used for one field at a time");
+        }
+
+        let from_length = match length.clone() {
+            Some(length) => {
+                quote!(ragnarok_bytes::FromBytesExt::from_n_bytes(byte_stream, #length as usize))
             }
+            None if length_remaining => quote!(ragnarok_bytes::FromBytesExt::from_n_bytes(
+                byte_stream,
+                (__packet_length as usize).saturating_sub(2 + (byte_stream.get_offset() - base_offset))
+            )),
+            None if length_remaining_off_by_one => quote!(ragnarok_bytes::FromBytesExt::from_n_bytes(
+                byte_stream,
+                (__packet_length as usize).saturating_sub(1 + (byte_stream.get_offset() - base_offset))
+            )),
             None => quote!(ragnarok_bytes::FromBytes::from_bytes(byte_stream)),
         };
 
-        let to_length_hint = match length_hint {
-            Some(length_hint) => quote!(ragnarok_bytes::ToBytesExt::to_n_bytes(&self.#field_identifier, #length_hint)),
+        let to_length = match length {
+            Some(length) if syn::parse::<syn::Ident>(length.clone().into()).is_ok() => {
+                quote!(ragnarok_bytes::ToBytesExt::to_n_bytes(&self.#field_identifier, self.#length as usize))
+            }
+            Some(length) => quote!(ragnarok_bytes::ToBytesExt::to_n_bytes(&self.#field_identifier, #length as usize)),
             None => quote!(ragnarok_bytes::ToBytes::to_bytes(&self.#field_identifier)),
         };
 
-        let repeating: Option<TokenStream> = get_unique_attribute(&mut field.attrs, "repeating").map(|attribute| match attribute.meta {
-            syn::Meta::List(list) => remove_self_from_stream(list.tokens),
+        let mut repeating: Option<(syn::Ident, bool)> = None;
+
+        if let Some(identifier) = get_unique_attribute(&mut field.attrs, "repeating").map(|attribute| match attribute.meta {
+            syn::Meta::List(list) => syn::parse(list.tokens.into()).expect("repeating takes a single identifier"),
             syn::Meta::Path(_) | syn::Meta::NameValue(_) => panic!("expected token stream in attribute"),
-        });
+        }) {
+            repeating = Some((identifier, false));
+        }
+
+        if let Some(identifier) = get_unique_attribute(&mut field.attrs, "repeating_option").map(|attribute| match attribute.meta {
+            syn::Meta::List(list) => syn::parse(list.tokens.into()).expect("repeating takes a single identifier"),
+            syn::Meta::Path(_) | syn::Meta::NameValue(_) => panic!("expected token stream in attribute"),
+        }) {
+            repeating = Some((identifier, true));
+        }
 
         let repeating_remaining = get_unique_attribute(&mut field.attrs, "repeating_remaining").is_some();
+        let repeating_expr = get_unique_attribute(&mut field.attrs, "repeating_expr").map(|attribute| match attribute.meta {
+            syn::Meta::List(list) => list.tokens,
+            syn::Meta::Path(_) | syn::Meta::NameValue(_) => panic!("expected token stream in attribute"),
+        });
 
         let version_smaller = get_unique_attribute(&mut field.attrs, "version_smaller")
             .map(|attribute| attribute.parse_args().expect("failed to parse version"))
@@ -96,36 +99,22 @@ pub fn byte_convertable_helper(data_struct: DataStruct) -> (Vec<TokenStream>, Ve
         );
         let version_function = version_smaller.or(version_equals_or_above);
         let version_restricted = version_function.is_some();
-        let is_repeating = repeating.is_some();
-
-        if is_packet_length {
-            assert!(counter == 0, "packet_length must always be the first field");
-            packet_length = Some(field_identifier.clone());
-        }
 
         // base from bytes implementation
-        let from_implementation = quote!(ragnarok_bytes::ConversionResultExt::trace::<Self>(#from_length_hint)?);
+        let from_implementation = quote!(ragnarok_bytes::ConversionResultExt::trace::<Self>(#from_length)?);
 
         // wrap base implementation in a loop if the element can appear multiple times
         let from_implementation = match repeating {
-            Some(repeat_count) => quote!({
-                let repeat_count = #repeat_count;
-                // TODO: Add check to make sure this allocation is not too big.
-                let mut vector = Vec::with_capacity(repeat_count as usize);
+            Some((repeat_count, is_option)) => {
+                deriveable_map.insert(repeat_count.clone(), (field_variable.clone(), is_option));
 
-                for _ in 0..repeat_count {
-                    vector.push(#from_implementation);
-                }
-
-                vector
-            }),
-            None if repeating_remaining => {
-                let packet_length = packet_length
-                    .as_ref()
-                    .expect("repeating_remaining is used but no packet_length attribute is set");
+                let repeat_count_inner = match is_option {
+                    true => quote!(#repeat_count.unwrap_or_default()),
+                    false => quote!(#repeat_count),
+                };
 
                 quote!({
-                    let repeat_count = (#packet_length - ((byte_stream.get_offset() - base_offset) as u16) - 2) / (<#field_type as ragnarok_bytes::FixedByteSizeCollection>::size_in_bytes() as u16);
+                    let repeat_count = #repeat_count_inner;
                     // TODO: Add check to make sure this allocation is not too big.
                     let mut vector = Vec::with_capacity(repeat_count as usize);
 
@@ -136,8 +125,46 @@ pub fn byte_convertable_helper(data_struct: DataStruct) -> (Vec<TokenStream>, Ve
                     vector
                 })
             }
+            None if repeating_remaining => {
+                quote!({
+                    let remaining_bytes = __packet_length - ((byte_stream.get_offset() - base_offset) as u16) - 2;
+                    let struct_size = <#field_type as ragnarok_bytes::FixedByteSizeCollection>::size_in_bytes() as u16;
+
+                    if remaining_bytes % struct_size != 0 {
+                        return Err(ragnarok_bytes::ConversionError::from_message("type doesn't perfectly divide remaining data"));
+                    }
+
+                    let repeat_count = (remaining_bytes / struct_size) as usize;
+                    // TODO: Add check to make sure this allocation is not too big.
+                    let mut vector = Vec::with_capacity(repeat_count);
+
+                    for _ in 0..repeat_count {
+                        vector.push(#from_implementation);
+                    }
+
+                    vector
+                })
+            }
+            None if repeating_expr.is_some() => {
+                let repeating_expr = repeating_expr.unwrap();
+
+                quote!({
+                    let repeat_count = (#repeating_expr) as usize;
+
+                    // TODO: Add check to make sure this allocation is not too big.
+                    let mut vector = Vec::with_capacity(repeat_count);
+
+                    for _ in 0..repeat_count {
+                        vector.push(#from_implementation);
+                    }
+
+                    vector
+                })
+            }
             None => from_implementation,
         };
+
+        implemented_fields.push(quote!(#field_variable));
 
         // wrap the potentially looped implementation in an option if it has a version
         // restriction
@@ -155,20 +182,18 @@ pub fn byte_convertable_helper(data_struct: DataStruct) -> (Vec<TokenStream>, Ve
             }
             None => quote!(let #field_variable = #from_implementation;),
         };
+        from_bytes_implementations.push(from_implementation);
 
         // base to byte implementation
-        let to_implementation = match is_repeating || version_restricted {
+        let to_implementation = match version_restricted {
             true => quote!({
-                panic!("implement for to_bytes as well");
+                panic!("version restricted fields can't be serialized at the moment");
                 [0u8].as_slice()
             }),
             false => {
-                quote!(ragnarok_bytes::ConversionResultExt::trace::<Self>(#to_length_hint)?.as_slice())
+                quote!(ragnarok_bytes::ConversionResultExt::trace::<Self>(#to_length)?.as_slice())
             }
         };
-
-        implemented_fields.push(quote!(#field_variable));
-        from_bytes_implementations.push(from_implementation);
         to_bytes_implementations.push(to_implementation);
 
         if is_version {
@@ -178,7 +203,116 @@ pub fn byte_convertable_helper(data_struct: DataStruct) -> (Vec<TokenStream>, Ve
         }
     }
 
+    // Implement `new` function.
+
+    let mut new_arguments = vec![];
+    let mut new_implementations = vec![];
+
+    for (counter, mut field) in fields.into_iter().enumerate() {
+        let counter_ident = format_ident!("_{}", counter);
+        let field_variable = field.ident.clone().unwrap_or(counter_ident);
+
+        let is_new_derive = get_unique_attribute(&mut field.attrs, "new_derive").is_some();
+        let is_new_default = get_unique_attribute(&mut field.attrs, "new_default").is_some();
+        let new_value = get_unique_attribute(&mut field.attrs, "new_value").map(|attribute| match attribute.meta {
+            syn::Meta::List(list) => list.tokens,
+            syn::Meta::Path(_) | syn::Meta::NameValue(_) => panic!("expected token stream in attribute"),
+        });
+
+        if (is_new_derive as usize) + (is_new_default as usize) + (new_value.is_some() as usize) > 1 {
+            panic!("only one of `new_derive`, `new_default`, or `new_value` can be used for one field at a time");
+        }
+
+        let field_type = field.ty;
+
+        if let Some(field_identifier) = &field.ident {
+            if is_new_derive {
+                let (collection, is_option) = deriveable_map.get(&field_variable).expect("can't derive field without repeat");
+
+                match is_option {
+                    true => {
+                        new_implementations.push(quote! {
+                            #field_identifier: Some(#collection.len() as _)
+                        });
+                    }
+                    false => {
+                        new_implementations.push(quote! {
+                            #field_identifier: #collection.len() as _
+                        });
+                    }
+                }
+            } else if is_new_default {
+                new_implementations.push(quote! {
+                    #field_identifier: Default::default()
+                });
+            } else if let Some(new_value) = new_value {
+                new_implementations.push(quote! {
+                    #field_identifier: #new_value
+                });
+            } else {
+                new_arguments.push(quote! {
+                    #field_variable: #field_type
+                });
+                new_implementations.push(quote! {
+                    #field_identifier: #field_variable
+                });
+            }
+        } else {
+            #[allow(clippy::collapsible_else_if)]
+            if is_new_derive {
+                let (collection, is_option) = deriveable_map.get(&field_variable).expect("can't derive field without repeat");
+
+                match is_option {
+                    true => {
+                        new_implementations.push(quote! {
+                            Some(#collection.len() as _)
+                        });
+                    }
+                    false => {
+                        new_implementations.push(quote! {
+                            #collection.len() as _
+                        });
+                    }
+                }
+            } else if is_new_default {
+                new_implementations.push(quote! {
+                    Default::default()
+                });
+            } else if let Some(new_value) = new_value {
+                new_implementations.push(quote! {
+                    #new_value
+                });
+            } else {
+                new_arguments.push(quote! {
+                    #field_variable: #field_type
+                });
+                new_implementations.push(quote! {
+                    #field_variable
+                });
+            }
+        }
+    }
+
+    let new_implementation_inner = match delimiter {
+        Delimiter::Brace => quote!(Self { #(#new_implementations),* }),
+        Delimiter::Parenthesis => quote!(Self(#(#new_implementations),*)),
+        _ => unreachable!(),
+    };
+
+    let new_implementation = quote! {
+        /// Automatically derived `new` function that will fill any fields annotated with any of
+        /// the `new` attributes.
+        ///
+        /// NOTE: The filled fields will *NOT* be updated, so keep that in mind when making
+        /// changes to the struct afterwards.
+        #[allow(too_many_arguments)]
+        pub fn new(#(#new_arguments),*) -> Self {
+            #new_implementation_inner
+        }
+    };
+
     (
+        new_implementation,
         from_bytes_implementations,
         implemented_fields,
         to_bytes_implementations,

--- a/ragnarok_procedural/src/packet.rs
+++ b/ragnarok_procedural/src/packet.rs
@@ -5,7 +5,7 @@ use syn::{Attribute, DataStruct, Generics, Ident};
 use super::helper::byte_convertable_helper;
 use crate::utils::*;
 
-pub fn derive_incoming_packet_struct(
+pub fn derive_packet_struct(
     data_struct: DataStruct,
     generics: Generics,
     mut attributes: Vec<Attribute>,
@@ -18,9 +18,11 @@ pub fn derive_incoming_packet_struct(
         .expect("packet needs to specify a signature")
         .expect("failed to parse packet header");
     let is_ping = get_unique_attribute(&mut attributes, "ping").is_some();
+    let is_variable_length = get_unique_attribute(&mut attributes, "variable_length").is_some();
 
     let signature = packet_signature.signature;
-    let (from_bytes_implementations, implemented_fields, _to_bytes_implementations, delimiter) = byte_convertable_helper(data_struct);
+    let (new_implementation, from_bytes_implementations, implemented_fields, to_bytes_implementations, delimiter) =
+        byte_convertable_helper(data_struct);
 
     let instanciate = match delimiter {
         proc_macro2::Delimiter::Brace => quote!(Self { #(#implemented_fields),* }),
@@ -28,56 +30,50 @@ pub fn derive_incoming_packet_struct(
         _ => panic!(),
     };
 
+    let insert_packet_length = is_variable_length.then_some(quote! {
+        let __packet_length = ragnarok_bytes::ConversionResultExt::trace::<Self>(u16::from_bytes(byte_stream))?;
+    });
+
+    let final_to_bytes = match is_variable_length {
+        _ if to_bytes_implementations.is_empty() => quote! {
+            Ok(Vec::new())
+        },
+        true => {
+            quote! {
+                let following_bytes = [#(#to_bytes_implementations),*].concat();
+                let packet_length = following_bytes.len() as u16 + 4;
+
+                let mut final_bytes = packet_length.to_bytes()?;
+                final_bytes.extend(following_bytes);
+
+                Ok(final_bytes)
+            }
+        }
+        false => quote! {
+            Ok([#(#to_bytes_implementations),*].concat())
+        },
+    };
+
     quote! {
-        impl #impl_generics ragnarok_packets::IncomingPacket for #name #type_generics #where_clause {
+        impl #impl_generics #name #type_generics #where_clause {
+            #new_implementation
+        }
+
+        impl #impl_generics ragnarok_packets::Packet for #name #type_generics #where_clause {
             const IS_PING: bool = #is_ping;
             const HEADER: ragnarok_packets::PacketHeader = ragnarok_packets::PacketHeader(#signature);
 
             fn payload_from_bytes<Meta>(byte_stream: &mut ragnarok_bytes::ByteStream<Meta>) -> ragnarok_bytes::ConversionResult<Self> {
                 let base_offset = byte_stream.get_offset();
+                #insert_packet_length
                 #(#from_bytes_implementations)*
                 let packet = #instanciate;
 
                 Ok(packet)
             }
 
-            #[cfg(feature = "packet-to-prototype-element")]
-            fn to_prototype_element<App: korangar_interface::application::Application>(
-                &self,
-            ) -> Box<dyn korangar_interface::elements::PrototypeElement<App> + Send> {
-                Box::new(self.clone())
-            }
-        }
-    }
-    .into()
-}
-
-pub fn derive_outgoing_packet_struct(
-    data_struct: DataStruct,
-    generics: Generics,
-    mut attributes: Vec<Attribute>,
-    name: Ident,
-) -> InterfaceTokenStream {
-    let (impl_generics, type_generics, where_clause) = generics.split_for_impl();
-
-    let packet_signature = get_unique_attribute(&mut attributes, "header")
-        .map(|attribute| attribute.parse_args::<PacketSignature>())
-        .expect("packet needs to specify a signature")
-        .expect("failed to parse packet header");
-    let is_ping = get_unique_attribute(&mut attributes, "ping").is_some();
-
-    let signature = packet_signature.signature;
-    let (_from_bytes_implementations, _implemented_fields, to_bytes_implementations, _delimiter) = byte_convertable_helper(data_struct);
-    let to_bytes = quote!([&#signature.to_le_bytes()[..], #(#to_bytes_implementations),*].concat());
-
-    quote! {
-        impl #impl_generics ragnarok_packets::OutgoingPacket for #name #type_generics #where_clause {
-            const IS_PING: bool = #is_ping;
-
-            // Temporary until serialization is always possible
-            #[allow(unreachable_code)]
-            fn packet_to_bytes(&self) -> ragnarok_bytes::ConversionResult<Vec<u8>> {
-                Ok(#to_bytes)
+            fn payload_to_bytes(&self) -> ragnarok_bytes::ConversionResult<Vec<u8>> {
+                #final_to_bytes
             }
 
             #[cfg(feature = "packet-to-prototype-element")]


### PR DESCRIPTION
Previously, a lot of types could only be deserialized but not
serialized. The goal is to make it easier to convert both ways, and to
make instantiation of `ToBytes` types easier by deriving an associated `new` function that initializes fields that have a fixed value or a value that can be derived.