### PR TITLE
Make graphics settings configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,6 +1413,7 @@ dependencies = [
  "rusttype",
  "serde",
  "serde-xml-rs",
+ "spin_sleep",
  "walkdir",
  "wgpu",
  "winit",
@@ -2981,6 +2982,15 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spin_sleep"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64bd7227d85bfd1b8df51e0d83da36d9baaee85eb75730386ef8e3ab6f2a2ea3"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "spirv"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ ron = "0.8"
 rusttype = "0.9"
 serde = "1.0"
 serde-xml-rs = "0.6"
+spin_sleep = "1.2"
 syn = "2.0"
 tokio = { version = "1.39", default-features = false }
 walkdir = "2.5"

--- a/korangar/Cargo.toml
+++ b/korangar/Cargo.toml
@@ -32,6 +32,7 @@ ron = { workspace = true }
 rusttype = { workspace = true, features = ["gpu_cache"] }
 serde = { workspace = true }
 serde-xml-rs = { workspace = true }
+spin_sleep = { workspace = true }
 walkdir = { workspace = true }
 wgpu = { workspace = true }
 winit = { workspace = true }

--- a/korangar/src/graphics/frame_pacer.rs
+++ b/korangar/src/graphics/frame_pacer.rs
@@ -1,0 +1,182 @@
+// A copy of "pacy" by https://github.com/BVE-Reborn/pacy/
+//
+// zlib License
+//
+// (C) 2020 Connor Fitzgerald
+//
+// This software is provided 'as-is', without any express or implied
+// warranty.  In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not claim
+//    that you wrote the original software. If you use this software in a
+//    product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+
+use spin_sleep::SpinSleeper;
+
+pub trait ComparativeTimestamp: Copy {
+    fn difference(base: Self, new: Self) -> Duration;
+}
+
+impl ComparativeTimestamp for Instant {
+    fn difference(base: Self, new: Self) -> Duration {
+        new - base
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct FrameStage<T: ComparativeTimestamp> {
+    index: usize,
+    base: T,
+}
+
+pub struct FramePacer {
+    internals: Internals,
+    sleeper: SpinSleeper,
+}
+
+impl FramePacer {
+    pub fn new(reported_frequency: f64) -> Self {
+        Self {
+            internals: Internals::new(Monitor::new(reported_frequency)),
+            sleeper: SpinSleeper::default(),
+        }
+    }
+
+    pub fn create_frame_stage<T>(&mut self, base: T) -> FrameStage<T>
+    where
+        T: ComparativeTimestamp,
+    {
+        let index = self.internals.frame_stages.len();
+        self.internals
+            .frame_stages
+            .push(FrameStageStats::new(self.internals.reference_instant.elapsed()));
+        FrameStage { index, base }
+    }
+
+    pub fn set_monitor_frequency(&mut self, frequency: f64) {
+        self.internals.monitor.reported_frequency = frequency;
+    }
+
+    pub fn begin_frame_stage<T>(&mut self, stage_id: FrameStage<T>, now: T)
+    where
+        T: ComparativeTimestamp,
+    {
+        self.internals.frame_stages[stage_id.index].begin(T::difference(stage_id.base, now));
+    }
+
+    pub fn end_frame_stage<T>(&mut self, stage_id: FrameStage<T>, now: T)
+    where
+        T: ComparativeTimestamp,
+    {
+        self.internals.frame_stages[stage_id.index].end(T::difference(stage_id.base, now));
+    }
+
+    pub fn wait_for_frame(&mut self) {
+        let next_frame_pipeline_duration: Duration = self
+            .internals
+            .frame_stages
+            .iter()
+            .map(FrameStageStats::estimate_time_for_completion)
+            .sum();
+
+        let sleep_duration = self
+            .internals
+            .monitor
+            .duration_until_next_hittable_timestamp(next_frame_pipeline_duration);
+
+        self.internals.sleep_history.push_back(sleep_duration);
+        self.sleeper.sleep(sleep_duration);
+    }
+}
+
+struct Internals {
+    reference_instant: Instant,
+    frame_stages: Vec<FrameStageStats>,
+    sleep_history: VecDeque<Duration>,
+    monitor: Monitor,
+}
+
+impl Internals {
+    fn new(monitor: Monitor) -> Self {
+        Self {
+            reference_instant: Instant::now(),
+            frame_stages: Vec::new(),
+            sleep_history: VecDeque::new(),
+            monitor,
+        }
+    }
+}
+
+#[derive(Default)]
+struct FrameStageStats {
+    offset: Duration,
+    start_time: Option<Duration>,
+    end_time: Option<Duration>,
+    duration_history: VecDeque<Duration>,
+}
+
+impl FrameStageStats {
+    fn new(offset: Duration) -> Self {
+        Self {
+            offset,
+            ..Default::default()
+        }
+    }
+
+    fn begin(&mut self, value: Duration) {
+        self.start_time = Some(self.offset + value);
+    }
+
+    fn end(&mut self, value: Duration) {
+        self.duration_history.reserve(1);
+        self.end_time = Some(self.offset + value);
+        if let Some(start_time) = self.start_time {
+            self.duration_history.push_back(self.end_time.unwrap() - start_time);
+        }
+    }
+
+    fn estimate_time_for_completion(&self) -> Duration {
+        *self.duration_history.iter().rev().take(10).max().unwrap_or(&Duration::from_secs(0))
+    }
+}
+
+struct Monitor {
+    reported_frequency: f64,
+    last_reported_timestamp: Instant,
+}
+
+impl Monitor {
+    fn new(reported_frequency: f64) -> Self {
+        Self {
+            reported_frequency,
+            last_reported_timestamp: Instant::now(),
+        }
+    }
+
+    fn duration_until_next_hittable_timestamp(&self, compute_time: Duration) -> Duration {
+        let actual_vblank_secs = ((self.reported_frequency + 0.5).floor() - 0.5).recip();
+        let actual_vblank_nanos = (1_000_000_000.0 * actual_vblank_secs) as u128;
+
+        let now = Instant::now();
+
+        let compute_finished = now + compute_time;
+        let dur_since_timestamp = compute_finished - self.last_reported_timestamp;
+
+        let nanos_into_frame = dur_since_timestamp.as_nanos() % actual_vblank_nanos;
+        let nanos_remaining = actual_vblank_nanos - nanos_into_frame;
+
+        Duration::from_nanos(nanos_remaining as u64)
+    }
+}

--- a/korangar/src/graphics/graphic_settings.rs
+++ b/korangar/src/graphics/graphic_settings.rs
@@ -4,6 +4,12 @@ use ron::ser::PrettyConfig;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum LimitFramerate {
+    Unlimited,
+    Limit(u16),
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub enum TextureSamplerType {
     Nearest,
     Linear,
@@ -40,15 +46,21 @@ impl ShadowDetail {
 
 #[derive(Serialize, Deserialize)]
 pub struct GraphicsSettings {
-    pub frame_limit: bool,
+    pub vsync: bool,
+    pub limit_framerate: LimitFramerate,
+    pub triple_buffering: bool,
+    pub texture_filtering: TextureSamplerType,
     pub shadow_detail: ShadowDetail,
 }
 
 impl Default for GraphicsSettings {
     fn default() -> Self {
         Self {
-            frame_limit: true,
-            shadow_detail: ShadowDetail::Medium,
+            vsync: true,
+            limit_framerate: LimitFramerate::Unlimited,
+            triple_buffering: true,
+            texture_filtering: TextureSamplerType::Linear,
+            shadow_detail: ShadowDetail::High,
         }
     }
 }

--- a/korangar/src/graphics/mod.rs
+++ b/korangar/src/graphics/mod.rs
@@ -5,6 +5,7 @@ mod color;
 mod engine;
 #[cfg(feature = "debug")]
 mod error;
+mod frame_pacer;
 mod graphic_settings;
 mod instruction;
 mod particles;
@@ -38,6 +39,7 @@ pub use self::color::*;
 pub use self::engine::{GraphicsEngine, GraphicsEngineDescriptor};
 #[cfg(feature = "debug")]
 pub use self::error::error_handler;
+pub use self::frame_pacer::*;
 pub use self::graphic_settings::*;
 pub use self::instruction::*;
 pub use self::particles::*;

--- a/korangar/src/graphics/render_settings.rs
+++ b/korangar/src/graphics/render_settings.rs
@@ -5,8 +5,6 @@ use derive_new::new;
 #[derive(Copy, Clone, new)]
 pub struct RenderSettings {
     #[new(value = "true")]
-    pub frame_limit: bool,
-    #[new(value = "true")]
     pub show_frames_per_second: bool,
     #[new(value = "true")]
     pub frustum_culling: bool,
@@ -22,8 +20,6 @@ pub struct RenderSettings {
     pub show_water: bool,
     #[new(value = "true")]
     pub show_indicators: bool,
-    #[new(value = "true")]
-    pub show_interface: bool,
     #[new(value = "true")]
     pub show_ambient_light: bool,
     #[new(value = "true")]


### PR DESCRIPTION
I included a hard copy of a frame pacer that I used in the past (it's not published). It is licensed under zlib license. The inclusion of the header is enough to fulfill the license requirements. No need to include it later inside the binary release.

For people that want the best possible latency without running their CPU hot, I included said frame pacer to limit the user selectable framerate.