### PR TITLE
Rework the effect rendering

### DIFF
--- a/korangar/src/graphics/color.rs
+++ b/korangar/src/graphics/color.rs
@@ -1,3 +1,5 @@
+use std::ops::{Add, Mul, Sub};
+
 use ragnarok_formats::color::{ColorBGRA, ColorRGB};
 use serde::{Deserialize, Serialize};
 
@@ -127,6 +129,45 @@ impl Color {
             }
         });
         [linear[0], linear[1], linear[2], self.alpha]
+    }
+}
+
+impl Add for Color {
+    type Output = Color;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self {
+            red: self.red + rhs.red,
+            blue: self.blue + rhs.blue,
+            green: self.green + rhs.green,
+            alpha: self.alpha + rhs.alpha,
+        }
+    }
+}
+
+impl Sub for Color {
+    type Output = Color;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self {
+            red: self.red - rhs.red,
+            blue: self.blue - rhs.blue,
+            green: self.green - rhs.green,
+            alpha: self.alpha - rhs.alpha,
+        }
+    }
+}
+
+impl Mul<f32> for Color {
+    type Output = Color;
+
+    fn mul(self, rhs: f32) -> Self::Output {
+        Self {
+            red: self.red * rhs,
+            blue: self.blue * rhs,
+            green: self.green * rhs,
+            alpha: self.alpha * rhs,
+        }
     }
 }
 

--- a/korangar/src/graphics/instruction.rs
+++ b/korangar/src/graphics/instruction.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use cgmath::{Matrix4, Point3, Vector2, Vector3};
 use ragnarok_packets::EntityId;
+use wgpu::BlendFactor;
 
 use super::color::Color;
 use super::vertices::ModelVertex;
@@ -199,6 +200,8 @@ pub struct EffectInstruction {
     pub texture_top_right: Vector2<f32>,
     pub texture_bottom_right: Vector2<f32>,
     pub color: Color,
+    pub source_blend_factor: BlendFactor,
+    pub destination_blend_factor: BlendFactor,
     pub texture: Arc<Texture>,
 }
 

--- a/korangar/src/graphics/mod.rs
+++ b/korangar/src/graphics/mod.rs
@@ -79,19 +79,6 @@ pub const WATER_ATTACHMENT_BLEND: BlendState = BlendState {
     },
 };
 
