### PR TITLE
Remove unsafe code from PacketHistoryCallback.

### DIFF
--- a/korangar/src/interface/elements/containers/packet.rs
+++ b/korangar/src/interface/elements/containers/packet.rs
@@ -175,7 +175,7 @@ pub struct PacketHistoryCallback {
 static BUFFER_POINTER: LazyLock<PacketHistoryBufferPointer> = LazyLock::new(|| Box::leak(Box::new(Mutex::new((RingBuffer::default(), 0)))));
 
 impl PacketHistoryCallback {
-    pub fn new() -> Self {
+    pub fn get_static_instance() -> Self {
         Self {
             buffer_pointer: &BUFFER_POINTER,
         }

--- a/korangar/src/main.rs
+++ b/korangar/src/main.rs
@@ -331,7 +331,7 @@ fn main() {
         #[cfg(not(feature = "debug"))]
         let mut networking_system = NetworkingSystem::spawn();
         #[cfg(feature = "debug")]
-        let packet_callback = interface::elements::PacketHistoryCallback::new();
+        let packet_callback = interface::elements::PacketHistoryCallback::get_static_instance();
         #[cfg(feature = "debug")]
         let mut networking_system = NetworkingSystem::spawn_with_callback(packet_callback.clone());
 

--- a/korangar/src/main.rs
+++ b/korangar/src/main.rs
@@ -331,11 +331,7 @@ fn main() {
         #[cfg(not(feature = "debug"))]
         let mut networking_system = NetworkingSystem::spawn();
         #[cfg(feature = "debug")]
-        let packet_callback = {
-            // SAFETY: This function leaks memory, but it's fine since we only call
-            // it once.
-            unsafe { interface::elements::PacketHistoryCallback::new() }
-        };
+        let packet_callback = interface::elements::PacketHistoryCallback::new();
         #[cfg(feature = "debug")]
         let mut networking_system = NetworkingSystem::spawn_with_callback(packet_callback.clone());
 


### PR DESCRIPTION
This makes sure that we only initialize the buffer once.