### PR TITLE
Make the profiler API sound.

### DIFF
--- a/korangar_debug/src/profiling/mod.rs
+++ b/korangar_debug/src/profiling/mod.rs
@@ -4,6 +4,6 @@ mod ring_buffer;
 mod statistics;
 
 pub use self::measurement::{ActiveMeasurement, Measurement};
-pub use self::profiler::{LockThreadProfier, Profiler};
+pub use self::profiler::{LockThreadProfiler, Profiler};
 pub use self::ring_buffer::RingBuffer;
 pub use self::statistics::{get_frame_by_index, get_number_of_saved_frames, get_statistics_data};

--- a/korangar_debug/src/profiling/profiler.rs
+++ b/korangar_debug/src/profiling/profiler.rs
@@ -1,5 +1,4 @@
 use std::cell::Cell;
-use std::marker::PhantomPinned;
 use std::sync::atomic::AtomicBool;
 use std::sync::Mutex;
 use std::time::Instant;
@@ -20,14 +19,11 @@ pub struct Profiler {
 }
 
 #[derive(Default)]
-pub struct ProfilerInner {
+struct ProfilerInner {
     root_measurement: Option<Measurement>,
     /// Self referencing pointers
     active_measurements: Vec<*const Measurement>,
     saved_frames: RingBuffer<Measurement, { Profiler::SAVED_FRAME_COUNT }>,
-    /// Since the profiler has some self-referencing fields, we want it to be
-    /// !Unpin.
-    _pin: PhantomPinned,
 }
 
 // Safety: It's in general safe to send a Profiler between threads, since the

--- a/korangar_debug/src/profiling/profiler.rs
+++ b/korangar_debug/src/profiling/profiler.rs
@@ -1,6 +1,5 @@
+use std::cell::Cell;
 use std::marker::PhantomPinned;
-use std::mem::MaybeUninit;
-use std::pin::Pin;
 use std::sync::atomic::AtomicBool;
 use std::sync::Mutex;
 use std::time::Instant;
@@ -9,61 +8,85 @@ use super::{ActiveMeasurement, Measurement, RingBuffer};
 use crate::logging::{print_debug, Colorize};
 
 #[thread_local]
-static mut PROFILER: MaybeUninit<&'static Mutex<Pin<Box<Profiler>>>> = MaybeUninit::uninit();
-static mut PROFILER_HALTED: AtomicBool = AtomicBool::new(false);
+static PROFILER: Cell<Option<&'static Mutex<Profiler>>> = Cell::new(None);
+static PROFILER_HALTED: AtomicBool = AtomicBool::new(false);
 
 #[derive(Default)]
 pub struct Profiler {
+    // Safety: The profiler has self-referencing fields, so we must make sure that the memory of
+    // these fields never move: The backing fields inside the inner profiler are saved on the heap
+    // and are not accessible by the outer API.
+    inner: Box<ProfilerInner>,
+}
+
+#[derive(Default)]
+pub struct ProfilerInner {
     root_measurement: Option<Measurement>,
     /// Self referencing pointers
     active_measurements: Vec<*const Measurement>,
-    saved_frames: RingBuffer<Measurement, { Self::SAVED_FRAME_COUNT }>,
+    saved_frames: RingBuffer<Measurement, { Profiler::SAVED_FRAME_COUNT }>,
     /// Since the profiler has some self-referencing fields, we want it to be
     /// !Unpin.
     _pin: PhantomPinned,
 }
+
+// Safety: It's in general safe to send a Profiler between threads, since the
+// referencing fields only point to inner data and the inner data is not moved
+// by sending it to other threads.
+unsafe impl Send for ProfilerInner {}
 
 impl Profiler {
     pub const ROOT_MEASUREMENT_NAME: &'static str = "total";
     pub const SAVED_FRAME_COUNT: usize = 128;
 
     /// Set the active profiler.
-    pub fn set_active(profiler: &'static Mutex<Pin<Box<Profiler>>>) {
-        unsafe { PROFILER.write(profiler) };
+    #[doc(hidden)]
+    pub fn set_active(profiler: &'static Mutex<Profiler>) {
+        PROFILER.set(Some(profiler));
     }
 
     /// Start a new measurement.
+    ///
+    /// # Note
+    /// Panics when called before having called `start_frame()` for the current
+    /// thread.
     pub fn start_measurement(name: &'static str) -> ActiveMeasurement {
-        let mut guard = unsafe { PROFILER.assume_init_ref().lock().unwrap() };
-        guard.as_mut().start_measurement_inner(name)
+        let mut guard = PROFILER.get().unwrap().lock().unwrap();
+        guard.start_measurement_inner(name)
     }
 
     /// Start a new measurement.
+    ///
+    /// # Note
+    /// Panics when called before having called `start_frame()` for the current
+    /// thread.
     pub(crate) fn stop_measurement(name: &'static str) {
-        let mut guard = unsafe { PROFILER.assume_init_ref().lock().unwrap() };
-        guard.as_mut().stop_measurement_inner(name)
+        let mut guard = PROFILER.get().unwrap().lock().unwrap();
+        guard.stop_measurement_inner(name)
     }
 
     /// Set the profiler halted state.
     pub fn set_halted(running: bool) {
-        unsafe { PROFILER_HALTED.store(running, std::sync::atomic::Ordering::Relaxed) };
+        PROFILER_HALTED.store(running, std::sync::atomic::Ordering::Relaxed);
     }
 
     /// Get the profiler halted state.
     pub fn get_halted() -> bool {
-        unsafe { PROFILER_HALTED.load(std::sync::atomic::Ordering::Relaxed) }
+        PROFILER_HALTED.load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Get the measurements of the previous SAVE_FRAME_COUNT frames.
     pub(crate) fn get_saved_frames(&self) -> &RingBuffer<Measurement, { Self::SAVED_FRAME_COUNT }> {
-        &self.saved_frames
+        &self.inner.saved_frames
     }
 
     /// Start a new frame by creating a new root measurement.
-    pub fn start_frame(self: Pin<&mut Self>) -> ActiveMeasurement {
+    #[doc(hidden)]
+    pub fn start_frame(&mut self) -> ActiveMeasurement {
         // Make sure that there are no active measurements.
-        if self.active_measurements.len() > 1 {
+        if self.inner.active_measurements.len() > 1 {
             let measurement_names = self
+                .inner
                 .active_measurements
                 .iter()
                 .skip(1)
@@ -79,36 +102,33 @@ impl Profiler {
             );
         }
 
-        // SAFETY: We do not move out of self.
-        let self_mut = unsafe { self.get_unchecked_mut() };
-
         // Start a new root measurement.
         let name = Self::ROOT_MEASUREMENT_NAME;
-        let previous_measurement = self_mut.root_measurement.replace(Measurement {
+        let previous_measurement = self.inner.root_measurement.replace(Measurement {
             name,
             start_time: Instant::now(),
             end_time: Instant::now(),
             indices: Vec::new(),
         });
 
-        // Set `active_measurements` to a well defined state.
-        self_mut.active_measurements = vec![self_mut.root_measurement.as_ref().unwrap() as *const _];
+        // Set `active_measurements` to a well-defined state.
+        self.inner.active_measurements = vec![self.inner.root_measurement.as_ref().unwrap() as *const _];
 
-        // Save the completed frame so we can inspect it in the profiler later on.
-        let profiler_halted = unsafe { PROFILER_HALTED.load(std::sync::atomic::Ordering::Relaxed) };
+        // Save the completed frame, so we can inspect it in the profiler later on.
+        let profiler_halted = PROFILER_HALTED.load(std::sync::atomic::Ordering::Relaxed);
         if let Some(previous_measurement) = previous_measurement
             && !profiler_halted
         {
-            self_mut.saved_frames.push(previous_measurement);
+            self.inner.saved_frames.push(previous_measurement);
         }
 
         ActiveMeasurement::new(name)
     }
 
     /// Start a new measurement.
-    fn start_measurement_inner(self: Pin<&mut Self>, name: &'static str) -> ActiveMeasurement {
+    fn start_measurement_inner(&mut self, name: &'static str) -> ActiveMeasurement {
         // Get the most recent active measurement.
-        let top_measurement = self.active_measurements.last().copied().unwrap();
+        let top_measurement = self.inner.active_measurements.last().copied().unwrap();
         let measurement = unsafe { &mut *(top_measurement as *mut Measurement) };
 
         // Add a new index to the measurement.
@@ -117,16 +137,14 @@ impl Profiler {
         // Set the index as the new most recent active measurement.
         let index = measurement.indices.last().unwrap();
 
-        // SAFETY: We do not move out of self.
-        let self_mut = unsafe { self.get_unchecked_mut() };
-        self_mut.active_measurements.push(index as *const _);
+        self.inner.active_measurements.push(index as *const _);
 
         ActiveMeasurement::new(name)
     }
 
     /// Stop a running measurement.
-    fn stop_measurement_inner(self: Pin<&mut Self>, name: &'static str) {
-        let Some(top_measurement) = self.active_measurements.last().copied() else {
+    fn stop_measurement_inner(&mut self, name: &'static str) {
+        let Some(top_measurement) = self.inner.active_measurements.last().copied() else {
             print_debug!(
                 "[{}] tried to stop measurement {} but no measurement is active",
                 "warning".yellow(),
@@ -150,18 +168,15 @@ impl Profiler {
         // Set the end time of the measurement.
         measurement.set_end_time();
 
-        // SAFETY: We do not move out of self.
-        let self_mut = unsafe { self.get_unchecked_mut() };
-
         // Remove the measurement from the list of active measurements.
-        self_mut.active_measurements.pop();
+        self.inner.active_measurements.pop();
     }
 }
 
 /// Implementation detail of the [`create_profiler_threads`] macro.
-pub trait LockThreadProfier {
+pub trait LockThreadProfiler {
     /// Lock the profiler corresponding to the variant.
-    fn lock_profiler(&self) -> std::sync::MutexGuard<'_, Pin<Box<Profiler>>>;
+    fn lock_profiler(&self) -> std::sync::MutexGuard<'_, Profiler>;
 }
 
 /// Profile the entire block.
@@ -178,22 +193,18 @@ macro_rules! profile_block {
 macro_rules! create_profiler_threads {
     ($name:ident, { $($thread:ident,)* $(,)? }) => {
         pub mod $name {
-            use std::boxed::Box;
-            use std::pin::Pin;
             use std::sync::MutexGuard;
             use $crate::profiling::Profiler;
-            use $crate::profiling::LockThreadProfier;
+            use $crate::profiling::LockThreadProfiler;
 
             mod locks {
-                use std::boxed::Box;
-                use std::pin::Pin;
                 use std::sync::{LazyLock, Mutex};
                 use $crate::profiling::Profiler;
 
                 $(
                     #[allow(non_upper_case_globals)]
-                    pub(super) static mut $thread: LazyLock<Mutex<Pin<Box<Profiler>>>> = LazyLock::new(|| {
-                        Mutex::new(Box::pin(Profiler::default()))
+                    pub(super) static $thread: LazyLock<Mutex<Profiler>> = LazyLock::new(|| {
+                        Mutex::new(Profiler::default())
                     });
                 )*
             }
@@ -204,10 +215,10 @@ macro_rules! create_profiler_threads {
                 $($thread),*
             }
 
-            impl LockThreadProfier for Enum {
-                fn lock_profiler(&self) -> MutexGuard<'_, Pin<Box<Profiler>>> {
+            impl LockThreadProfiler for Enum {
+                fn lock_profiler(&self) -> MutexGuard<'_, Profiler> {
                     match self {
-                        $(Self::$thread => unsafe { locks::$thread.lock().unwrap() }),*
+                        $(Self::$thread => locks::$thread.lock().unwrap()),*
                     }
                 }
             }
@@ -220,8 +231,8 @@ macro_rules! create_profiler_threads {
 
                     /// Start the frame.
                     pub fn start_frame() -> ActiveMeasurement {
-                        let profiler = unsafe { &super::locks::$thread };
-                        let measurement = profiler.lock().unwrap().as_mut().start_frame();
+                        let profiler = &super::locks::$thread;
+                        let measurement = profiler.lock().unwrap().start_frame();
                         Profiler::set_active(profiler);
                         measurement
                     }

--- a/korangar_debug/src/profiling/statistics.rs
+++ b/korangar_debug/src/profiling/statistics.rs
@@ -3,7 +3,7 @@ use std::ops::Div;
 use std::time::Duration;
 
 use super::measurement::Measurement;
-use crate::profiling::LockThreadProfier;
+use crate::profiling::LockThreadProfiler;
 
 #[derive(Default, Debug)]
 struct MeasurementTiming {
@@ -66,7 +66,7 @@ pub struct FrameData {
     pub total_time: Duration,
 }
 
-pub fn get_statistics_data(thread: impl LockThreadProfier) -> (Vec<FrameData>, HashMap<&'static str, MeasurementStatistics>, Duration) {
+pub fn get_statistics_data(thread: impl LockThreadProfiler) -> (Vec<FrameData>, HashMap<&'static str, MeasurementStatistics>, Duration) {
     let profiler = thread.lock_profiler();
     let mut longest_frame_time = Duration::default();
 
@@ -109,12 +109,12 @@ pub fn get_statistics_data(thread: impl LockThreadProfier) -> (Vec<FrameData>, H
     (frame_data, statistics_map, longest_frame_time)
 }
 
-pub fn get_number_of_saved_frames(thread: impl LockThreadProfier) -> usize {
+pub fn get_number_of_saved_frames(thread: impl LockThreadProfiler) -> usize {
     let profiler = thread.lock_profiler();
     profiler.get_saved_frames().iter().count()
 }
 
-pub fn get_frame_by_index(thread: impl LockThreadProfier, index: usize) -> Measurement {
+pub fn get_frame_by_index(thread: impl LockThreadProfiler, index: usize) -> Measurement {
     let profiler = thread.lock_profiler();
 
     // TODO: maybe don't use the iterator to receive the frame? That would help


### PR DESCRIPTION
Before this change it was possible to trigger UB by calling start_measurement() of a profiler, before having called set_active() by calling start_frame().

The only real penalty right now is the check if the option is set, when calling the measurement functions. This shouldn't result in any measurable performance penalty, since this is an easy case for a branch predictor.

I removed the Pin, since it should not be possible using the external API and safe Rust to move the inner profiler around and thus invalidating the internal references.

I also moved the Box into the Profiler itself and documented the safety assumptions that must be upheld.