-pub const EFFECT_ATTACHMENT_BLEND: BlendState = BlendState {
-    color: BlendComponent {
-        src_factor: BlendFactor::One,
-        dst_factor: BlendFactor::One,
-        operation: BlendOperation::Max,
-    },
-    alpha: BlendComponent {
-        src_factor: BlendFactor::One,
-        dst_factor: BlendFactor::One,
-        operation: BlendOperation::Max,
-    },
-};
-
 /// Trait to prepare all GPU data of contexts, computer and renderer.
 pub(crate) trait Prepare {
     /// Prepares the GPU data.

--- a/korangar/src/loaders/effect/mod.rs
+++ b/korangar/src/loaders/effect/mod.rs
@@ -1,182 +1,24 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use cgmath::{Point3, Vector2, Vector3};
+use cgmath::Deg;
 #[cfg(feature = "debug")]
-use korangar_debug::logging::{Colorize, Timer};
-use korangar_util::collision::{Frustum, Sphere};
+use korangar_debug::logging::{print_debug, Colorize, Timer};
 use korangar_util::FileLoader;
 use ragnarok_bytes::{ByteStream, FromBytes};
-use ragnarok_formats::effect::{EffectData, Frame};
+use ragnarok_formats::effect::EffectData;
 use ragnarok_formats::version::InternalVersion;
-use ragnarok_packets::EntityId;
+use wgpu::BlendFactor;
 
 use super::error::LoadError;
 use super::TextureLoader;
-use crate::graphics::{Camera, Color, Texture};
+use crate::graphics::Color;
 use crate::loaders::GameFileLoader;
-use crate::renderer::EffectRenderer;
-use crate::{point_light_extent, PointLightId, PointLightManager};
-
-fn ease_interpolate(start_value: f32, end_value: f32, time: f32, bias: f32, sub_multiplier: f32) -> f32 {
-    if bias > 0.0 {
-        (end_value - start_value) * time.powf(1.0 + bias / 5.0) + start_value * sub_multiplier
-    } else if bias < 0.0 {
-        (end_value - start_value) * (1.0 - (1.0 - time).powf(-bias / 5.0 + 1.0)) + start_value * sub_multiplier
-    } else {
-        (end_value - start_value) * time + start_value * sub_multiplier
-    }
-}
-
-pub fn interpolate(first: &Frame, second: &Frame, frame_index: usize) -> Frame {
-    let time = 1.0 / (second.frame_index as f32 - first.frame_index as f32) * (frame_index as f32 - first.frame_index as f32);
-    let sub_mult = 1.0;
-
-    // TODO: angle bias
-    let angle = ease_interpolate(first.angle, second.angle, time, 0.0, sub_mult);
-    let color = [
-        (second.color[0] - first.color[0]) * time + first.color[0] * sub_mult,
-        (second.color[1] - first.color[1]) * time + first.color[1] * sub_mult,
-        (second.color[2] - first.color[2]) * time + first.color[2] * sub_mult,
-        (second.color[3] - first.color[3]) * time + first.color[3] * sub_mult,
-    ];
-
-    let uv = (0..8)
-        .map(|index| (second.uv[index] - first.uv[index]) * time + first.uv[index] * sub_mult)
-        .next_chunk()
-        .unwrap();
-
-    // TODO: scale bias
-    let xy = (0..8)
-        .map(|index| ease_interpolate(first.xy[index], second.xy[index], time, 0.0, sub_mult))
-        .next_chunk()
-        .unwrap();
-
-    // TODO: additional logic for animation type 2 and 3
-    let texture_index = first.texture_index;
-
-    // TODO: bezier curves
-    let offset_x = (second.offset.x - first.offset.x) * time + first.offset.x * sub_mult;
-    let offset_y = (second.offset.y - first.offset.y) * time + first.offset.y * sub_mult;
-
-    Frame {
-        frame_index: frame_index as i32,
-        frame_type: first.frame_type,
-        offset: Vector2::new(offset_x, offset_y),
-        uv,
-        xy,
-        texture_index,
-        animation_type: first.animation_type,
-        delay: first.delay,
-        angle,
-        color,
-        source_alpha: first.source_alpha,
-        destination_alpha: first.destination_alpha,
-        mt_present: first.mt_present,
-    }
-}
+use crate::world::{AnimationType, Effect, Frame, FrameType, Layer, MultiTexturePresent};
 
 pub struct EffectLoader {
     game_file_loader: Arc<GameFileLoader>,
     cache: HashMap<String, Arc<Effect>>,
-}
-
-pub struct Layer {
-    pub textures: Vec<Arc<Texture>>,
-    pub frames: Vec<Frame>,
-    pub indices: Vec<Option<usize>>,
-}
-
-impl Layer {
-    fn interpolate(&self, frame_timer: &FrameTimer) -> Option<Frame> {
-        if let Some(frame_index) = self.indices[frame_timer.current_frame] {
-            if let Some(next_frame) = self.frames.get(frame_index + 2) {
-                return Some(interpolate(&self.frames[frame_index], next_frame, frame_timer.current_frame));
-            } else {
-                return Some(self.frames[frame_index].clone());
-            }
-        }
-
-        None
-    }
-}
-
-pub struct Effect {
-    frames_per_second: usize,
-    max_key: usize,
-    layers: Vec<Layer>,
-}
-
-pub struct FrameTimer {
-    total_timer: f32,
-    frames_per_second: usize,
-    max_key: usize,
-    current_frame: usize,
-}
-
-impl FrameTimer {
-    pub fn update(&mut self, delta_time: f32) -> bool {
-        self.total_timer += delta_time;
-        self.current_frame = (self.total_timer / (1.0 / self.frames_per_second as f32)) as usize;
-
-        if self.current_frame >= self.max_key {
-            // TODO: better wrapping
-            self.total_timer = 0.0;
-            self.current_frame = 0;
-            return false;
-        }
-
-        true
-    }
-}
-
-impl Effect {
-    pub fn new_frame_timer(&self) -> FrameTimer {
-        FrameTimer {
-            total_timer: 0.0,
-            frames_per_second: self.frames_per_second,
-            max_key: self.max_key,
-            current_frame: 0,
-        }
-    }
-
-    pub fn render(&self, renderer: &mut EffectRenderer, camera: &dyn Camera, frame_timer: &FrameTimer, position: Point3<f32>) {
-        for layer in &self.layers {
-            let Some(frame) = layer.interpolate(frame_timer) else {
-                continue;
-            };
-
-            if frame.texture_index < 0.0 || frame.texture_index as usize > layer.textures.len() {
-                continue;
-            }
-
-            renderer.render_effect(
-                camera,
-                position,
-                layer.textures[frame.texture_index as usize].clone(),
-                [
-                    Vector2::new(frame.xy[0], frame.xy[4]),
-                    Vector2::new(frame.xy[1], frame.xy[5]),
-                    Vector2::new(frame.xy[3], frame.xy[7]),
-                    Vector2::new(frame.xy[2], frame.xy[6]),
-                ],
-                [
-                    Vector2::new(frame.uv[0] + frame.uv[2], frame.uv[3] + frame.uv[1]),
-                    Vector2::new(frame.uv[0] + frame.uv[2], frame.uv[1]),
-                    Vector2::new(frame.uv[0], frame.uv[1]),
-                    Vector2::new(frame.uv[0], frame.uv[3] + frame.uv[1]),
-                ],
-                frame.offset,
-                frame.angle,
-                Color::rgba(
-                    frame.color[0] / 255.0,
-                    frame.color[1] / 255.0,
-                    frame.color[2] / 255.0,
-                    frame.color[3] / 255.0,
-                ),
-            );
-        }
-    }
 }
 
 impl EffectLoader {
@@ -205,58 +47,99 @@ impl EffectLoader {
             None => "",
         };
 
-        let effect = Arc::new(Effect {
-            frames_per_second: effect_data.frames_per_second as usize,
-            max_key: effect_data.max_key as usize,
-            layers: effect_data
+        let effect = Arc::new(Effect::new(
+            effect_data.frames_per_second as usize,
+            effect_data.max_key as usize,
+            effect_data
                 .layers
                 .into_iter()
-                .map(|layer_data| Layer {
-                    textures: layer_data
-                        .texture_names
-                        .into_iter()
-                        .map(|name| {
-                            let path = format!("effect\\{}{}", prefix, name.name);
-                            texture_loader.get(&path).unwrap()
-                        })
-                        .collect(),
-                    indices: {
-                        let frame_count = layer_data.frames.len();
-                        let mut map = Vec::with_capacity(frame_count);
-                        let mut list_index = 0;
+                .map(|layer_data| {
+                    let mut previous_source_blend_factor = None;
+                    let mut previous_destination_blend_factor = None;
 
-                        if frame_count > 0 {
-                            let mut previous = None;
+                    Layer::new(
+                        layer_data
+                            .texture_names
+                            .into_iter()
+                            .map(|name| {
+                                let path = format!("effect\\{}{}", prefix, name.name);
+                                texture_loader.get(&path).unwrap()
+                            })
+                            .collect(),
+                        {
+                            let frame_count = layer_data.frames.len();
+                            let mut map = Vec::with_capacity(frame_count);
+                            let mut list_index = 0;
 
-                            for _ in 0..layer_data.frames[0].frame_index {
-                                map.push(None);
-                                list_index += 1;
-                            }
+                            if frame_count > 0 {
+                                let mut previous = None;
 
-                            for (index, frame) in layer_data.frames.iter().skip(1).enumerate() {
-                                for _ in list_index..frame.frame_index as usize {
-                                    map.push(previous);
+                                for _ in 0..layer_data.frames[0].frame_index {
+                                    map.push(None);
                                     list_index += 1;
                                 }
 
-                                previous = Some(index);
+                                for (index, frame) in layer_data.frames.iter().skip(1).enumerate() {
+                                    for _ in list_index..frame.frame_index as usize {
+                                        map.push(previous);
+                                        list_index += 1;
+                                    }
+
+                                    previous = Some(index);
+                                }
+
+                                // TODO: conditional
+                                map.push(previous);
+                                list_index += 1;
                             }
 
-                            // TODO: conditional
-                            map.push(previous);
-                            list_index += 1;
-                        }
+                            for _ in list_index..effect_data.max_key as usize {
+                                map.push(None)
+                            }
 
-                        for _ in list_index..effect_data.max_key as usize {
-                            map.push(None)
-                        }
+                            map
+                        },
+                        layer_data
+                            .frames
+                            .into_iter()
+                            .map(|frame| {
+                                let source_blend_factor = parse_blend_factor(frame.source_blend_factor, previous_source_blend_factor, true);
+                                previous_source_blend_factor = Some(source_blend_factor);
 
-                        map
-                    },
-                    frames: layer_data.frames,
+                                let destination_blend_factor =
+                                    parse_blend_factor(frame.destination_blend_factor, previous_destination_blend_factor, false);
+                                previous_destination_blend_factor = Some(destination_blend_factor);
+
+                                let animation_type = parse_animation_type(frame.animation_type);
+                                let frame_type = parse_frame_type(frame.frame_type);
+                                let mt_present = parse_mt_present(frame.mt_present);
+
+                                Frame::new(
+                                    frame.frame_index as usize,
+                                    frame_type,
+                                    frame.offset,
+                                    frame.uv,
+                                    frame.xy,
+                                    frame.texture_index as usize,
+                                    animation_type,
+                                    frame.delay,
+                                    Deg(frame.angle / (1024.0 / 360.0)).into(),
+                                    Color::rgba(
+                                        frame.color[0] / 255.0,
+                                        frame.color[1] / 255.0,
+                                        frame.color[2] / 255.0,
+                                        frame.color[3] / 255.0,
+                                    ),
+                                    source_blend_factor,
+                                    destination_blend_factor,
+                                    mt_present,
+                                )
+                            })
+                            .collect(),
+                    )
                 })
                 .collect(),
-        });
+        ));
 
         self.cache.insert(path.to_string(), effect.clone());
 
@@ -274,167 +157,68 @@ impl EffectLoader {
     }
 }
 
-pub enum EffectCenter {
-    Entity(EntityId, Point3<f32>),
-    Position(Point3<f32>),
-}
-
-impl EffectCenter {
-    fn to_position(&self) -> Point3<f32> {
-        match self {
-            EffectCenter::Entity(_, position) | EffectCenter::Position(position) => *position,
+fn parse_blend_factor(value: i32, previous: Option<BlendFactor>, is_source: bool) -> BlendFactor {
+    match value {
+        0 => previous.unwrap(),
+        1 => BlendFactor::Zero,
+        2 => BlendFactor::One,
+        3 => BlendFactor::Src,
+        4 => BlendFactor::OneMinusSrc,
+        5 => BlendFactor::SrcAlpha,
+        6 => BlendFactor::OneMinusSrcAlpha,
+        7 => BlendFactor::DstAlpha,
+        8 => BlendFactor::OneMinusDstAlpha,
+        9 => BlendFactor::Dst,
+        10 => BlendFactor::OneMinusDst,
+        11 => BlendFactor::SrcAlphaSaturated,
+        // D3DBLEND_BOTHSRCALPHA
+        //
+        // Obsolete. Starting with DirectX 6, you can achieve the same effect
+        // by setting the source and destination blend factors to D3DBLEND_SRCALPHA
+        // and D3DBLEND_INVSRCALPHA in separate calls.
+        12 if is_source => BlendFactor::SrcAlpha,
+        12 if !is_source => BlendFactor::OneMinusSrcAlpha,
+        _ => {
+            #[cfg(feature = "debug")]
+            print_debug!("[{}] unknown blend factor found in frame data: {value}", "error".red());
+            BlendFactor::Zero
         }
     }
 }
 
-pub trait EffectBase {
-    fn update(&mut self, entities: &[crate::world::Entity], delta_time: f32) -> bool;
-
-    fn mark_for_deletion(&mut self);
-
-    fn register_point_lights(&self, point_light_manager: &mut PointLightManager, camera: &dyn Camera);
-
-    fn render(&self, renderer: &mut EffectRenderer, camera: &dyn Camera);
-}
-
-pub struct EffectWithLight {
-    effect: Arc<Effect>,
-    frame_timer: FrameTimer,
-    center: EffectCenter,
-    effect_offset: Vector3<f32>,
-    point_light_id: PointLightId,
-    light_offset: Vector3<f32>,
-    light_color: Color,
-    light_intensity: f32,
-    repeating: bool,
-    current_light_intensity: f32,
-    gets_deleted: bool,
-}
-
-impl EffectWithLight {
-    pub fn new(
-        effect: Arc<Effect>,
-        frame_timer: FrameTimer,
-        center: EffectCenter,
-        effect_offset: Vector3<f32>,
-        point_light_id: PointLightId,
-        light_offset: Vector3<f32>,
-        light_color: Color,
-        light_intensity: f32,
-        repeating: bool,
-    ) -> Self {
-        Self {
-            effect,
-            frame_timer,
-            center,
-            effect_offset,
-            point_light_id,
-            light_offset,
-            light_color,
-            light_intensity,
-            repeating,
-            current_light_intensity: 0.0,
-            gets_deleted: false,
+fn parse_animation_type(value: i32) -> AnimationType {
+    match value {
+        0 => AnimationType::Type0,
+        1 => AnimationType::Type1,
+        2 => AnimationType::Type2,
+        3 => AnimationType::Type3,
+        _ => {
+            #[cfg(feature = "debug")]
+            print_debug!("[{}] unknown animation type found in frame data: {value}", "error".red());
+            AnimationType::Type1
         }
     }
 }
 
-impl EffectBase for EffectWithLight {
-    fn update(&mut self, entities: &[crate::world::Entity], delta_time: f32) -> bool {
-        const FADE_SPEED: f32 = 5.0;
-
-        if let EffectCenter::Entity(entity_id, position) = &mut self.center
-            && let Some(entity) = entities.iter().find(|entity| entity.get_entity_id() == *entity_id)
-        {
-            let new_position = entity.get_position();
-            *position = new_position;
-        }
-
-        if !self.gets_deleted && !self.frame_timer.update(delta_time) && !self.repeating {
-            self.gets_deleted = true;
-        }
-
-        let (target, clamping_function): (f32, fn(f32, f32) -> f32) = match self.gets_deleted {
-            true => (0.0, f32::max),
-            false => (self.light_intensity, f32::min),
-        };
-
-        self.current_light_intensity += (target - self.current_light_intensity) * FADE_SPEED * delta_time;
-        self.current_light_intensity = clamping_function(self.current_light_intensity, target);
-
-        !self.gets_deleted || self.current_light_intensity > 0.1
-    }
-
-    fn mark_for_deletion(&mut self) {
-        self.gets_deleted = true;
-    }
-
-    fn register_point_lights(&self, point_light_manager: &mut PointLightManager, camera: &dyn Camera) {
-        let (view_matrix, projection_matrix) = camera.view_projection_matrices();
-        let frustum = Frustum::new(projection_matrix * view_matrix);
-
-        let extent = point_light_extent(self.light_color, self.current_light_intensity);
-        let light_position = self.center.to_position() + self.light_offset;
-
-        if frustum.intersects_sphere(&Sphere::new(light_position, extent)) {
-            point_light_manager.register_fading(
-                self.point_light_id,
-                light_position,
-                self.light_color,
-                self.current_light_intensity,
-                self.light_intensity,
-            )
-        }
-    }
-
-    fn render(&self, renderer: &mut EffectRenderer, camera: &dyn Camera) {
-        if !self.gets_deleted {
-            self.effect.render(
-                renderer,
-                camera,
-                &self.frame_timer,
-                self.center.to_position() + self.effect_offset,
-            );
+fn parse_frame_type(value: i32) -> FrameType {
+    match value {
+        0 => FrameType::Basic,
+        1 => FrameType::Morphing,
+        _ => {
+            #[cfg(feature = "debug")]
+            print_debug!("[{}] unknown frame type found in frame data: {value}", "error".red());
+            FrameType::Basic
         }
     }
 }
 
-#[derive(Default)]
-pub struct EffectHolder {
-    effects: Vec<(Box<dyn EffectBase + Send + Sync>, Option<EntityId>)>,
-}
-
-impl EffectHolder {
-    pub fn add_effect(&mut self, effect: Box<dyn EffectBase + Send + Sync>) {
-        self.effects.push((effect, None));
-    }
-
-    pub fn add_unit(&mut self, effect: Box<dyn EffectBase + Send + Sync>, entity_id: EntityId) {
-        self.effects.push((effect, Some(entity_id)));
-    }
-
-    pub fn remove_unit(&mut self, removed_entity_id: EntityId) {
-        self.effects
-            .iter_mut()
-            .filter(|(_, entity_id)| entity_id.is_some_and(|entity_id| entity_id == removed_entity_id))
-            .for_each(|(effect, _)| effect.mark_for_deletion());
-    }
-
-    pub fn clear(&mut self) {
-        self.effects.clear();
-    }
-
-    pub fn update(&mut self, entities: &[crate::world::Entity], delta_time: f32) {
-        self.effects.retain_mut(|(effect, _)| effect.update(entities, delta_time));
-    }
-
-    pub fn register_point_lights(&self, point_light_manager: &mut PointLightManager, camera: &dyn Camera) {
-        self.effects
-            .iter()
-            .for_each(|(effect, _)| effect.register_point_lights(point_light_manager, camera));
-    }
-
-    pub fn render(&self, renderer: &mut EffectRenderer, camera: &dyn Camera) {
-        self.effects.iter().for_each(|(effect, _)| effect.render(renderer, camera));
+fn parse_mt_present(value: i32) -> MultiTexturePresent {
+    match value {
+        0 => MultiTexturePresent::None,
+        _ => {
+            #[cfg(feature = "debug")]
+            print_debug!("[{}] unknown multi texture present found in frame data: {value}", "error".red());
+            MultiTexturePresent::None
+        }
     }
 }

--- a/korangar/src/loaders/mod.rs
+++ b/korangar/src/loaders/mod.rs
@@ -13,7 +13,7 @@ mod sprite;
 mod texture;
 
 pub use self::action::*;
-pub use self::effect::{EffectHolder, EffectLoader, *};
+pub use self::effect::EffectLoader;
 pub use self::font::{FontLoader, FontSize, Scaling};
 pub use self::gamefile::*;
 pub use self::map::{MapLoader, MAP_TILE_SIZE};

--- a/korangar/src/renderer/effect.rs
+++ b/korangar/src/renderer/effect.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
-use cgmath::{Matrix2, Point3, Vector2};
+use cgmath::{Matrix2, Point3, Rad, Vector2};
 use korangar_interface::application::PositionTrait;
+use wgpu::BlendFactor;
 
 use crate::graphics::{Camera, Color, EffectInstruction, Texture};
 use crate::interface::layout::{ScreenPosition, ScreenSize};
@@ -39,8 +40,10 @@ impl EffectRenderer {
         corner_screen_position: [Vector2<f32>; 4],
         texture_coordinates: [Vector2<f32>; 4],
         offset: Vector2<f32>,
-        angle: f32,
+        angle: Rad<f32>,
         color: Color,
+        source_blend_factor: BlendFactor,
+        destination_blend_factor: BlendFactor,
     ) {
         const EFFECT_ORIGIN: Vector2<f32> = Vector2::new(319.0, 291.0);
 
@@ -49,7 +52,7 @@ impl EffectRenderer {
         let screen_space_position = camera.clip_to_screen_space(clip_space_position);
 
         let half_screen = Vector2::new(self.window_size.width / 2.0, self.window_size.height / 2.0);
-        let rotation_matrix = Matrix2::from_angle(cgmath::Deg(angle / (1024.0 / 360.0)));
+        let rotation_matrix = Matrix2::from_angle(angle);
 
         let corner_screen_position =
             corner_screen_position.map(|position| (rotation_matrix * position) + offset - EFFECT_ORIGIN - half_screen);
@@ -73,6 +76,8 @@ impl EffectRenderer {
             texture_top_right: texture_coordinates[1],
             texture_bottom_right: texture_coordinates[0],
             color,
+            source_blend_factor,
+            destination_blend_factor,
             texture,
         });
     }

--- a/korangar/src/world/effect/mod.rs
+++ b/korangar/src/world/effect/mod.rs
@@ -1,14 +1,31 @@
 mod lookup;
 
-use cgmath::Vector3;
-use ragnarok_formats::map::EffectSource;
+use std::sync::Arc;
 
-#[cfg(feature = "debug")]
-use crate::graphics::Camera;
+use cgmath::{Point3, Rad, Vector2, Vector3};
+use derive_new::new;
+use korangar_util::collision::{Frustum, Sphere};
+use ragnarok_formats::map::EffectSource;
+use ragnarok_packets::EntityId;
+use wgpu::BlendFactor;
+
+use crate::graphics::{Camera, Color, Texture};
+use crate::renderer::EffectRenderer;
 #[cfg(feature = "debug")]
 use crate::renderer::MarkerRenderer;
 #[cfg(feature = "debug")]
 use crate::world::MarkerIdentifier;
+use crate::world::{point_light_extent, PointLightId, PointLightManager};
+
+pub trait EffectBase {
+    fn update(&mut self, entities: &[crate::world::Entity], delta_time: f32) -> bool;
+
+    fn mark_for_deletion(&mut self);
+
+    fn register_point_lights(&self, point_light_manager: &mut PointLightManager, camera: &dyn Camera);
+
+    fn render(&self, renderer: &mut EffectRenderer, camera: &dyn Camera);
+}
 
 pub trait EffectSourceExt {
     fn offset(&mut self, offset: Vector3<f32>);
@@ -25,5 +42,350 @@ impl EffectSourceExt for EffectSource {
     #[cfg(feature = "debug")]
     fn render_marker(&self, renderer: &mut impl MarkerRenderer, camera: &dyn Camera, marker_identifier: MarkerIdentifier, hovered: bool) {
         renderer.render_marker(camera, marker_identifier, self.position, hovered);
+    }
+}
+
+#[derive(new)]
+pub struct Effect {
+    frames_per_second: usize,
+    max_key: usize,
+    layers: Vec<Layer>,
+}
+
+impl Effect {
+    pub fn new_frame_timer(&self) -> FrameTimer {
+        FrameTimer {
+            total_timer: 0.0,
+            frames_per_second: self.frames_per_second,
+            max_key: self.max_key,
+            current_frame: 0,
+        }
+    }
+
+    pub fn render(&self, renderer: &mut EffectRenderer, camera: &dyn Camera, frame_timer: &FrameTimer, position: Point3<f32>) {
+        for layer in &self.layers {
+            let Some(frame) = layer.interpolate_frame(frame_timer) else {
+                continue;
+            };
+
+            if frame.texture_index > layer.textures.len() {
+                continue;
+            }
+
+            renderer.render_effect(
+                camera,
+                position,
+                layer.textures[frame.texture_index].clone(),
+                [
+                    Vector2::new(frame.xy[0], frame.xy[4]),
+                    Vector2::new(frame.xy[1], frame.xy[5]),
+                    Vector2::new(frame.xy[3], frame.xy[7]),
+                    Vector2::new(frame.xy[2], frame.xy[6]),
+                ],
+                [
+                    Vector2::new(frame.uv[0] + frame.uv[2], frame.uv[3] + frame.uv[1]),
+                    Vector2::new(frame.uv[0] + frame.uv[2], frame.uv[1]),
+                    Vector2::new(frame.uv[0], frame.uv[1]),
+                    Vector2::new(frame.uv[0], frame.uv[3] + frame.uv[1]),
+                ],
+                frame.offset,
+                frame.angle,
+                frame.color,
+                frame.source_blend_factor,
+                frame.destination_blend_factor,
+            );
+        }
+    }
+}
+
+#[derive(new)]
+pub struct Layer {
+    textures: Vec<Arc<Texture>>,
+    indices: Vec<Option<usize>>,
+    frames: Vec<Frame>,
+}
+
+impl Layer {
+    fn interpolate_frame(&self, frame_timer: &FrameTimer) -> Option<Frame> {
+        if let Some(frame_index) = self.indices[frame_timer.current_frame] {
+            if let Some(next_frame) = self.frames.get(frame_index + 2) {
+                Some(Self::interpolate(
+                    &self.frames[frame_index],
+                    next_frame,
+                    frame_timer.current_frame,
+                ))
+            } else {
+                Some(self.frames[frame_index].clone())
+            }
+        } else {
+            None
+        }
+    }
+
+    fn interpolate(first: &Frame, second: &Frame, frame_index: usize) -> Frame {
+        let time = 1.0 / (second.frame_index - first.frame_index) as f32 * (frame_index - first.frame_index) as f32;
+        let sub_mult = 1.0;
+
+        // TODO: angle bias
+        let angle = Self::ease_interpolate(first.angle.0, second.angle.0, time, 0.0, sub_mult);
+        let color = (second.color - first.color) * time + first.color * sub_mult;
+
+        let uv = (0..8)
+            .map(|index| (second.uv[index] - first.uv[index]) * time + first.uv[index] * sub_mult)
+            .next_chunk()
+            .unwrap();
+
+        // TODO: scale bias
+        let xy = (0..8)
+            .map(|index| Self::ease_interpolate(first.xy[index], second.xy[index], time, 0.0, sub_mult))
+            .next_chunk()
+            .unwrap();
+
+        // TODO: additional logic for animation type 2 and 3
+        let texture_index = first.texture_index;
+
+        // TODO: bezier curves
+        let offset_x = (second.offset.x - first.offset.x) * time + first.offset.x * sub_mult;
+        let offset_y = (second.offset.y - first.offset.y) * time + first.offset.y * sub_mult;
+
+        Frame {
+            frame_index,
+            frame_type: first.frame_type,
+            offset: Vector2::new(offset_x, offset_y),
+            uv,
+            xy,
+            texture_index,
+            animation_type: first.animation_type,
+            delay: first.delay,
+            angle: Rad(angle),
+            color,
+            source_blend_factor: first.source_blend_factor,
+            destination_blend_factor: first.destination_blend_factor,
+            mt_present: first.mt_present,
+        }
+    }
+
+    fn ease_interpolate(start_value: f32, end_value: f32, time: f32, bias: f32, sub_multiplier: f32) -> f32 {
+        if bias > 0.0 {
+            (end_value - start_value) * time.powf(1.0 + bias / 5.0) + start_value * sub_multiplier
+        } else if bias < 0.0 {
+            (end_value - start_value) * (1.0 - (1.0 - time).powf(-bias / 5.0 + 1.0)) + start_value * sub_multiplier
+        } else {
+            (end_value - start_value) * time + start_value * sub_multiplier
+        }
+    }
+}
+
+#[derive(Debug, Clone, new)]
+pub struct Frame {
+    frame_index: usize,
+    frame_type: FrameType,
+    offset: Vector2<f32>,
+    uv: [f32; 8],
+    xy: [f32; 8],
+    texture_index: usize,
+    animation_type: AnimationType,
+    delay: f32,
+    angle: Rad<f32>,
+    color: Color,
+    source_blend_factor: BlendFactor,
+    destination_blend_factor: BlendFactor,
+    mt_present: MultiTexturePresent,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum AnimationType {
+    Type0,
+    Type1,
+    Type2,
+    Type3,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum FrameType {
+    Basic,
+    Morphing,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum MultiTexturePresent {
+    None,
+}
+
+pub struct FrameTimer {
+    total_timer: f32,
+    frames_per_second: usize,
+    max_key: usize,
+    current_frame: usize,
+}
+
+impl FrameTimer {
+    pub fn update(&mut self, delta_time: f32) -> bool {
+        self.total_timer += delta_time;
+        self.current_frame = (self.total_timer / (1.0 / self.frames_per_second as f32)) as usize;
+
+        if self.current_frame >= self.max_key {
+            // TODO: better wrapping
+            self.total_timer = 0.0;
+            self.current_frame = 0;
+            return false;
+        }
+
+        true
+    }
+}
+
+pub enum EffectCenter {
+    Entity(EntityId, Point3<f32>),
+    Position(Point3<f32>),
+}
+
+impl EffectCenter {
+    fn to_position(&self) -> Point3<f32> {
+        match self {
+            EffectCenter::Entity(_, position) | EffectCenter::Position(position) => *position,
+        }
+    }
+}
+
+pub struct EffectWithLight {
+    effect: Arc<Effect>,
+    frame_timer: FrameTimer,
+    center: EffectCenter,
+    effect_offset: Vector3<f32>,
+    point_light_id: PointLightId,
+    light_offset: Vector3<f32>,
+    light_color: Color,
+    light_intensity: f32,
+    repeating: bool,
+    current_light_intensity: f32,
+    gets_deleted: bool,
+}
+
+impl EffectWithLight {
+    pub fn new(
+        effect: Arc<Effect>,
+        frame_timer: FrameTimer,
+        center: EffectCenter,
+        effect_offset: Vector3<f32>,
+        point_light_id: PointLightId,
+        light_offset: Vector3<f32>,
+        light_color: Color,
+        light_intensity: f32,
+        repeating: bool,
+    ) -> Self {
+        Self {
+            effect,
+            frame_timer,
+            center,
+            effect_offset,
+            point_light_id,
+            light_offset,
+            light_color,
+            light_intensity,
+            repeating,
+            current_light_intensity: 0.0,
+            gets_deleted: false,
+        }
+    }
+}
+
+impl EffectBase for EffectWithLight {
+    fn update(&mut self, entities: &[crate::world::Entity], delta_time: f32) -> bool {
+        const FADE_SPEED: f32 = 5.0;
+
+        if let EffectCenter::Entity(entity_id, position) = &mut self.center
+            && let Some(entity) = entities.iter().find(|entity| entity.get_entity_id() == *entity_id)
+        {
+            let new_position = entity.get_position();
+            *position = new_position;
+        }
+
+        if !self.gets_deleted && !self.frame_timer.update(delta_time) && !self.repeating {
+            self.gets_deleted = true;
+        }
+
+        let (target, clamping_function): (f32, fn(f32, f32) -> f32) = match self.gets_deleted {
+            true => (0.0, f32::max),
+            false => (self.light_intensity, f32::min),
+        };
+
+        self.current_light_intensity += (target - self.current_light_intensity) * FADE_SPEED * delta_time;
+        self.current_light_intensity = clamping_function(self.current_light_intensity, target);
+
+        !self.gets_deleted || self.current_light_intensity > 0.1
+    }
+
+    fn mark_for_deletion(&mut self) {
+        self.gets_deleted = true;
+    }
+
+    fn register_point_lights(&self, point_light_manager: &mut PointLightManager, camera: &dyn Camera) {
+        let (view_matrix, projection_matrix) = camera.view_projection_matrices();
+        let frustum = Frustum::new(projection_matrix * view_matrix);
+
+        let extent = point_light_extent(self.light_color, self.current_light_intensity);
+        let light_position = self.center.to_position() + self.light_offset;
+
+        if frustum.intersects_sphere(&Sphere::new(light_position, extent)) {
+            point_light_manager.register_fading(
+                self.point_light_id,
+                light_position,
+                self.light_color,
+                self.current_light_intensity,
+                self.light_intensity,
+            )
+        }
+    }
+
+    fn render(&self, renderer: &mut EffectRenderer, camera: &dyn Camera) {
+        if !self.gets_deleted {
+            self.effect.render(
+                renderer,
+                camera,
+                &self.frame_timer,
+                self.center.to_position() + self.effect_offset,
+            );
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct EffectHolder {
+    effects: Vec<(Box<dyn EffectBase + Send + Sync>, Option<EntityId>)>,
+}
+
+impl EffectHolder {
+    pub fn add_effect(&mut self, effect: Box<dyn EffectBase + Send + Sync>) {
+        self.effects.push((effect, None));
+    }
+
+    pub fn add_unit(&mut self, effect: Box<dyn EffectBase + Send + Sync>, entity_id: EntityId) {
+        self.effects.push((effect, Some(entity_id)));
+    }
+
+    pub fn remove_unit(&mut self, removed_entity_id: EntityId) {
+        self.effects
+            .iter_mut()
+            .filter(|(_, entity_id)| entity_id.is_some_and(|entity_id| entity_id == removed_entity_id))
+            .for_each(|(effect, _)| effect.mark_for_deletion());
+    }
+
+    pub fn clear(&mut self) {
+        self.effects.clear();
+    }
+
+    pub fn update(&mut self, entities: &[crate::world::Entity], delta_time: f32) {
+        self.effects.retain_mut(|(effect, _)| effect.update(entities, delta_time));
+    }
+
+    pub fn register_point_lights(&self, point_light_manager: &mut PointLightManager, camera: &dyn Camera) {
+        self.effects
+            .iter()
+            .for_each(|(effect, _)| effect.register_point_lights(point_light_manager, camera));
+    }
+
+    pub fn render(&self, renderer: &mut EffectRenderer, camera: &dyn Camera) {
+        self.effects.iter().for_each(|(effect, _)| effect.render(renderer, camera));
     }
 }

--- a/ragnarok_formats/src/effect.rs
+++ b/ragnarok_formats/src/effect.rs
@@ -24,10 +24,8 @@ pub struct Frame {
     pub delay: f32,
     pub angle: f32,
     pub color: [f32; 4],
-    // Needs to actually set the attachment blend mode of the source alpha
-    pub source_alpha: i32,
-    // Needs to actually set the attachment blend mode of the destination alpha
-    pub destination_alpha: i32,
+    pub source_blend_factor: i32,
+    pub destination_blend_factor: i32,
     pub mt_present: i32,
 }
 


### PR DESCRIPTION
- Separated effect loading and effect rendering code.
- Introduced types for enumerated values.
- Properly parse "use previous" values.
- Implement a pipeline cache for effects.
- Preload the TOP5 pipelines.

Will fix #107 