### PR TITLE
Picker values can fully store 32-bit values.

### DIFF
--- a/korangar/src/graphics/renderers/deferred/buffer/buffer.wgsl
+++ b/korangar/src/graphics/renderers/deferred/buffer/buffer.wgsl
@@ -69,10 +69,10 @@ fn fs_main(
     }
 
     if (constants.show_picker_texture != 0u) {
-        let picker = textureLoad(picker_texture, pixel_coord, 0).r;
-        let red = f32(picker & 0xfu) / 100.0;
-        let green = f32((picker >> 8u) & 0xfu) / 100.0;
-        let blue = f32((picker >> 16u) & 0xfu) / 100.0;
+        let picker = textureLoad(picker_texture, pixel_coord, 0).rg;
+        let red = f32(picker.r & 0xfu) / 100.0;
+        let green = f32((picker.r >> 8u) & 0xfu) / 100.0;
+        let blue = f32((picker.r >> 16u) & 0xfu) / 100.0;
         output_color += vec3<f32>(red, green, blue);
     }
 

--- a/korangar/src/graphics/renderers/picker/entity/entity.wgsl
+++ b/korangar/src/graphics/renderers/picker/entity/entity.wgsl
@@ -7,7 +7,8 @@ struct Constants {
     world: mat4x4<f32>,
     texture_position: vec2<f32>,
     texture_size: vec2<f32>,
-    identifier: u32,
+    identifier_high: u32,
+    identifier_low: u32,
     mirror: u32,
 }
 
@@ -43,14 +44,14 @@ fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
 }
 
 @fragment
