### PR TITLE
Fix debug build and activate optimizations.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,39 @@ wgpu = "22.1"
 winit = "0.30"
 xml-rs = "0.8"
 yazi = "0.2"
+
+[profile.dev.build-override]
+opt-level = 3
+
+[profile.dev.package."*"]
+opt-level = 3
+
+[profile.dev.package.korangar]
+opt-level = 0
+
+[profile.dev.package.korangar_audio]
+opt-level = 3
+
+[profile.dev.package.korangar_debug]
+opt-level = 3
+
+[profile.dev.package.korangar_interface]
+opt-level = 3
+
+[profile.dev.package.korangar_networking]
+opt-level = 3
+
+[profile.dev.package.korangar_util]
+opt-level = 3
+
+[profile.dev.package.ragnarok_bytes]
+opt-level = 3
+
+[profile.dev.package.ragnarok_formats]
+opt-level = 3
+
+[profile.dev.package.ragnarok_packets]
+opt-level = 3
+
+[profile.dev.package.ragnarok_procedural]
+opt-level = 3

--- a/korangar/src/loaders/action/mod.rs
+++ b/korangar/src/loaders/action/mod.rs
@@ -50,7 +50,7 @@ impl AnimationState {
     }
 
     pub fn update(&mut self, client_tick: ClientTick) {
-        let mut time = client_tick.0 - self.start_time.0;
+        let mut time = client_tick.0.saturating_sub(self.start_time.0);
 
         // TODO: make everything have a duration so that we can update the start_time
         // from time to time so that animations won't start to drop frames as

--- a/korangar/src/world/entity/mod.rs
+++ b/korangar/src/world/entity/mod.rs
@@ -361,7 +361,10 @@ impl Common {
                 let last_step = active_movement.steps[last_step_index];
                 let next_step = active_movement.steps[last_step_index + 1];
 
-                let array = (last_step.0 - next_step.0).map(|c| c as isize);
+                let last_step_position = last_step.0.map(|value| value as isize);
+                let next_step_position = next_step.0.map(|value| value as isize);
+
+                let array = last_step_position - next_step_position;
                 let array: &[isize; 2] = array.as_ref();
                 self.head_direction = match array {
                     [0, 1] => 0,


### PR DESCRIPTION
This PR makes the debug builds usable again. Some integer underflow are fixed and I also activated compiler optimization for all dependencies of the client. I left the debug level for the main client crate at 0, simply because it's the main target when using the debugger in normal development.

Workspace dependencies and build dependencies need their own override. This also enabled us to toggle the optimization for sub-crates if less optimizations are needed for better debugging.