### PR TITLE
Fix enemy status bar rendering

### DIFF
--- a/korangar/src/world/entity/mod.rs
+++ b/korangar/src/world/entity/mod.rs
@@ -973,7 +973,7 @@ impl Npc {
 
         renderer.render_rectangle(
             render_target,
-            final_position - theme.status_bar.border_size.get() + ScreenSize::only_width(bar_width / 2.0),
+            final_position - theme.status_bar.border_size.get() - ScreenSize::only_width(bar_width / 2.0),
             ScreenSize {
                 width: bar_width,
                 height: theme.status_bar.enemy_health_height.get(),


### PR DESCRIPTION
Mob status bars were a little messed up

Old: 
![image](https://github.com/vE5li/korangar/assets/6844975/7838d2c1-5f03-4da7-90b9-fdfb0a12361c)

New:
![0518184751_korangar_44](https://github.com/vE5li/korangar/assets/6844975/98c2f09c-7487-4e83-a999-aaa90f7258d3)
![0518184755_korangar_45](https://github.com/vE5li/korangar/assets/6844975/ddbb58b2-60b7-4aa7-af89-e5c44ead904d)
