### PR TITLE
Improve the profiler.

### DIFF
--- a/korangar/src/interface/windows/debug/inspector.rs
+++ b/korangar/src/interface/windows/debug/inspector.rs
@@ -1,4 +1,4 @@
-use korangar_debug::profiling::Measurement;
+use korangar_debug::profiling::FrameMeasurement;
 use korangar_interface::elements::ElementWrap;
 use korangar_interface::size_bound;
 use korangar_interface::windows::{PrototypeWindow, Window, WindowBuilder};
@@ -9,12 +9,12 @@ use crate::interface::layout::ScreenSize;
 use crate::interface::windows::WindowCache;
 
 pub struct FrameInspectorWindow {
-    measurement: Measurement,
+    frame_measurement: FrameMeasurement,
 }
 
 impl FrameInspectorWindow {
-    pub fn new(measurement: Measurement) -> Self {
-        Self { measurement }
+    pub fn new(frame_measurement: FrameMeasurement) -> Self {
+        Self { frame_measurement }
     }
 }
 
@@ -25,7 +25,7 @@ impl PrototypeWindow<InterfaceSettings> for FrameInspectorWindow {
         application: &InterfaceSettings,
         available_space: ScreenSize,
     ) -> Window<InterfaceSettings> {
-        let elements = vec![FrameInspectorView::new(self.measurement.clone()).wrap()];
+        let elements = vec![FrameInspectorView::new(self.frame_measurement.clone()).wrap()];
 
         WindowBuilder::new()
             .with_title("Frame Inspector".to_string())

--- a/korangar_debug/src/lib.rs
+++ b/korangar_debug/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(decl_macro)]
 #![feature(let_chains)]
+#![feature(slice_take)]
 #![feature(thread_local)]
 
 #[macro_use]

--- a/korangar_debug/src/profiling/frame_measurement.rs
+++ b/korangar_debug/src/profiling/frame_measurement.rs
@@ -1,0 +1,84 @@
+use std::ops::{Index, IndexMut};
+
+use crate::profiling::Measurement;
+
+#[derive(Default, Clone)]
+pub struct FrameMeasurement {
+    buffer: Vec<Measurement>,
+    next_index: usize,
+}
+
+impl FrameMeasurement {
+    /// Clears the measurement without de-allocating.
+    pub(super) fn clear(&mut self) {
+        self.next_index = 0;
+    }
+
+    /// Creates a new measurement and returns its index.
+    pub(super) fn new_measurement(&mut self, name: &'static str) -> usize {
+        let index = self.next_index;
+        self.next_index += 1;
+
+        if index == self.buffer.len() {
+            self.buffer.push(Measurement::default());
+        }
+
+        let measurement = &mut self.buffer[index];
+        measurement.start_measurement(name);
+
+        index
+    }
+
+    /// Returns the root measurement of the frame's measurement.
+    pub fn root_measurement(&self) -> &Measurement {
+        &self.buffer[0]
+    }
+}
+
+impl Index<usize> for FrameMeasurement {
+    type Output = Measurement;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.buffer[index]
+    }
+}
+
+impl IndexMut<usize> for FrameMeasurement {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.buffer[index]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::profiling::FrameMeasurement;
+
+    #[test]
+    fn basic_api() {
+        let mut measurement = FrameMeasurement::default();
+
+        assert_eq!(measurement.new_measurement("0"), 0);
+        assert_eq!(measurement.new_measurement("1"), 1);
+        assert_eq!(measurement.new_measurement("2"), 2);
+        assert_eq!(measurement.new_measurement("3"), 3);
+
+        assert_eq!(measurement.root_measurement().name, "0");
+        assert_eq!(measurement[0].name, "0");
+        assert_eq!(measurement[1].name, "1");
+        assert_eq!(measurement[2].name, "2");
+        assert_eq!(measurement[3].name, "3");
+
+        measurement.clear();
+
+        assert_eq!(measurement.new_measurement("9"), 0);
+        assert_eq!(measurement.new_measurement("8"), 1);
+        assert_eq!(measurement.new_measurement("7"), 2);
+        assert_eq!(measurement.new_measurement("6"), 3);
+
+        assert_eq!(measurement.root_measurement().name, "9");
+        assert_eq!(measurement[0].name, "9");
+        assert_eq!(measurement[1].name, "8");
+        assert_eq!(measurement[2].name, "7");
+        assert_eq!(measurement[3].name, "6");
+    }
+}