-fn fs_main(@location(0) texture_coordinates: vec2<f32>) -> @location(0) u32 {
+fn fs_main(@location(0) texture_coordinates: vec2<f32>) -> @location(0) vec2<u32> {
     let diffuse_color = textureSample(sampled_texture, texture_sampler, texture_coordinates);
 
     if (diffuse_color.a != 1.0) {
         discard;
     }
 
-    return constants.identifier;
+    return vec2<u32>(constants.identifier_low, constants.identifier_high);
 }
 
 // Optimized version of the following truth table:

--- a/korangar/src/graphics/renderers/picker/entity/mod.rs
+++ b/korangar/src/graphics/renderers/picker/entity/mod.rs
@@ -30,7 +30,8 @@ struct Constants {
     world: [[f32; 4]; 4],
     texture_position: [f32; 2],
     texture_size: [f32; 2],
-    identifier: u32,
+    identifier_high: u32,
+    identifier_low: u32,
     mirror: u32,
 }
 
@@ -192,7 +193,6 @@ impl EntityRenderer {
         let world_matrix = camera.billboard_matrix(position, origin, size);
         let texture_size = Vector2::new(1.0 / cell_count.x as f32, 1.0 / cell_count.y as f32);
         let texture_position = Vector2::new(texture_size.x * cell_position.x as f32, texture_size.y * cell_position.y as f32);
-        let picker_target = PickerTarget::Entity(entity_id);
 
         let bind_group = self.device.create_bind_group(&BindGroupDescriptor {
             label: Some("entity"),
@@ -213,11 +213,15 @@ impl EntityRenderer {
             ],
         });
 
+        let picker_target = PickerTarget::Entity(entity_id);
+        let (identifier_high, identifier_low) = picker_target.into();
+
         let push_constants = Constants {
             world: world_matrix.into(),
             texture_position: texture_position.into(),
             texture_size: texture_size.into(),
-            identifier: picker_target.into(),
+            identifier_high,
+            identifier_low,
             mirror: mirror as u32,
         };
 

--- a/korangar/src/graphics/renderers/picker/geometry/geometry.wgsl
+++ b/korangar/src/graphics/renderers/picker/geometry/geometry.wgsl
@@ -35,12 +35,12 @@ fn vs_main(
 fn fs_main(
     @location(0) texture_coordinates: vec2<f32>,
     @location(1) texture_index: i32
-) -> @location(0) u32 {
+) -> @location(0) vec2<u32> {
     let diffuse_color = textureSample(textures[texture_index], texture_sampler, texture_coordinates);
 
     if (diffuse_color.a != 1.0) {
         discard;
     }
 
-    return 0u;
+    return vec2<u32>(0u);
 }

--- a/korangar/src/graphics/renderers/picker/marker/marker.wgsl
+++ b/korangar/src/graphics/renderers/picker/marker/marker.wgsl
@@ -1,7 +1,8 @@
 struct Constants {
     screen_position: vec2<f32>,
     screen_size: vec2<f32>,
-    identifier: u32,
+    identifier_high: u32,
+    identifier_low: u32,
 }
 
 var<push_constant> constants: Constants;
@@ -15,8 +16,8 @@ fn vs_main(@builtin(vertex_index) vertex_index: u32) -> @builtin(position) vec4<
 }
 
 @fragment
-fn fs_main() -> @location(0) u32 {
-    return constants.identifier;
+fn fs_main() -> @location(0) vec2<u32> {
+    return vec2<u32>(constants.identifier_low, constants.identifier_high);
 }
 
 // Optimized version of the following truth table:

--- a/korangar/src/graphics/renderers/picker/marker/mod.rs
+++ b/korangar/src/graphics/renderers/picker/marker/mod.rs
@@ -18,7 +18,8 @@ const SHADER: ShaderModuleDescriptor = include_wgsl!("marker.wgsl");
 struct Constants {
     screen_position: [f32; 2],
     screen_size: [f32; 2],
-    identifier: u32,
+    identifier_high: u32,
+    identifier_low: u32,
 }
 
 pub struct MarkerRenderer {
@@ -100,11 +101,13 @@ impl MarkerRenderer {
         }
 
         let picker_target = PickerTarget::Marker(marker_identifier);
+        let (identifier_high, identifier_low) = picker_target.into();
 
         let push_constants = Constants {
             screen_position: screen_position.into(),
             screen_size: screen_size.into(),
-            identifier: picker_target.into(),
+            identifier_high,
+            identifier_low,
         };
 
         render_pass.set_push_constants(ShaderStages::VERTEX_FRAGMENT, 0, cast_slice(&[push_constants]));

--- a/korangar/src/graphics/renderers/picker/selector/selector.wgsl
+++ b/korangar/src/graphics/renderers/picker/selector/selector.wgsl
@@ -9,6 +9,7 @@ var<push_constant> constants: Constants;
 @compute
 @workgroup_size(1)
 fn cs_main() {
-    let texel_value = textureLoad(texture, constants.pointer_position, 0);
-    buffer[0] = texel_value.x;
+    let texel_value = textureLoad(texture, constants.pointer_position, 0).rg;
+    buffer[0] = texel_value.r;
+    buffer[1] = texel_value.g;
 }

--- a/korangar/src/graphics/renderers/picker/target.rs
+++ b/korangar/src/graphics/renderers/picker/target.rs
@@ -5,33 +5,32 @@ use ragnarok_packets::EntityId;
 #[cfg(feature = "debug")]
 use crate::world::MarkerIdentifier;
 
-#[cfg(feature = "debug")]
-enum MarkerEncoding {
-    Object = 10,
-    LightSource = 11,
-    SoundSource = 12,
-    EffectSource = 13,
-    Entity = 14,
-    Shadow = 15,
+#[repr(u32)]
+pub(super) enum PickerValueType {
+    Nothing,
+    Tile,
+    Entity,
+    #[cfg(feature = "debug")]
+    ObjectMarker,
+    #[cfg(feature = "debug")]
+    LightSourceMarker,
+    #[cfg(feature = "debug")]
+    SoundSourceMarker,
+    #[cfg(feature = "debug")]
+    EffectSourceMarker,
+    #[cfg(feature = "debug")]
+    EntityMarker,
+    #[cfg(feature = "debug")]
+    ShadowMarker,
 }
 
-/// Encoding a `PickerTarget` as `u32` has the following format:
+/// Encoding of a `PickerTarget` as `u64` has the following format:
 ///
-/// If the most significant bit is set (`(1 << 31)`), it encodes a position. In
-/// that case, the next 15 bits are used to store the X position, and the
-/// remaining 16 bits contain the Y position. That gives us an effective maximum
-/// value of 16384 for the X channel, which for Ragnarok Online is plenty.
-///
-/// If the `debug` feature is enabled, the most significant byte can contain a
-/// value matching that of a `MarkerEncoding` (private enum). If that is the
-/// case, the remaining 3 bytes are to be interpreted as the value of the
-/// marker.
-///
-/// If the most significant bit is not set and the first byte does not match any
-/// `MarkerEncoding`, an entity is encoded. This way we can use the full 32
-/// bits to store the 32 bit [`EntityId`].
-#[derive(Debug, PartialEq, Eq)]
+/// The high 32 bits are the `PickerValueType`.
+/// The low 32 bits are the data of the value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PickerTarget {
+    Nothing,
     Tile {
         x: u16,
         y: u16,
@@ -41,65 +40,73 @@ pub enum PickerTarget {
     Marker(MarkerIdentifier),
 }
 
-impl From<u32> for PickerTarget {
-    fn from(data: u32) -> Self {
-        if data >> 31 == 1 {
-            let x = ((data >> 16) as u16) ^ (1 << 15);
+impl From<u64> for PickerTarget {
+    fn from(data: u64) -> Self {
+        if data >> 32 == PickerValueType::Tile as u64 {
+            let x = (data >> 16) as u16;
             let y = data as u16;
             return Self::Tile { x, y };
         }
 
-        #[cfg(feature = "debug")]
-        if data >> 24 == MarkerEncoding::Object as u32 {
-            return Self::Marker(MarkerIdentifier::Object(data & 0xFFF));
+        if data >> 32 == PickerValueType::Entity as u64 {
+            return Self::Entity(EntityId(data as u32));
         }
 
         #[cfg(feature = "debug")]
-        if data >> 24 == MarkerEncoding::LightSource as u32 {
-            return Self::Marker(MarkerIdentifier::LightSource(data & 0xFFF));
+        if data >> 32 == PickerValueType::ObjectMarker as u64 {
+            return Self::Marker(MarkerIdentifier::Object(data as u32));
         }
 
         #[cfg(feature = "debug")]
-        if data >> 24 == MarkerEncoding::SoundSource as u32 {
-            return Self::Marker(MarkerIdentifier::SoundSource(data as usize & 0xFFF));
+        if data >> 32 == PickerValueType::LightSourceMarker as u64 {
+            return Self::Marker(MarkerIdentifier::LightSource(data as u32));
         }
 
         #[cfg(feature = "debug")]
-        if data >> 24 == MarkerEncoding::EffectSource as u32 {
-            return Self::Marker(MarkerIdentifier::EffectSource(data as usize & 0xFFF));
+        if data >> 32 == PickerValueType::SoundSourceMarker as u64 {
+            return Self::Marker(MarkerIdentifier::SoundSource(data as u32));
         }
 
         #[cfg(feature = "debug")]
-        if data >> 24 == MarkerEncoding::Entity as u32 {
-            return Self::Marker(MarkerIdentifier::Entity(data as usize & 0xFFF));
+        if data >> 32 == PickerValueType::EffectSourceMarker as u64 {
+            return Self::Marker(MarkerIdentifier::EffectSource(data as u32));
         }
 
         #[cfg(feature = "debug")]
-        if data >> 24 == MarkerEncoding::Shadow as u32 {
-            return Self::Marker(MarkerIdentifier::Shadow(data as usize & 0xFFF));
+        if data >> 32 == PickerValueType::EntityMarker as u64 {
+            return Self::Marker(MarkerIdentifier::Entity(data as u32));
         }
 
-        Self::Entity(EntityId(data))
+        #[cfg(feature = "debug")]
+        if data >> 32 == PickerValueType::ShadowMarker as u64 {
+            return Self::Marker(MarkerIdentifier::Shadow(data as u32));
+        }
+
+        Self::Nothing
     }
 }
 
-impl From<PickerTarget> for u32 {
+impl From<PickerTarget> for u64 {
+    fn from(picker_target: PickerTarget) -> Self {
+        let (high, low) = <(u32, u32)>::from(picker_target);
+        (u64::from(high) << 32) | u64::from(low)
+    }
+}
+
+impl From<PickerTarget> for (u32, u32) {
     fn from(picker_target: PickerTarget) -> Self {
         match picker_target {
-            PickerTarget::Tile { x, y } => {
-                let mut encoded = ((x as u32) << 16) | y as u32;
-                encoded |= 1 << 31;
-                encoded
-            }
-            PickerTarget::Entity(EntityId(entity_id)) => entity_id,
+            PickerTarget::Nothing => (PickerValueType::Nothing as u32, 0),
+            PickerTarget::Tile { x, y } => (PickerValueType::Tile as u32, ((x as u32) << 16) | y as u32),
+            PickerTarget::Entity(EntityId(entity_id)) => (PickerValueType::Entity as u32, entity_id),
             #[cfg(feature = "debug")]
             PickerTarget::Marker(marker_identifier) => match marker_identifier {
-                MarkerIdentifier::Object(index) => ((MarkerEncoding::Object as u32) << 24) | (index.key() & 0xFFF),
-                MarkerIdentifier::LightSource(index) => ((MarkerEncoding::LightSource as u32) << 24) | (index as u32 & 0xFFF),
-                MarkerIdentifier::SoundSource(index) => ((MarkerEncoding::SoundSource as u32) << 24) | (index as u32 & 0xFFF),
-                MarkerIdentifier::EffectSource(index) => ((MarkerEncoding::EffectSource as u32) << 24) | (index as u32 & 0xFFF),
-                MarkerIdentifier::Entity(index) => ((MarkerEncoding::Entity as u32) << 24) | (index as u32 & 0xFFF),
-                MarkerIdentifier::Shadow(index) => ((MarkerEncoding::Shadow as u32) << 24) | (index as u32 & 0xFFF),
+                MarkerIdentifier::Object(index) => (PickerValueType::ObjectMarker as u32, index.key()),
+                MarkerIdentifier::LightSource(index) => (PickerValueType::LightSourceMarker as u32, index),
+                MarkerIdentifier::SoundSource(index) => (PickerValueType::SoundSourceMarker as u32, index),
+                MarkerIdentifier::EffectSource(index) => (PickerValueType::EffectSourceMarker as u32, index),
+                MarkerIdentifier::Entity(index) => (PickerValueType::EntityMarker as u32, index),
+                MarkerIdentifier::Shadow(index) => (PickerValueType::ShadowMarker as u32, index),
                 _ => panic!(),
             },
         }
@@ -118,41 +125,51 @@ mod encoding {
     // Position
     const X: u16 = 7;
     const Y: u16 = 3;
-    const ENCODED_POSITION: u32 = 0b1_000000000000111_0000000000000011;
+    const ENCODED_POSITION: u64 = 0x00000001_00070003;
 
     // Markers
     #[cfg(feature = "debug")]
-    const OBJECT_MARKER: MarkerIdentifier = MarkerIdentifier::Object(7);
+    const OBJECT_MARKER: MarkerIdentifier = MarkerIdentifier::Object(255);
     #[cfg(feature = "debug")]
-    const LIGHT_SOURCE_MARKER: MarkerIdentifier = MarkerIdentifier::LightSource(7);
+    const LIGHT_SOURCE_MARKER: MarkerIdentifier = MarkerIdentifier::LightSource(254);
     #[cfg(feature = "debug")]
-    const SOUND_SOURCE_MARKER: MarkerIdentifier = MarkerIdentifier::SoundSource(7);
+    const SOUND_SOURCE_MARKER: MarkerIdentifier = MarkerIdentifier::SoundSource(253);
     #[cfg(feature = "debug")]
-    const EFFECT_SOURCE_MARKER: MarkerIdentifier = MarkerIdentifier::EffectSource(7);
+    const EFFECT_SOURCE_MARKER: MarkerIdentifier = MarkerIdentifier::EffectSource(252);
     #[cfg(feature = "debug")]
-    const ENTITY_MARKER: MarkerIdentifier = MarkerIdentifier::Entity(7);
+    const ENTITY_MARKER: MarkerIdentifier = MarkerIdentifier::Entity(251);
     #[cfg(feature = "debug")]
-    const SHADOW_MARKER: MarkerIdentifier = MarkerIdentifier::Shadow(7);
+    const SHADOW_MARKER: MarkerIdentifier = MarkerIdentifier::Shadow(250);
     #[cfg(feature = "debug")]
-    const ENCODED_OBJECT_MARKER: u32 = 0b00001010_000000000000000000000111;
+    const ENCODED_OBJECT_MARKER: u64 = 0x00000003_000000FF;
     #[cfg(feature = "debug")]
-    const ENCODED_LIGHT_SOURCE_MARKER: u32 = 0b00001011_000000000000000000000111;
+    const ENCODED_LIGHT_SOURCE_MARKER: u64 = 0x00000004_000000FE;
     #[cfg(feature = "debug")]
-    const ENCODED_SOUND_SOURCE_MARKER: u32 = 0b00001100_000000000000000000000111;
+    const ENCODED_SOUND_SOURCE_MARKER: u64 = 0x00000005_000000FD;
     #[cfg(feature = "debug")]
-    const ENCODED_EFFECT_SOURCE_MARKER: u32 = 0b00001101_000000000000000000000111;
+    const ENCODED_EFFECT_SOURCE_MARKER: u64 = 0x00000006_000000FC;
     #[cfg(feature = "debug")]
-    const ENCODED_ENTITY_MARKER: u32 = 0b00001110_000000000000000000000111;
+    const ENCODED_ENTITY_MARKER: u64 = 0x00000007_000000FB;
     #[cfg(feature = "debug")]
-    const ENCODED_SHADOW_MARKER: u32 = 0b00001111_000000000000000000000111;
+    const ENCODED_SHADOW_MARKER: u64 = 0x00000008_000000FA;
 
     // Entity
     const ENTITY_ID: EntityId = EntityId(7);
-    const ENCODED_ENTITY_ID: u32 = 0b00000000000000000000000000000111;
+    const ENCODED_ENTITY_ID: u64 = 0x00000002_00000007;
+
+    #[test]
+    fn from_u64() {
+        let target = PickerTarget::Tile { x: X, y: Y };
+
+        let (high, low) = <(u32, u32)>::from(target);
+        let encoded = u64::from(target);
+
+        assert_eq!(((high as u64) << 32) | low as u64, encoded);
+    }
 
     #[test]
     fn encode_tile() {
-        assert_eq!(u32::from(PickerTarget::Tile { x: X, y: Y }), ENCODED_POSITION);
+        assert_eq!(u64::from(PickerTarget::Tile { x: X, y: Y }), ENCODED_POSITION);
     }
 
     #[test]
@@ -163,20 +180,20 @@ mod encoding {
     #[test]
     #[cfg(feature = "debug")]
     fn encode_object_marker() {
-        assert_eq!(u32::from(PickerTarget::Marker(OBJECT_MARKER)), ENCODED_OBJECT_MARKER);
+        assert_eq!(u64::from(PickerTarget::Marker(OBJECT_MARKER)), ENCODED_OBJECT_MARKER);
     }
 
     #[test]
     #[cfg(feature = "debug")]
     fn decode_object_marker() {
-        assert_eq!(PickerTarget::from(ENCODED_OBJECT_MARKER), PickerTarget::Marker(OBJECT_MARKER));
+        assert_eq!(PickerTarget::from(ENCODED_OBJECT_MARKER), PickerTarget::Marker(OBJECT_MARKER),);
     }
 
     #[test]
     #[cfg(feature = "debug")]
     fn encode_light_source_marker() {
         assert_eq!(
-            u32::from(PickerTarget::Marker(LIGHT_SOURCE_MARKER)),
+            u64::from(PickerTarget::Marker(LIGHT_SOURCE_MARKER)),
             ENCODED_LIGHT_SOURCE_MARKER
         );
     }
@@ -186,7 +203,7 @@ mod encoding {
     fn decode_light_source_marker() {
         assert_eq!(
             PickerTarget::from(ENCODED_LIGHT_SOURCE_MARKER),
-            PickerTarget::Marker(LIGHT_SOURCE_MARKER)
+            PickerTarget::Marker(LIGHT_SOURCE_MARKER),
         );
     }
 
@@ -194,7 +211,7 @@ mod encoding {
     #[cfg(feature = "debug")]
     fn encode_sound_source_marker() {
         assert_eq!(
-            u32::from(PickerTarget::Marker(SOUND_SOURCE_MARKER)),
+            u64::from(PickerTarget::Marker(SOUND_SOURCE_MARKER)),
             ENCODED_SOUND_SOURCE_MARKER
         );
     }
@@ -204,7 +221,7 @@ mod encoding {
     fn decode_sound_source_marker() {
         assert_eq!(
             PickerTarget::from(ENCODED_SOUND_SOURCE_MARKER),
-            PickerTarget::Marker(SOUND_SOURCE_MARKER)
+            PickerTarget::Marker(SOUND_SOURCE_MARKER),
         );
     }
 
@@ -212,7 +229,7 @@ mod encoding {
     #[cfg(feature = "debug")]
     fn encode_effect_source_marker() {
         assert_eq!(
-            u32::from(PickerTarget::Marker(EFFECT_SOURCE_MARKER)),
+            u64::from(PickerTarget::Marker(EFFECT_SOURCE_MARKER)),
             ENCODED_EFFECT_SOURCE_MARKER
         );
     }
@@ -222,37 +239,37 @@ mod encoding {
     fn decode_effect_source_marker() {
         assert_eq!(
             PickerTarget::from(ENCODED_EFFECT_SOURCE_MARKER),
-            PickerTarget::Marker(EFFECT_SOURCE_MARKER)
+            PickerTarget::Marker(EFFECT_SOURCE_MARKER),
         );
     }
 
     #[test]
     #[cfg(feature = "debug")]
     fn encode_entity_marker() {
-        assert_eq!(u32::from(PickerTarget::Marker(ENTITY_MARKER)), ENCODED_ENTITY_MARKER);
+        assert_eq!(u64::from(PickerTarget::Marker(ENTITY_MARKER)), ENCODED_ENTITY_MARKER);
     }
 
     #[test]
     #[cfg(feature = "debug")]
     fn decode_entity_marker() {
-        assert_eq!(PickerTarget::from(ENCODED_ENTITY_MARKER), PickerTarget::Marker(ENTITY_MARKER));
+        assert_eq!(PickerTarget::from(ENCODED_ENTITY_MARKER), PickerTarget::Marker(ENTITY_MARKER),);
     }
 
     #[test]
     #[cfg(feature = "debug")]
     fn encode_shadow_marker() {
-        assert_eq!(u32::from(PickerTarget::Marker(SHADOW_MARKER)), ENCODED_SHADOW_MARKER);
+        assert_eq!(u64::from(PickerTarget::Marker(SHADOW_MARKER)), ENCODED_SHADOW_MARKER);
     }
 
     #[test]
     #[cfg(feature = "debug")]
     fn decode_shadow_marker() {
-        assert_eq!(PickerTarget::from(ENCODED_SHADOW_MARKER), PickerTarget::Marker(SHADOW_MARKER));
+        assert_eq!(PickerTarget::from(ENCODED_SHADOW_MARKER), PickerTarget::Marker(SHADOW_MARKER),);
     }
 
     #[test]
     fn encode_entity() {
-        assert_eq!(u32::from(PickerTarget::Entity(ENTITY_ID)), ENCODED_ENTITY_ID);
+        assert_eq!(u64::from(PickerTarget::Entity(ENTITY_ID)), ENCODED_ENTITY_ID);
     }
 
     #[test]

--- a/korangar/src/graphics/renderers/picker/tile/tile.wgsl
+++ b/korangar/src/graphics/renderers/picker/tile/tile.wgsl
@@ -9,6 +9,8 @@ struct VertexOutput {
 
 @group(0) @binding(0) var<uniform> matrices: Matrices;
 
+override tile_enum_value: f32;
+
 @vertex
 fn vs_main(
     @location(0) position: vec3<f32>,
@@ -21,6 +23,6 @@ fn vs_main(
 }
 
 @fragment
-fn fs_main(@location(0) @interpolate(flat) identifier: u32) -> @location(0) u32 {
-    return identifier;
+fn fs_main(@location(0) @interpolate(flat) identifier: u32) -> @location(0) vec2<u32> {
+    return vec2<u32>(identifier, u32(tile_enum_value));
 }

--- a/korangar/src/loaders/map/vertices.rs
+++ b/korangar/src/loaders/map/vertices.rs
@@ -240,7 +240,7 @@ pub fn generate_tile_vertices(gat_data: &mut GatData) -> (Vec<ModelVertex>, Vec<
             let third_position = Point3::new(offset.x + 5.0, tile.lower_right_height, offset.y + 5.0);
             let fourth_position = Point3::new(offset.x, tile.lower_left_height, offset.y + 5.0);
 
-            let color = PickerTarget::Tile { x: x as u16, y: y as u16 }.into();
+            let (_, color) = PickerTarget::Tile { x: x as u16, y: y as u16 }.into();
             tile_picker_vertices.push(TileVertex::new(first_position, color));
             tile_picker_vertices.push(TileVertex::new(second_position, color));
             tile_picker_vertices.push(TileVertex::new(third_position, color));

--- a/korangar/src/world/map/mod.rs
+++ b/korangar/src/world/map/mod.rs
@@ -98,11 +98,11 @@ pub fn get_light_direction(day_timer: f32) -> Vector3<f32> {
 pub enum MarkerIdentifier {
     Object(u32),
     LightSource(u32),
-    SoundSource(usize),
-    EffectSource(usize),
-    Particle(usize, usize),
-    Entity(usize),
-    Shadow(usize),
+    SoundSource(u32),
+    EffectSource(u32),
+    Particle(u16, u16),
+    Entity(u32),
+    Shadow(u32),
 }
 
 #[cfg(feature = "debug")]
@@ -490,10 +490,10 @@ impl Map {
         match marker_identifier {
             MarkerIdentifier::Object(key) => self.objects.get(ObjectKey::new(key)).unwrap(),
             MarkerIdentifier::LightSource(key) => self.light_sources.get(LightSourceKey::new(key)).unwrap(),
-            MarkerIdentifier::SoundSource(index) => &self.sound_sources[index],
-            MarkerIdentifier::EffectSource(index) => &self.effect_sources[index],
+            MarkerIdentifier::SoundSource(index) => &self.sound_sources[index as usize],
+            MarkerIdentifier::EffectSource(index) => &self.effect_sources[index as usize],
             MarkerIdentifier::Particle(..) => todo!(),
-            MarkerIdentifier::Entity(index) => &entities[index],
+            MarkerIdentifier::Entity(index) => &entities[index as usize],
             MarkerIdentifier::Shadow(..) => todo!(),
         }
     }
@@ -548,7 +548,7 @@ impl Map {
 
         if render_settings.show_sound_markers {
             self.sound_sources.iter().enumerate().for_each(|(index, sound_source)| {
-                let marker_identifier = MarkerIdentifier::SoundSource(index);
+                let marker_identifier = MarkerIdentifier::SoundSource(index as u32);
 
                 sound_source.render_marker(
                     render_target,
@@ -563,7 +563,7 @@ impl Map {
 
         if render_settings.show_effect_markers {
             self.effect_sources.iter().enumerate().for_each(|(index, effect_source)| {
-                let marker_identifier = MarkerIdentifier::EffectSource(index);
+                let marker_identifier = MarkerIdentifier::EffectSource(index as u32);
 
                 effect_source.render_marker(
                     render_target,
@@ -578,7 +578,7 @@ impl Map {
 
         if render_settings.show_entity_markers {
             entities.iter().enumerate().for_each(|(index, entity)| {
-                let marker_identifier = MarkerIdentifier::Entity(index);
+                let marker_identifier = MarkerIdentifier::Entity(index as u32);
 
                 entity.render_marker(
                     render_target,
@@ -596,7 +596,7 @@ impl Map {
                 .with_shadow_iterator()
                 .enumerate()
                 .for_each(|(index, light_source)| {
-                    let marker_identifier = MarkerIdentifier::Shadow(index);
+                    let marker_identifier = MarkerIdentifier::Shadow(index as u32);
 
                     renderer.render_marker(
                         render_target,
@@ -643,7 +643,7 @@ impl Map {
                 );
             }
             MarkerIdentifier::SoundSource(index) => {
-                let sound_source = &self.sound_sources[index];
+                let sound_source = &self.sound_sources[index as usize];
                 let extent = sound_source.range;
 
                 renderer.render_circle(
@@ -659,7 +659,7 @@ impl Map {
             MarkerIdentifier::Particle(_index, _particle_index) => {}
             MarkerIdentifier::Entity(_index) => {}
             MarkerIdentifier::Shadow(index) => {
-                let point_light = point_light_set.with_shadow_iterator().nth(index).unwrap();
+                let point_light = point_light_set.with_shadow_iterator().nth(index as usize).unwrap();
                 let extent = point_light_extent(point_light.color, point_light.range);
 
                 renderer.render_circle(


### PR DESCRIPTION
This removes the implicit reliance of an entity ID to not use the full 32-bit value range. Since we can't assume the actual range that is used inside the 32 bit of an EntityId, we need to properly encode the full 32 bit inside the picker buffer.

For this we use a Rg32Uint texture, to store the picker values. This doubles the picker texture size (4K texture is around 65 MiB). The runtime of the shader is still very low and insignificant compared to other render passes.

This also allows us to encode much more data into the picker value later, if we need to do so.