### PR TITLE
Make `BuyItemInformation` packet fields public

### DIFF
--- a/ragnarok_packets/src/lib.rs
+++ b/ragnarok_packets/src/lib.rs
@@ -2832,8 +2832,8 @@ pub enum BuyItemResult {
 #[derive(Debug, Clone, ByteConvertable, FixedByteSize)]
 #[cfg_attr(feature = "interface", derive(korangar_interface::elements::PrototypeElement))]
 pub struct BuyItemInformation {
-    amount: u16,
-    item_id: u16,
+    pub amount: u16,
+    pub item_id: u16,
 }
 
 #[derive(Debug, Clone, Packet, ClientPacket, MapServer)]


### PR DESCRIPTION
It will help to build a `bindgen` library to be used by other languages