--- a/korangar_debug/src/profiling/measurement.rs
+++ b/korangar_debug/src/profiling/measurement.rs
@@ -28,22 +28,32 @@ pub struct Measurement {
     pub name: &'static str,
     pub start_time: Instant,
     pub end_time: Instant,
-    pub indices: Vec<Measurement>,
+    pub indices: Vec<usize>,
 }
 
-impl Measurement {
-    pub fn new(name: &'static str) -> Self {
+impl Default for Measurement {
+    fn default() -> Self {
         let start_time = Instant::now();
 
         Self {
-            name,
+            name: "",
             start_time,
             end_time: start_time,
             indices: Vec::new(),
         }
     }
+}
 
-    pub(super) fn set_end_time(&mut self) {
+impl Measurement {
+    pub(super) fn start_measurement(&mut self, name: &'static str) {
+        let start_time = Instant::now();
+        self.name = name;
+        self.start_time = start_time;
+        self.end_time = start_time;
+        self.indices.clear();
+    }
+
+    pub(super) fn stop_measurement(&mut self) {
         self.end_time = Instant::now();
     }
 

--- a/korangar_debug/src/profiling/mod.rs
+++ b/korangar_debug/src/profiling/mod.rs
@@ -1,8 +1,10 @@
+mod frame_measurement;
 mod measurement;
 mod profiler;
 mod ring_buffer;
 mod statistics;
 
+pub use self::frame_measurement::FrameMeasurement;
 pub use self::measurement::{ActiveMeasurement, Measurement};
 pub use self::profiler::{LockThreadProfiler, Profiler};
 pub use self::ring_buffer::RingBuffer;

--- a/korangar_debug/src/profiling/ring_buffer.rs
+++ b/korangar_debug/src/profiling/ring_buffer.rs
@@ -1,66 +1,273 @@
+use std::ops::Index;
+
 pub struct RingBuffer<T, const N: usize> {
     buffer: [Option<T>; N],
-    index: usize,
+    start: usize,
+    length: usize,
 }
 
 impl<T, const N: usize> Default for RingBuffer<T, N> {
     fn default() -> Self {
         Self {
             buffer: [const { None }; N],
-            index: 0,
+            start: 0,
+            length: 0,
         }
     }
 }
 
 impl<T, const N: usize> RingBuffer<T, N> {
-    pub fn push(&mut self, item: T) {
-        let index = self.index;
-        self.buffer[index] = Some(item);
-        self.index = (self.index + 1) % N;
+    /// Returns the count of the stored values.
+    pub fn len(&self) -> usize {
+        self.length
     }
 
-    pub fn iter(&self) -> RingBufferIter<'_, T, N> {
-        let start_index = match self.buffer[self.index] {
-            Some(..) => self.index,
-            None => 0,
-        };
+    /// Returns `true` if the ring buffer is empty.
+    pub fn is_empty(&self) -> bool {
+        self.length == 0
+    }
 
-        RingBufferIter {
-            ring_buffer: self,
-            last_index: start_index.wrapping_sub(1) % N,
-            current_index: start_index,
-            done: false,
+    /// Pushes a value into the ring buffer.
+    ///
+    /// # Note
+    /// Will fail to compile if N == 0
+    ///
+    /// ```compile_fail
+    /// let mut buffer = RingBuffer::<(), 0>::default();
+    /// buffer.push(());
+    /// ```
+    pub fn push(&mut self, value: T) {
+        assert!(N > 0, "N == 0 not supported");
+
+        let index;
+
+        if self.length >= N {
+            index = self.start;
+            self.start = bounded_add::<N>(self.start, 1);
+        } else {
+            self.length += 1;
+            index = bounded_add::<N>(self.start, self.length - 1);
+        }
+
+        self.buffer[index] = Some(value);
+    }
+
+    /// Pushes either a default value or a recycled value.
+    ///
+    /// # Note
+    /// Will fail to compile if N == 0
+    ///
+    /// ```compile_fail
+    /// let mut buffer = RingBuffer::<(), 0>::default();
+    /// buffer.push_default_or_recycle();
+    /// ```
+    pub fn push_default_or_recycle(&mut self)
+    where
+        T: Default,
+    {
+        assert!(N > 0, "N == 0 not supported");
+
+        if self.length >= N {
+            self.start = bounded_add::<N>(self.start, 1);
+        } else {
+            self.length += 1;
+            let back = bounded_add::<N>(self.start, self.length - 1);
+            self.buffer[back] = Some(T::default());
         }
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.iter().next().is_none()
+    /// Returns the value at the given index.
+    pub fn get(&self, index: usize) -> Option<&T> {
+        if index >= self.length {
+            return None;
+        }
+        let index = bounded_add::<N>(self.start, index);
+        self.buffer[index].as_ref()
     }
 
+    /// Returns the last value that was pushed.
+    pub fn back(&self) -> Option<&T> {
+        if self.is_empty() {
+            return None;
+        }
+        let back = bounded_add::<N>(self.start, self.length - 1);
+        self.buffer[back].as_ref()
+    }
+
+    /// Returns the last value that was pushed.
+    pub fn back_mut(&mut self) -> Option<&mut T> {
+        if self.is_empty() {
+            return None;
+        }
+        let back = bounded_add::<N>(self.start, self.length - 1);
+        self.buffer[back].as_mut()
+    }
+
+    /// Returns an iterator over all values that are stored inside the ring
+    /// buffer.
+    pub fn iter(&self) -> RingBufferIter<'_, T> {
+        let (front, back) = self.as_slices();
+        RingBufferIter { front, back }
+    }
+
+    /// Clears the ring buffer.
     pub fn clear(&mut self) {
-        *self = Self::default();
+        *self = Self::default()
+    }
+
+    /// Returns the content of the ring buffer as two slices.
+    fn as_slices(&self) -> (&[Option<T>], &[Option<T>]) {
+        if self.is_empty() {
+            return (&[], &[]);
+        }
+
+        let start = self.start;
+        let end = bounded_add::<N>(self.start, self.length);
+
+        let (front, back) = if start < end {
+            (&self.buffer[start..end], &[][..])
+        } else {
+            let (back, front) = self.buffer.split_at(start);
+            (front, &back[..end])
+        };
+
+        (front, back)
     }
 }
 
-pub struct RingBufferIter<'a, T, const N: usize> {
-    ring_buffer: &'a RingBuffer<T, N>,
-    current_index: usize,
-    last_index: usize,
-    done: bool,
+/// An iterator that iterates over all values of the ring buffer.
+pub struct RingBufferIter<'a, T> {
+    front: &'a [Option<T>],
+    back: &'a [Option<T>],
 }
 
-impl<'a, T, const N: usize> Iterator for RingBufferIter<'a, T, N> {
+impl<'a, T> Iterator for RingBufferIter<'a, T> {
     type Item = &'a T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.done {
-            return None;
+        if let Some(item) = self.front.take_first() {
+            item.as_ref()
+        } else if let Some(item) = self.back.take_first() {
+            item.as_ref()
+        } else {
+            None
         }
+    }
 
-        let index = self.current_index;
-        self.done |= index == self.last_index;
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        (len, Some(len))
+    }
+}
 
-        self.current_index = (self.current_index + 1) % N;
-        self.ring_buffer.buffer[index].as_ref()
+impl<'a, T> ExactSizeIterator for RingBufferIter<'a, T> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.front.len() + self.back.len()
+    }
+}
+
+impl<const N: usize, T> Index<usize> for RingBuffer<T, N> {
+    type Output = T;
+
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        self.get(index).expect("index out-of-bounds")
+    }
+}
+
+#[inline]
+const fn bounded_add<const M: usize>(x: usize, y: usize) -> usize {
+    let (sum, overflow) = x.overflowing_add(y);
+    (sum + (overflow as usize) * (usize::MAX % M + 1)) % M
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn bounded_add_edge_cases() {
+        assert_eq!(bounded_add::<10>(7, 3), 0);
+        assert_eq!(bounded_add::<10>(usize::MAX, 1), 6);
+        assert_eq!(bounded_add::<10>(2, usize::MAX), 7);
+        assert_eq!(bounded_add::<1>(100, 5), 0);
+        assert_eq!(bounded_add::<10>(5, 0), 5);
+        assert_eq!(bounded_add::<10>(0, 5), 5);
+    }
+
+    #[test]
+    fn push() {
+        const COUNT: usize = 2;
+        let mut buffer = RingBuffer::<usize, COUNT>::default();
+        buffer.push(0);
+        assert_eq!(buffer.get(0), Some(&0));
+
+        buffer.push(1);
+        assert_eq!(buffer.get(0), Some(&0));
+        assert_eq!(buffer.get(1), Some(&1));
+
+        buffer.push(2);
+        assert_eq!(buffer.get(0), Some(&1));
+        assert_eq!(buffer.get(1), Some(&2));
+
+        buffer.push(3);
+        assert_eq!(buffer.get(0), Some(&2));
+        assert_eq!(buffer.get(1), Some(&3));
+    }
+
+    #[test]
+    fn push_default_or_recycle() {
+        const COUNT: usize = 2;
+        let mut buffer = RingBuffer::<usize, COUNT>::default();
+        buffer.push_default_or_recycle();
+        *buffer.back_mut().unwrap() = 0;
+        assert_eq!(buffer.get(0), Some(&0));
+
+        buffer.push_default_or_recycle();
+        *buffer.back_mut().unwrap() = 1;
+        assert_eq!(buffer.get(0), Some(&0));
+        assert_eq!(buffer.get(1), Some(&1));
+
+        buffer.push_default_or_recycle();
+        *buffer.back_mut().unwrap() = 2;
+        assert_eq!(buffer.get(0), Some(&1));
+        assert_eq!(buffer.get(1), Some(&2));
+
+        buffer.push_default_or_recycle();
+        *buffer.back_mut().unwrap() = 3;
+        assert_eq!(buffer.get(0), Some(&2));
+        assert_eq!(buffer.get(1), Some(&3));
+    }
+
+    #[test]
+    fn iter() {
+        const COUNT: usize = 5;
+        let mut buffer = RingBuffer::<usize, COUNT>::default();
+
+        assert_eq!(0, buffer.iter().count());
+        assert_eq!(None, buffer.iter().last().copied());
+
+        for index in 1..COUNT {
+            buffer.push(index);
+            assert_eq!(buffer.len(), index);
+            assert_eq!(buffer.iter().count(), index);
+            assert_eq!(buffer.iter().last().copied(), Some(index));
+        }
+    }
+
+    #[test]
+    fn back() {
+        const COUNT: usize = 2;
+
+        let mut buffer = RingBuffer::<usize, COUNT>::default();
+
+        assert_eq!(None, buffer.back());
+
+        for index in 0..COUNT * 3 {
+            buffer.push(index);
+            assert_eq!(buffer.back(), Some(&index));
+        }
     }
 }


### PR DESCRIPTION
 - No use of unsafe and possible UB.
 - Allocations are minimized.
 - All measurements of a frame are saved continuously.
 - Faster length calculation and index operation on ring buffer.
 - Added tests for the container.
 
Benchmark:

```
start_frame() with drop:

old = 112.10 ns
new = 60.176 ns

start_measurement() with drop:

old = 93.523 ns
new = 96.892 ns
```

start_frame() is a lot faster, start_measurement() is a little bit slower, but overall the consistent performance should improve, since once all frame slots are filled, we won't hit the allocator anymore. Packets still hit the allocator, because the boxed trait object can't be re-used.