### PR TITLE
Make wireframe uniformly white

### DIFF
--- a/korangar/src/graphics/passes/geometry/model.rs
+++ b/korangar/src/graphics/passes/geometry/model.rs
@@ -18,6 +18,8 @@ use crate::graphics::passes::{
 use crate::graphics::{Buffer, GlobalContext, ModelVertex, Prepare, RenderInstruction, TextureGroup};
 
 const SHADER: ShaderModuleDescriptor = include_wgsl!("shader/model.wgsl");
+#[cfg(feature = "debug")]
+const SHADER_WIREFRAME: ShaderModuleDescriptor = include_wgsl!("shader/model_wireframe.wgsl");
 const DRAWER_NAME: &str = "geometry model";
 const INITIAL_INSTRUCTION_SIZE: usize = 256;
 
@@ -48,6 +50,8 @@ impl Drawer<{ BindGroupCount::One }, { ColorAttachmentCount::Three }, { DepthAtt
 
     fn new(device: &Device, _queue: &Queue, _global_context: &GlobalContext, render_pass_context: &Self::Context) -> Self {
         let shader_module = device.create_shader_module(SHADER);
+        #[cfg(feature = "debug")]
+        let shader_module_wireframe = device.create_shader_module(SHADER_WIREFRAME);
 
         let instance_data_buffer = Buffer::with_capacity(
             device,
@@ -111,7 +115,7 @@ impl Drawer<{ BindGroupCount::One }, { ColorAttachmentCount::Three }, { DepthAtt
         let wireframe_pipeline = Self::create_pipeline(
             device,
             render_pass_context,
-            &shader_module,
+            &shader_module_wireframe,
             instance_index_buffer_layout.clone(),
             &pipeline_layout,
             PolygonMode::Line,

--- a/korangar/src/graphics/passes/geometry/shader/model_wireframe.wgsl
+++ b/korangar/src/graphics/passes/geometry/shader/model_wireframe.wgsl
@@ -1,0 +1,57 @@
+struct GlobalUniforms {
+    view_projection: mat4x4<f32>,
+    inverse_view_projection: mat4x4<f32>,
+    view:mat4x4<f32>,
+    indicator_positions: mat4x4<f32>,
+    indicator_color: vec4<f32>,
+    ambient_color: vec4<f32>,
+    pointer_position: vec2<u32>,
+    animation_timer: f32,
+    day_timer: f32,
+    water_level: f32,
+}
+
+struct InstanceData {
+    world: mat4x4<f32>,
+    inv_world: mat4x4<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) normal: vec4<f32>,
+}
+
+struct FragmentOutput {
+    @location(0) fragment_color: vec4<f32>,
+    @location(1) fragment_normal: vec4<f32>,
+}
+
+@group(0) @binding(0) var<uniform> global_uniforms: GlobalUniforms;
+@group(1) @binding(0) var<storage, read> instance_data: array<InstanceData>;
+
+@vertex
+fn vs_main(
+    @location(0) position: vec3<f32>,
+    @location(1) normal: vec3<f32>,
+    @location(5) wind_affinity: f32,
+    @location(6) instance_id: u32
+) -> VertexOutput {
+    let instance = instance_data[instance_id];
+
+    let world_position = instance.world * vec4<f32>(position, 1.0);
+    let wind_position = world_position + vec4<f32>(global_uniforms.animation_timer);
+    let offset = vec4<f32>(sin(wind_position.x), 0.0, sin(wind_position.z), 0.0) * wind_affinity;
+
+    var output: VertexOutput;
+    output.position = global_uniforms.view_projection * (world_position + offset);
+    output.normal = instance.inv_world * vec4<f32>(normal, 1.0);
+    return output;
+}
+
+@fragment
+fn fs_main(input: VertexOutput) -> FragmentOutput {
+    var output: FragmentOutput;
+    output.fragment_color = vec4<f32>(1.0);
+    output.fragment_normal = input.normal;
+    return output;
+}


### PR DESCRIPTION
Implemented in a different shader, so that we don't need to let debug code bleed into normal code too much.