### PR TITLE
Use a KD-Tree to query static light sources.

### DIFF
--- a/korangar/src/graphics/renderers/picker/target.rs
+++ b/korangar/src/graphics/renderers/picker/target.rs
@@ -56,7 +56,7 @@ impl From<u32> for PickerTarget {
 
         #[cfg(feature = "debug")]
         if data >> 24 == MarkerEncoding::LightSource as u32 {
-            return Self::Marker(MarkerIdentifier::LightSource(data as usize & 0xFFF));
+            return Self::Marker(MarkerIdentifier::LightSource(data & 0xFFF));
         }
 
         #[cfg(feature = "debug")]

--- a/korangar/src/loaders/map/mod.rs
+++ b/korangar/src/loaders/map/mod.rs
@@ -135,10 +135,9 @@ impl MapLoader {
             .light_sources
             .drain(..)
             .map(|light_source| {
-                let clone = light_source.clone();
                 let extent = point_light_extent(light_source.color.into(), light_source.range);
                 let sphere = Sphere::new(light_source.position, extent);
-                let key = light_sources.insert(clone).expect("light sources slab is full");
+                let key = light_sources.insert(light_source).expect("light sources slab is full");
                 (key, sphere)
             })
             .collect();

--- a/korangar/src/world/light/mod.rs
+++ b/korangar/src/world/light/mod.rs
@@ -92,14 +92,7 @@ impl PointLight {
         renderer: &DeferredRenderer,
         camera: &dyn Camera,
     ) {
-        renderer.point_light(
-            render_target,
-            render_pass,
-            camera,
-            self.position,
-            self.color.to_owned(),
-            self.range,
-        );
+        renderer.point_light(render_target, render_pass, camera, self.position, self.color, self.range);
     }
 
     fn render_with_shadows(
@@ -116,7 +109,7 @@ impl PointLight {
             camera,
             shadow_map,
             self.position,
-            self.color.to_owned(),
+            self.color,
             self.range,
         );
     }

--- a/korangar/src/world/map/mod.rs
+++ b/korangar/src/world/map/mod.rs
@@ -441,7 +441,7 @@ impl Map {
             point_light_manager.register(
                 PointLightId::new(light_source_key.key()),
                 light_source.position,
-                light_source.color.clone().into(),
+                light_source.color.into(),
                 light_source.range,
             );
         }
@@ -630,7 +630,7 @@ impl Map {
             }
             MarkerIdentifier::LightSource(key) => {
                 let light_source = self.light_sources.get(LightSourceKey::new(key)).unwrap();
-                let color = light_source.color.clone().into();
+                let color = light_source.color.into();
                 let extent = point_light_extent(color, light_source.range);
 
                 renderer.render_circle(

--- a/korangar/src/world/mod.rs
+++ b/korangar/src/world/mod.rs
@@ -13,3 +13,34 @@ pub use self::map::*;
 pub use self::model::*;
 pub use self::object::*;
 pub use self::sound::*;
+
+pub struct ResourceSetBuffer<K> {
+    visible: Vec<K>,
+}
+
+impl<K> Default for ResourceSetBuffer<K> {
+    fn default() -> Self {
+        Self { visible: Vec::new() }
+    }
+}
+
+impl<K> ResourceSetBuffer<K> {
+    pub(super) fn create_set(&mut self, initializer: impl FnOnce(&mut Vec<K>)) -> ResourceSet<'_, K> {
+        self.visible.clear();
+
+        initializer(&mut self.visible);
+
+        ResourceSet { visible: &self.visible }
+    }
+}
+
+#[derive(Default)]
+pub struct ResourceSet<'a, K> {
+    visible: &'a [K],
+}
+
+impl<K> ResourceSet<'_, K> {
+    pub(super) fn iterate_visible(&self) -> std::slice::Iter<'_, K> {
+        self.visible.iter()
+    }
+}

--- a/korangar/src/world/object/mod.rs
+++ b/korangar/src/world/object/mod.rs
@@ -10,7 +10,7 @@ use wgpu::RenderPass;
 
 #[cfg(feature = "debug")]
 use super::MarkerIdentifier;
-use super::{Model, ObjectKey};
+use super::Model;
 #[cfg(feature = "debug")]
 use crate::graphics::{DeferredRenderer, MarkerRenderer};
 use crate::{Camera, GeometryRenderer, Renderer};
@@ -75,33 +75,5 @@ impl Object {
             self.transform.position,
             hovered,
         );
-    }
-}
-
-#[derive(Default)]
-pub struct ObjectSetBuffer {
-    visible_objects: Vec<ObjectKey>,
-}
-
-impl ObjectSetBuffer {
-    pub(super) fn create_set(&mut self, initializer: impl FnOnce(&mut Vec<ObjectKey>)) -> ObjectSet<'_> {
-        self.visible_objects.clear();
-
-        initializer(&mut self.visible_objects);
-
-        ObjectSet {
-            visible_objects: &self.visible_objects,
-        }
-    }
-}
-
-#[derive(Default)]
-pub struct ObjectSet<'a> {
-    visible_objects: &'a [ObjectKey],
-}
-
-impl ObjectSet<'_> {
-    pub(super) fn iterate_visible(&self) -> std::slice::Iter<'_, ObjectKey> {
-        self.visible_objects.iter()
     }
 }

--- a/ragnarok_formats/src/color.rs
+++ b/ragnarok_formats/src/color.rs
@@ -1,6 +1,6 @@
 use ragnarok_bytes::ByteConvertable;
 
-#[derive(Clone, Debug, ByteConvertable)]
+#[derive(Clone, Copy, Debug, ByteConvertable)]
 #[cfg_attr(feature = "interface", derive(korangar_interface::elements::PrototypeElement))]
 pub struct ColorRGB {
     pub red: f32,
@@ -16,7 +16,7 @@ impl ColorRGB {
     }
 }
 
-#[derive(Clone, Debug, ByteConvertable)]
+#[derive(Clone, Copy, Debug, ByteConvertable)]
 #[cfg_attr(feature = "interface", derive(korangar_interface::elements::PrototypeElement))]
 pub struct ColorBGRA {
     pub blue: u8,


### PR DESCRIPTION
I re-used the already present "ObjectSet" to also serve the light sources. Maybe we should re-work it? In the end there are two kind of objects it can hold: Static objects on the map and static light sources of the map. I needed to implment Default for the ObjectSet, because I couldn't implement Default on the keys.