### PR TITLE
Implement and use a texture atlas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1471,6 +1471,7 @@ version = "0.1.0"
 dependencies = [
  "cgmath",
  "derive-new",
+ "image",
  "korangar_interface",
  "rand",
 ]

--- a/korangar/src/graphics/engine.rs
+++ b/korangar/src/graphics/engine.rs
@@ -587,8 +587,6 @@ impl GraphicsEngine {
 
                 let draw_data = ModelBatchDrawData {
                     batches: instruction.directional_model_batches,
-                    map_textures: instruction.map_textures,
-                    map_vertex_buffer: instruction.map_model_vertex_group,
                     #[cfg(feature = "debug")]
                     show_wireframe: false,
                 };
@@ -611,8 +609,6 @@ impl GraphicsEngine {
                         let model_data = PointShadowBatchData {
                             pass_data,
                             caster: instruction.point_light_shadow_caster,
-                            map_textures: instruction.map_textures,
-                            map_vertex_group: instruction.map_model_vertex_group,
                         };
 
                         let mut render_pass = engine_context.point_shadow_pass_context.create_pass(
@@ -642,8 +638,6 @@ impl GraphicsEngine {
 
                 let draw_data = ModelBatchDrawData {
                     batches: instruction.model_batches,
-                    map_textures: instruction.map_textures,
-                    map_vertex_buffer: instruction.map_model_vertex_group,
                     #[cfg(feature = "debug")]
                     show_wireframe: instruction.render_settings.show_wireframe,
                 };

--- a/korangar/src/graphics/instruction.rs
+++ b/korangar/src/graphics/instruction.rs
@@ -7,7 +7,7 @@ use super::color::Color;
 use super::vertices::ModelVertex;
 #[cfg(feature = "debug")]
 use super::RenderSettings;
-use super::{Buffer, Texture, TextureGroup, TileVertex, WaterVertex};
+use super::{Buffer, Texture, TileVertex, WaterVertex};
 use crate::interface::layout::{CornerRadius, ScreenClip, ScreenPosition, ScreenSize};
 #[cfg(feature = "debug")]
 use crate::world::MarkerIdentifier;
@@ -37,8 +37,6 @@ pub struct RenderInstruction<'a> {
     pub point_shadow_models: &'a [ModelInstruction],
     pub point_shadow_entities: &'a [EntityInstruction],
     pub effects: &'a [EffectInstruction],
-    pub map_textures: &'a TextureGroup,
-    pub map_model_vertex_group: &'a Buffer<ModelVertex>,
     pub map_picker_tile_vertex_buffer: &'a Buffer<TileVertex>,
     pub map_water_vertex_buffer: Option<&'a Buffer<WaterVertex>>,
     pub font_atlas_texture: &'a Texture,
@@ -79,6 +77,8 @@ pub struct PointShadowCasterInstruction {
     pub screen_size: ScreenSize,
     pub color: Color,
     pub range: f32,
+    pub model_texture: Arc<Texture>,
+    pub model_vertex_buffer: Arc<Buffer<ModelVertex>>,
     /// Start point inside the point_shadow_entities.
     pub entity_offset: [usize; 6],
     /// Model count inside the point_shadow_entities.
@@ -165,10 +165,8 @@ pub struct IndicatorInstruction {
 pub struct ModelBatch {
     pub offset: usize,
     pub count: usize,
-    /// Optional texture group that is used instead of the default map textures.
-    pub textures: Option<Arc<TextureGroup>>,
-    /// Optional texture group that is used instead of the default map textures.
-    pub vertex_buffer: Option<Arc<Buffer<ModelVertex>>>,
+    pub texture: Arc<Texture>,
+    pub vertex_buffer: Arc<Buffer<ModelVertex>>,
 }
 
 #[derive(Clone, Debug)]

--- a/korangar/src/graphics/passes/directional_shadow/model.rs
+++ b/korangar/src/graphics/passes/directional_shadow/model.rs
@@ -14,7 +14,7 @@ use crate::graphics::passes::{
     BindGroupCount, ColorAttachmentCount, DepthAttachmentCount, DirectionalShadowRenderPassContext, DrawIndirectArgs, Drawer,
     ModelBatchDrawData, RenderPassContext,
 };
-use crate::graphics::{Buffer, GlobalContext, ModelVertex, Prepare, RenderInstruction, TextureGroup};
+use crate::graphics::{Buffer, GlobalContext, ModelVertex, Prepare, RenderInstruction, Texture};
 
 const SHADER: ShaderModuleDescriptor = include_wgsl!("shader/model.wgsl");
 const DRAWER_NAME: &str = "directional shadow model";
@@ -66,7 +66,7 @@ impl Drawer<{ BindGroupCount::Two }, { ColorAttachmentCount::None }, { DepthAtta
             attributes: &[VertexAttribute {
                 format: VertexFormat::Uint32,
                 offset: 0,
-                shader_location: 6,
+                shader_location: 5,
             }],
         };
 
@@ -99,7 +99,7 @@ impl Drawer<{ BindGroupCount::Two }, { ColorAttachmentCount::None }, { DepthAtta
                 Self::Context::bind_group_layout(device)[0],
                 Self::Context::bind_group_layout(device)[1],
                 &bind_group_layout,
-                TextureGroup::bind_group_layout(device),
+                Texture::bind_group_layout(device),
             ],
             push_constant_ranges: &[],
         });
@@ -158,11 +158,8 @@ impl Drawer<{ BindGroupCount::Two }, { ColorAttachmentCount::None }, { DepthAtta
                 continue;
             }
 
-            let textures = batch.textures.as_deref().unwrap_or(draw_data.map_textures);
-            let vertex_buffer = batch.vertex_buffer.as_deref().unwrap_or(draw_data.map_vertex_buffer);
-
-            pass.set_bind_group(3, textures.bind_group(), &[]);
-            pass.set_vertex_buffer(0, vertex_buffer.slice(..));
+            pass.set_bind_group(3, batch.texture.get_bind_group(), &[]);
+            pass.set_vertex_buffer(0, batch.vertex_buffer.slice(..));
             pass.set_vertex_buffer(1, self.instance_index_vertex_buffer.slice(..));
             pass.multi_draw_indirect(
                 self.command_buffer.get_buffer(),

--- a/korangar/src/graphics/passes/directional_shadow/shader/model.wgsl
+++ b/korangar/src/graphics/passes/directional_shadow/shader/model.wgsl
@@ -10,21 +10,19 @@ struct InstanceData {
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
     @location(0) texture_coordinates: vec2<f32>,
-    @location(1) texture_index: i32,
 }
 
 @group(0) @binding(1) var nearest_sampler: sampler;
 @group(1) @binding(0) var<uniform> pass_uniforms: PassUniforms;
 @group(2) @binding(0) var<storage, read> instance_data: array<InstanceData>;
-@group(3) @binding(0) var textures: binding_array<texture_2d<f32>>;
+@group(3) @binding(0) var texture: texture_2d<f32>;
 
 @vertex
 fn vs_main(
     @location(0) position: vec3<f32>,
     @location(2) texture_coordinates: vec2<f32>,
-    @location(3) texture_index: i32,
-    @location(5) wind_affinity: f32,
-    @location(6) instance_id: u32
+    @location(4) wind_affinity: f32,
+    @location(5) instance_id: u32
 ) -> VertexOutput {
     let instance = instance_data[instance_id];
 
@@ -35,15 +33,14 @@ fn vs_main(
     var output: VertexOutput;
     output.position = pass_uniforms.view_projection * (world_position + offset);
     output.texture_coordinates = texture_coordinates;
-    output.texture_index = texture_index;
     return output;
 }
 
 @fragment
 fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
-    var diffuse_color = textureSample(textures[input.texture_index], nearest_sampler, input.texture_coordinates);
+    var diffuse_color = textureSample(texture, nearest_sampler, input.texture_coordinates);
 
-    if (diffuse_color.a != 1.0) {
+    if (diffuse_color.a < 1.0) {
         discard;
     }
 

--- a/korangar/src/graphics/passes/geometry/model.rs
+++ b/korangar/src/graphics/passes/geometry/model.rs
@@ -15,7 +15,7 @@ use crate::graphics::passes::{
     BindGroupCount, ColorAttachmentCount, DepthAttachmentCount, DrawIndirectArgs, Drawer, GeometryRenderPassContext, ModelBatchDrawData,
     RenderPassContext,
 };
-use crate::graphics::{Buffer, GlobalContext, ModelVertex, Prepare, RenderInstruction, TextureGroup};
+use crate::graphics::{Buffer, GlobalContext, ModelVertex, Prepare, RenderInstruction, Texture};
 
 const SHADER: ShaderModuleDescriptor = include_wgsl!("shader/model.wgsl");
 #[cfg(feature = "debug")]
@@ -74,7 +74,7 @@ impl Drawer<{ BindGroupCount::One }, { ColorAttachmentCount::Three }, { DepthAtt
             attributes: &[VertexAttribute {
                 format: VertexFormat::Uint32,
                 offset: 0,
-                shader_location: 6,
+                shader_location: 5,
             }],
         };
 
@@ -106,7 +106,7 @@ impl Drawer<{ BindGroupCount::One }, { ColorAttachmentCount::Three }, { DepthAtt
             bind_group_layouts: &[
                 Self::Context::bind_group_layout(device)[0],
                 &bind_group_layout,
-                TextureGroup::bind_group_layout(device),
+                Texture::bind_group_layout(device),
             ],
             push_constant_ranges: &[],
         });
@@ -167,11 +167,8 @@ impl Drawer<{ BindGroupCount::One }, { ColorAttachmentCount::Three }, { DepthAtt
                 continue;
             }
 
-            let textures = batch.textures.as_deref().unwrap_or(draw_data.map_textures);
-            let vertex_buffer = batch.vertex_buffer.as_deref().unwrap_or(draw_data.map_vertex_buffer);
-
-            pass.set_bind_group(2, textures.bind_group(), &[]);
-            pass.set_vertex_buffer(0, vertex_buffer.slice(..));
+            pass.set_bind_group(2, batch.texture.get_bind_group(), &[]);
+            pass.set_vertex_buffer(0, batch.vertex_buffer.slice(..));
             pass.set_vertex_buffer(1, self.instance_index_vertex_buffer.slice(..));
             pass.multi_draw_indirect(
                 self.command_buffer.get_buffer(),

--- a/korangar/src/graphics/passes/geometry/shader/model.wgsl
+++ b/korangar/src/graphics/passes/geometry/shader/model.wgsl
@@ -20,8 +20,7 @@ struct VertexOutput {
     @builtin(position) position: vec4<f32>,
     @location(0) normal: vec4<f32>,
     @location(1) texture_coordinates: vec2<f32>,
-    @location(2) texture_index: i32,
-    @location(3) color: vec3<f32>,
+    @location(2) color: vec3<f32>,
 }
 
 struct FragmentOutput {
@@ -33,17 +32,16 @@ struct FragmentOutput {
 @group(0) @binding(1) var nearest_sampler: sampler;
 @group(0) @binding(3) var texture_sampler: sampler;
 @group(1) @binding(0) var<storage, read> instance_data: array<InstanceData>;
-@group(2) @binding(0) var textures: binding_array<texture_2d<f32>>;
+@group(2) @binding(0) var texture: texture_2d<f32>;
 
 @vertex
 fn vs_main(
     @location(0) position: vec3<f32>,
     @location(1) normal: vec3<f32>,
     @location(2) texture_coordinates: vec2<f32>,
-    @location(3) texture_index: i32,
-    @location(4) color: vec3<f32>,
-    @location(5) wind_affinity: f32,
-    @location(6) instance_id: u32
+    @location(3) color: vec3<f32>,
+    @location(4) wind_affinity: f32,
+    @location(5) instance_id: u32
 ) -> VertexOutput {
     let instance = instance_data[instance_id];
 
@@ -55,15 +53,14 @@ fn vs_main(
     output.position = global_uniforms.view_projection * (world_position + offset);
     output.normal = instance.inv_world * vec4<f32>(normal, 1.0);
     output.texture_coordinates = texture_coordinates;
-    output.texture_index = texture_index;
     output.color = color;
     return output;
 }
 
 @fragment
 fn fs_main(input: VertexOutput) -> FragmentOutput {
-    let diffuse_color = textureSample(textures[input.texture_index], texture_sampler, input.texture_coordinates);
-    let alpha_channel = textureSample(textures[input.texture_index], nearest_sampler, input.texture_coordinates).a;
+    let diffuse_color = textureSample(texture, texture_sampler, input.texture_coordinates);
+    let alpha_channel = textureSample(texture, nearest_sampler, input.texture_coordinates).a;
 
     if (alpha_channel < 1.0) {
         discard;

--- a/korangar/src/graphics/passes/mod.rs
+++ b/korangar/src/graphics/passes/mod.rs
@@ -18,7 +18,7 @@ pub(crate) use screen::*;
 pub(crate) use selector::*;
 use wgpu::{BindGroupLayout, CommandEncoder, ComputePass, Device, Queue, RenderPass, TextureFormat, TextureView};
 
-use crate::graphics::{Buffer, GlobalContext, ModelBatch, ModelVertex, TextureGroup};
+use crate::graphics::{GlobalContext, ModelBatch};
 use crate::loaders::TextureLoader;
 
 #[derive(Clone, Copy, PartialEq, Eq, ConstParamTy)]
@@ -121,8 +121,6 @@ struct DrawIndirectArgs {
 /// buffer.
 pub(crate) struct ModelBatchDrawData<'a> {
     pub(crate) batches: &'a [ModelBatch],
-    pub(crate) map_textures: &'a TextureGroup,
-    pub(crate) map_vertex_buffer: &'a Buffer<ModelVertex>,
     #[cfg(feature = "debug")]
     pub(crate) show_wireframe: bool,
 }

--- a/korangar/src/graphics/passes/point_shadow/mod.rs
+++ b/korangar/src/graphics/passes/point_shadow/mod.rs
@@ -4,21 +4,21 @@ mod model;
 
 use std::sync::OnceLock;
 
-use bytemuck::{bytes_of, Pod, Zeroable};
+use bytemuck::{Pod, Zeroable};
 pub(crate) use entity::PointShadowEntityDrawer;
 pub(crate) use indicator::PointShadowIndicatorDrawer;
 pub(crate) use model::PointShadowModelDrawer;
 use wgpu::util::StagingBelt;
 use wgpu::{
-    BindGroup, BindGroupDescriptor, BindGroupEntry, BindGroupLayout, BindGroupLayoutDescriptor, BindGroupLayoutEntry, BindingResource,
-    BindingType, BufferBindingType, BufferUsages, CommandEncoder, Device, LoadOp, Operations, Queue, RenderPass,
-    RenderPassDepthStencilAttachment, RenderPassDescriptor, ShaderStages, StoreOp, TextureFormat, TextureView,
+    BindGroup, BindGroupDescriptor, BindGroupEntry, BindGroupLayout, BindGroupLayoutDescriptor, BindGroupLayoutEntry, CommandEncoder,
+    Device, LoadOp, Operations, Queue, RenderPass, RenderPassDepthStencilAttachment, RenderPassDescriptor, ShaderStages, StoreOp,
+    TextureFormat, TextureView,
 };
 
 use super::{BindGroupCount, ColorAttachmentCount, DepthAttachmentCount, RenderPassContext};
-use crate::graphics::{Buffer, GlobalContext, ModelVertex, PointShadowCasterInstruction, Prepare, RenderInstruction, TextureGroup};
+use crate::graphics::buffer::DynamicUniformBuffer;
+use crate::graphics::{GlobalContext, PointShadowCasterInstruction, Prepare, RenderInstruction};
 use crate::loaders::TextureLoader;
-use crate::NUMBER_OF_POINT_LIGHTS_WITH_SHADOWS;
 
 const PASS_NAME: &str = "point shadow render pass";
 const NUMBER_FACES: usize = 6;
@@ -41,17 +41,12 @@ pub(crate) struct PointShadowData {
 pub(crate) struct PointShadowBatchData<'a> {
     pub(crate) pass_data: PointShadowData,
     pub(crate) caster: &'a [PointShadowCasterInstruction],
-    pub(crate) map_textures: &'a TextureGroup,
-    pub(crate) map_vertex_group: &'a Buffer<ModelVertex>,
 }
 
 pub(crate) struct PointShadowRenderPassContext {
     point_shadow_texture_format: TextureFormat,
-    uniforms_buffer: Buffer<u8>,
+    uniforms_buffer: DynamicUniformBuffer<PassUniforms>,
     bind_group: BindGroup,
-    uniforms_data: Vec<PassUniforms>,
-    buffer_data: Box<[u8]>,
-    aligned_size: usize,
 }
 
 impl RenderPassContext<{ BindGroupCount::Two }, { ColorAttachmentCount::None }, { DepthAttachmentCount::One }>
@@ -62,28 +57,14 @@ impl RenderPassContext<{ BindGroupCount::Two }, { ColorAttachmentCount::None }, 
     fn new(device: &Device, _queue: &Queue, _texture_loader: &TextureLoader, global_context: &GlobalContext) -> Self {
         let point_shadow_texture_format = global_context.point_shadow_map_textures[0].get_texture_format();
 
-        let uniform_alignment = device.limits().min_uniform_buffer_offset_alignment as usize;
-        let aligned_size = (size_of::<PassUniforms>() + uniform_alignment - 1) & !(uniform_alignment - 1);
-        let buffer_size = aligned_size * NUMBER_OF_POINT_LIGHTS_WITH_SHADOWS * NUMBER_FACES;
-
-        let uniforms_buffer = Buffer::with_capacity(
-            device,
-            format!("{PASS_NAME} pass uniforms"),
-            BufferUsages::UNIFORM | BufferUsages::COPY_DST,
-            buffer_size as _,
-        );
+        let uniforms_buffer = DynamicUniformBuffer::new(device, &format!("{PASS_NAME} pass uniforms"));
 
         let bind_group = Self::create_bind_group(device, &uniforms_buffer);
-        let uniforms_data = Vec::with_capacity(NUMBER_OF_POINT_LIGHTS_WITH_SHADOWS * NUMBER_FACES);
-        let buffer_data = vec![0; buffer_size].into_boxed_slice();
 
         Self {
             point_shadow_texture_format,
             uniforms_buffer,
             bind_group,
-            uniforms_data,
-            buffer_data,
-            aligned_size,
         }
     }
 
@@ -94,7 +75,7 @@ impl RenderPassContext<{ BindGroupCount::Two }, { ColorAttachmentCount::None }, 
         global_context: &GlobalContext,
         pass_data: PointShadowData,
     ) -> RenderPass<'encoder> {
-        let dynamic_offset = ((pass_data.shadow_caster_index * NUMBER_FACES + pass_data.face_index) * self.aligned_size) as u32;
+        let dynamic_offset = self.uniforms_buffer.dynamic_offset(pass_data.shadow_caster_index * NUMBER_FACES);
 
         let mut pass = encoder.begin_render_pass(&RenderPassDescriptor {
             label: Some(PASS_NAME),
@@ -134,11 +115,7 @@ impl RenderPassContext<{ BindGroupCount::Two }, { ColorAttachmentCount::None }, 
                 entries: &[BindGroupLayoutEntry {
                     binding: 0,
                     visibility: ShaderStages::VERTEX_FRAGMENT,
-                    ty: BindingType::Buffer {
-                        ty: BufferBindingType::Uniform,
-                        has_dynamic_offset: true,
-                        min_binding_size: std::num::NonZeroU64::new(size_of::<PassUniforms>() as _),
-                    },
+                    ty: DynamicUniformBuffer::<PassUniforms>::get_binding_type(),
                     count: None,
                 }],
             })
@@ -158,28 +135,19 @@ impl RenderPassContext<{ BindGroupCount::Two }, { ColorAttachmentCount::None }, 
 
 impl Prepare for PointShadowRenderPassContext {
     fn prepare(&mut self, _device: &Device, instructions: &RenderInstruction) {
-        self.uniforms_data.clear();
-        instructions.point_light_shadow_caster.iter().for_each(|caster| {
-            (0..NUMBER_FACES).for_each(|face_index| {
-                let uniform = PassUniforms {
-                    view_projection: caster.view_projection_matrices[face_index].into(),
-                    light_position: caster.position.to_homogeneous().into(),
-                    animation_timer: instructions.uniforms.animation_timer,
-                    padding: Default::default(),
-                };
-                self.uniforms_data.push(uniform);
-            });
+        let uniforms = instructions.point_light_shadow_caster.iter().flat_map(|caster| {
+            (0..NUMBER_FACES).map(|face_index| PassUniforms {
+                view_projection: caster.view_projection_matrices[face_index].into(),
+                light_position: caster.position.to_homogeneous().into(),
+                animation_timer: instructions.uniforms.animation_timer,
+                padding: Default::default(),
+            })
         });
-
-        for (index, uniform) in self.uniforms_data.iter().enumerate() {
-            let start = index * self.aligned_size;
-            let end = start + size_of::<PassUniforms>();
-            self.buffer_data[start..end].copy_from_slice(bytes_of(uniform));
-        }
+        self.uniforms_buffer.write_data(uniforms);
     }
 
     fn upload(&mut self, device: &Device, staging_belt: &mut StagingBelt, command_encoder: &mut CommandEncoder) {
-        let recreated = self.uniforms_buffer.write(device, staging_belt, command_encoder, &self.buffer_data);
+        let recreated = self.uniforms_buffer.upload(device, staging_belt, command_encoder);
 
         if recreated {
             self.bind_group = Self::create_bind_group(device, &self.uniforms_buffer);
@@ -188,17 +156,13 @@ impl Prepare for PointShadowRenderPassContext {
 }
 
 impl PointShadowRenderPassContext {
-    fn create_bind_group(device: &Device, uniforms_buffer: &Buffer<u8>) -> BindGroup {
+    fn create_bind_group(device: &Device, uniforms_buffer: &DynamicUniformBuffer<PassUniforms>) -> BindGroup {
         device.create_bind_group(&BindGroupDescriptor {
             label: Some(PASS_NAME),
             layout: Self::bind_group_layout(device)[1],
             entries: &[BindGroupEntry {
                 binding: 0,
-                resource: BindingResource::Buffer(wgpu::BufferBinding {
-                    buffer: uniforms_buffer.get_buffer(),
-                    offset: 0,
-                    size: Some(std::num::NonZeroU64::new(size_of::<PassUniforms>() as u64).unwrap()),
-                }),
+                resource: uniforms_buffer.get_binding_resource(),
             }],
         })
     }

--- a/korangar/src/graphics/passes/point_shadow/model.rs
+++ b/korangar/src/graphics/passes/point_shadow/model.rs
@@ -14,7 +14,7 @@ use crate::graphics::passes::{
     BindGroupCount, ColorAttachmentCount, DepthAttachmentCount, DrawIndirectArgs, Drawer, PointShadowBatchData,
     PointShadowRenderPassContext, RenderPassContext,
 };
-use crate::graphics::{Buffer, GlobalContext, ModelVertex, Prepare, RenderInstruction, TextureGroup};
+use crate::graphics::{Buffer, GlobalContext, ModelVertex, Prepare, RenderInstruction, Texture};
 
 const SHADER: ShaderModuleDescriptor = include_wgsl!("shader/model.wgsl");
 const DRAWER_NAME: &str = "point shadow model";
@@ -66,7 +66,7 @@ impl Drawer<{ BindGroupCount::Two }, { ColorAttachmentCount::None }, { DepthAtta
             attributes: &[VertexAttribute {
                 format: VertexFormat::Uint32,
                 offset: 0,
-                shader_location: 6,
+                shader_location: 5,
             }],
         };
 
@@ -99,7 +99,7 @@ impl Drawer<{ BindGroupCount::Two }, { ColorAttachmentCount::None }, { DepthAtta
                 Self::Context::bind_group_layout(device)[0],
                 Self::Context::bind_group_layout(device)[1],
                 &bind_group_layout,
-                TextureGroup::bind_group_layout(device),
+                Texture::bind_group_layout(device),
             ],
             push_constant_ranges: &[],
         });
@@ -153,14 +153,13 @@ impl Drawer<{ BindGroupCount::Two }, { ColorAttachmentCount::None }, { DepthAtta
         if batch.mode_count[face_index] == 0 {
             return;
         }
-
         let offset = batch.model_offset[face_index];
         let count = batch.mode_count[face_index];
 
         pass.set_pipeline(&self.pipeline);
         pass.set_bind_group(2, &self.bind_group, &[]);
-        pass.set_bind_group(3, draw_data.map_textures.bind_group(), &[]);
-        pass.set_vertex_buffer(0, draw_data.map_vertex_group.slice(..));
+        pass.set_bind_group(3, batch.model_texture.get_bind_group(), &[]);
+        pass.set_vertex_buffer(0, batch.model_vertex_buffer.slice(..));
         pass.set_vertex_buffer(1, self.instance_index_vertex_buffer.slice(..));
         pass.multi_draw_indirect(
             self.command_buffer.get_buffer(),

--- a/korangar/src/graphics/passes/point_shadow/shader/model.wgsl
+++ b/korangar/src/graphics/passes/point_shadow/shader/model.wgsl
@@ -12,21 +12,19 @@ struct VertexOutput {
     @builtin(position) position: vec4<f32>,
     @location(0) world_position: vec4<f32>,
     @location(1) texture_coordinates: vec2<f32>,
-    @location(2) texture_index: i32,
 }
 
 @group(0) @binding(1) var nearest_sampler: sampler;
 @group(1) @binding(0) var<uniform> pass_uniforms: PassUniforms;
 @group(2) @binding(0) var<storage, read> instance_data: array<InstanceData>;
-@group(3) @binding(0) var textures: binding_array<texture_2d<f32>>;
+@group(3) @binding(0) var texture: texture_2d<f32>;
 
 @vertex
 fn vs_main(
     @location(0) position: vec3<f32>,
     @location(2) texture_coordinates: vec2<f32>,
-    @location(3) texture_index: i32,
-    @location(5) wind_affinity: f32,
-    @location(6) instance_id: u32,
+    @location(4) wind_affinity: f32,
+    @location(5) instance_id: u32,
 ) -> VertexOutput {
     let instance = instance_data[instance_id];
 
@@ -38,13 +36,12 @@ fn vs_main(
     output.world_position = (world_position + offset);
     output.position = pass_uniforms.view_projection * output.world_position;
     output.texture_coordinates = texture_coordinates;
-    output.texture_index = texture_index;
     return output;
 }
 
 @fragment
 fn fs_main(input: VertexOutput) -> @builtin(frag_depth) f32 {
-    var diffuse_color = textureSample(textures[input.texture_index], nearest_sampler, input.texture_coordinates);
+    var diffuse_color = textureSample(texture, nearest_sampler, input.texture_coordinates);
 
     let light_distance = length(input.world_position.xyz - pass_uniforms.light_position.xyz);
 

--- a/korangar/src/graphics/texture.rs
+++ b/korangar/src/graphics/texture.rs
@@ -1,23 +1,21 @@
 use std::fmt::{Debug, Formatter};
-use std::num::NonZeroU32;
-use std::sync::{Arc, OnceLock};
+use std::sync::OnceLock;
 
 use derive_new::new;
 use wgpu::util::{DeviceExt, TextureDataOrder};
 use wgpu::{
     BindGroup, BindGroupDescriptor, BindGroupEntry, BindGroupLayout, BindGroupLayoutDescriptor, BindGroupLayoutEntry, BindingResource,
-    BindingType, Device, Extent3d, Features, Queue, ShaderStages, TextureDescriptor, TextureDimension, TextureFormat, TextureSampleType,
+    BindingType, Device, Extent3d, Queue, ShaderStages, TextureDescriptor, TextureDimension, TextureFormat, TextureSampleType,
     TextureUsages, TextureView, TextureViewDescriptor, TextureViewDimension,
 };
 
-use crate::graphics::features_supported;
 use crate::interface::layout::ScreenSize;
-use crate::MAX_BINDING_TEXTURE_ARRAY_COUNT;
 
 pub struct Texture {
     label: Option<String>,
     texture: wgpu::Texture,
     texture_view: TextureView,
+    bind_group: BindGroup,
 }
 
 impl Debug for Texture {
@@ -38,10 +36,20 @@ impl Texture {
             ..Default::default()
         });
 
+        let bind_group = device.create_bind_group(&BindGroupDescriptor {
+            label: descriptor.label,
+            layout: Self::bind_group_layout(device),
+            entries: &[BindGroupEntry {
+                binding: 0,
+                resource: BindingResource::TextureView(&texture_view),
+            }],
+        });
+
         Self {
             label,
             texture,
             texture_view,
+            bind_group,
         }
     }
 
@@ -53,10 +61,20 @@ impl Texture {
             ..Default::default()
         });
 
+        let bind_group = device.create_bind_group(&BindGroupDescriptor {
+            label: descriptor.label,
+            layout: Self::bind_group_layout(device),
+            entries: &[BindGroupEntry {
+                binding: 0,
+                resource: BindingResource::TextureView(&texture_view),
+            }],
+        });
+
         Self {
             label,
             texture,
             texture_view,
+            bind_group,
         }
     }
 
@@ -75,19 +93,16 @@ impl Texture {
     pub fn get_texture_view(&self) -> &TextureView {
         &self.texture_view
     }
-}
 
-pub struct TextureGroup {
-    _textures: Vec<Arc<Texture>>,
-    bind_group: BindGroup,
-}
+    pub fn get_bind_group(&self) -> &BindGroup {
+        &self.bind_group
+    }
 
-impl TextureGroup {
     pub fn bind_group_layout(device: &Device) -> &'static BindGroupLayout {
         static LAYOUT: OnceLock<BindGroupLayout> = OnceLock::new();
         LAYOUT.get_or_init(|| {
             device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-                label: Some("texture group"),
+                label: None,
                 entries: &[BindGroupLayoutEntry {
                     binding: 0,
                     visibility: ShaderStages::FRAGMENT,
@@ -96,44 +111,10 @@ impl TextureGroup {
                         view_dimension: TextureViewDimension::D2,
                         multisampled: false,
                     },
-                    count: NonZeroU32::new(MAX_BINDING_TEXTURE_ARRAY_COUNT as u32),
+                    count: None,
                 }],
             })
         })
-    }
-
-    pub fn bind_group(&self) -> &BindGroup {
-        &self.bind_group
-    }
-
-    pub(crate) fn new(device: &Device, label: &str, textures: Vec<Arc<Texture>>) -> Self {
-        let texture_count = textures.len();
-        let mut texture_views: Vec<&TextureView> = textures
-            .iter()
-            .take(MAX_BINDING_TEXTURE_ARRAY_COUNT.min(texture_count))
-            .map(|texture| texture.get_texture_view())
-            .collect();
-
-        if !features_supported(Features::PARTIALLY_BOUND_BINDING_ARRAY) {
-            for _ in 0..MAX_BINDING_TEXTURE_ARRAY_COUNT.saturating_sub(texture_count) {
-                texture_views.push(texture_views[0]);
-            }
-        }
-
-        let layout = Self::bind_group_layout(device);
-        let bind_group = device.create_bind_group(&BindGroupDescriptor {
-            label: Some(label),
-            layout,
-            entries: &[BindGroupEntry {
-                binding: 0,
-                resource: BindingResource::TextureViewArray(&texture_views),
-            }],
-        });
-
-        Self {
-            _textures: textures,
-            bind_group,
-        }
     }
 }
 
@@ -154,9 +135,30 @@ impl Debug for CubeTexture {
 }
 
 impl CubeTexture {
-    pub fn new(device: &Device, descriptor: &TextureDescriptor) -> Self {
+    pub(crate) fn new(
+        device: &Device,
+        texture_name: &str,
+        dimensions: ScreenSize,
+        format: TextureFormat,
+        attachment_image_type: AttachmentTextureType,
+    ) -> CubeTexture {
+        let descriptor = TextureDescriptor {
+            label: Some(texture_name),
+            size: Extent3d {
+                width: dimensions.width as u32,
+                height: dimensions.height as u32,
+                depth_or_array_layers: 6,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: TextureDimension::D2,
+            format,
+            usage: attachment_image_type.into(),
+            view_formats: &[],
+        };
+
         let label = descriptor.label.map(|label| label.to_string());
-        let texture = device.create_texture(descriptor);
+        let texture = device.create_texture(&descriptor);
 
         let texture_view = texture.create_view(&TextureViewDescriptor {
             label: descriptor.label,
@@ -212,32 +214,78 @@ impl CubeTexture {
     }
 }
 
-pub(crate) enum TextureType {
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
+pub(crate) enum AttachmentTextureType {
     ColorAttachment,
     DepthAttachment,
     Depth,
 }
 
-impl From<TextureType> for TextureUsages {
-    fn from(value: TextureType) -> Self {
+impl From<AttachmentTextureType> for TextureUsages {
+    fn from(value: AttachmentTextureType) -> Self {
         match value {
-            TextureType::ColorAttachment => TextureUsages::TEXTURE_BINDING | TextureUsages::RENDER_ATTACHMENT,
-            TextureType::DepthAttachment => TextureUsages::TEXTURE_BINDING | TextureUsages::RENDER_ATTACHMENT,
-            TextureType::Depth => TextureUsages::TEXTURE_BINDING | TextureUsages::RENDER_ATTACHMENT,
+            AttachmentTextureType::ColorAttachment => TextureUsages::TEXTURE_BINDING | TextureUsages::RENDER_ATTACHMENT,
+            AttachmentTextureType::DepthAttachment => TextureUsages::TEXTURE_BINDING | TextureUsages::RENDER_ATTACHMENT,
+            AttachmentTextureType::Depth => TextureUsages::TEXTURE_BINDING | TextureUsages::RENDER_ATTACHMENT,
         }
     }
 }
 
+pub struct AttachmentTexture {
+    label: Option<String>,
+    texture: wgpu::Texture,
+    texture_view: TextureView,
+}
+
+impl Debug for AttachmentTexture {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        match &self.label {
+            None => write!(formatter, "TextureAttachment(\"Unknown\")"),
+            Some(label) => write!(formatter, "TextureAttachment(\"{label}\")"),
+        }
+    }
+}
+
+impl AttachmentTexture {
+    pub fn new(device: &Device, descriptor: &TextureDescriptor) -> Self {
+        let label = descriptor.label.map(|label| label.to_string());
+        let texture = device.create_texture(descriptor);
+        let texture_view = texture.create_view(&TextureViewDescriptor {
+            label: descriptor.label,
+            ..Default::default()
+        });
+
+        Self {
+            label,
+            texture,
+            texture_view,
+        }
+    }
+
+    pub fn get_format(&self) -> TextureFormat {
+        self.texture.format()
+    }
+
+    pub fn get_texture_view(&self) -> &TextureView {
+        &self.texture_view
+    }
+}
+
 #[derive(new)]
-pub(crate) struct TextureFactory<'a> {
+pub(crate) struct AttachmentTextureFactory<'a> {
     device: &'a Device,
     dimensions: ScreenSize,
     sample_count: u32,
 }
 
-impl<'a> TextureFactory<'a> {
-    pub(crate) fn new_texture(&self, texture_name: &str, format: TextureFormat, attachment_image_type: TextureType) -> Texture {
-        Texture::new(self.device, &TextureDescriptor {
+impl<'a> AttachmentTextureFactory<'a> {
+    pub(crate) fn new_attachment(
+        &self,
+        texture_name: &str,
+        format: TextureFormat,
+        attachment_image_type: AttachmentTextureType,
+    ) -> AttachmentTexture {
+        AttachmentTexture::new(&self.device, &TextureDescriptor {
             label: Some(texture_name),
             size: Extent3d {
                 width: self.dimensions.width as u32,
@@ -246,23 +294,6 @@ impl<'a> TextureFactory<'a> {
             },
             mip_level_count: 1,
             sample_count: self.sample_count,
-            dimension: TextureDimension::D2,
-            format,
-            usage: attachment_image_type.into(),
-            view_formats: &[],
-        })
-    }
-
-    pub(crate) fn new_cube_texture(&self, texture_name: &str, format: TextureFormat, attachment_image_type: TextureType) -> CubeTexture {
-        CubeTexture::new(self.device, &TextureDescriptor {
-            label: Some(texture_name),
-            size: Extent3d {
-                width: self.dimensions.width as u32,
-                height: self.dimensions.height as u32,
-                depth_or_array_layers: 6,
-            },
-            mip_level_count: 1,
-            sample_count: 1,
             dimension: TextureDimension::D2,
             format,
             usage: attachment_image_type.into(),

--- a/korangar/src/graphics/vertices/model.rs
+++ b/korangar/src/graphics/vertices/model.rs
@@ -10,7 +10,6 @@ pub struct ModelVertex {
     pub position: [f32; 3],
     pub normal: [f32; 3],
     pub texture_coordinates: [f32; 2],
-    pub texture_index: i32,
     pub color: [f32; 3],
     pub wind_affinity: f32,
 }
@@ -20,7 +19,6 @@ impl ModelVertex {
         position: Point3<f32>,
         normal: Vector3<f32>,
         texture_coordinates: Vector2<f32>,
-        texture_index: i32,
         color: Color,
         wind_affinity: f32,
     ) -> Self {
@@ -28,7 +26,6 @@ impl ModelVertex {
             position: [position.x, position.y, position.z],
             normal: [normal.x, normal.y, normal.z],
             texture_coordinates: [texture_coordinates.x, texture_coordinates.y],
-            texture_index,
             color: [color.red, color.green, color.blue],
             wind_affinity,
         }
@@ -39,9 +36,8 @@ impl ModelVertex {
                 0 => Float32x3,
                 1 => Float32x3,
                 2 => Float32x2,
-                3 => Sint32,
-                4 => Float32x3,
-                5 => Float32,
+                3 => Float32x3,
+                4 => Float32,
         );
 
         VertexBufferLayout {

--- a/korangar/src/loaders/mod.rs
+++ b/korangar/src/loaders/mod.rs
@@ -21,4 +21,4 @@ pub use self::model::*;
 pub use self::script::{ResourceMetadata, ScriptLoader};
 pub use self::server::{load_client_info, ClientInfo, ServiceId};
 pub use self::sprite::*;
-pub use self::texture::TextureLoader;
+pub use self::texture::{TextureAtlasFactory, TextureLoader};

--- a/korangar/src/world/entity/mod.rs
+++ b/korangar/src/world/entity/mod.rs
@@ -5,6 +5,8 @@ use derive_new::new;
 use korangar_interface::elements::PrototypeElement;
 use korangar_interface::windows::{PrototypeWindow, Window};
 use korangar_networking::EntityData;
+#[cfg(feature = "debug")]
+use korangar_util::texture_atlas::AtlasAllocation;
 use ragnarok_formats::map::TileFlags;
 use ragnarok_packets::{AccountId, CharacterInformation, ClientTick, EntityId, Sex, StatusType, WorldPosition};
 #[cfg(feature = "debug")]
@@ -626,7 +628,7 @@ impl Common {
     }
 
     #[cfg(feature = "debug")]
-    pub fn generate_pathing_mesh(&mut self, device: &Device, queue: &Queue, map: &Map) {
+    pub fn generate_pathing_mesh(&mut self, device: &Device, queue: &Queue, map: &Map, pathing_mapping: &[AtlasAllocation]) {
         use crate::{Color, NativeModelVertex, MAP_TILE_SIZE};
 
         const HALF_TILE_SIZE: f32 = MAP_TILE_SIZE / 2.0;
@@ -721,7 +723,7 @@ impl Common {
             ));
         }
 
-        let pathing_vertices = NativeModelVertex::to_vertices(native_pathing_vertices, None);
+        let pathing_vertices = NativeModelVertex::to_vertices(native_pathing_vertices, pathing_mapping);
 
         if let Some(steps_vertex_buffer) = &active_movement.pathing_vertex_buffer {
             steps_vertex_buffer.write_exact(queue, pathing_vertices.as_slice());
@@ -1067,8 +1069,9 @@ impl Entity {
     }
 
     #[cfg(feature = "debug")]
-    pub fn generate_pathing_mesh(&mut self, device: &Device, queue: &Queue, map: &Map) {
-        self.get_common_mut().generate_pathing_mesh(device, queue, map);
+    pub fn generate_pathing_mesh(&mut self, device: &Device, queue: &Queue, map: &Map, pathing_texture_mapping: &[AtlasAllocation]) {
+        self.get_common_mut()
+            .generate_pathing_mesh(device, queue, map, pathing_texture_mapping);
     }
 
     pub fn render(&self, instructions: &mut Vec<EntityInstruction>, camera: &dyn Camera) {

--- a/korangar/src/world/light/mod.rs
+++ b/korangar/src/world/light/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use cgmath::{Matrix4, Point3, SquareMatrix, Vector2, Vector3, Zero};
 use korangar_util::collision::Sphere;
 use ragnarok_formats::map::LightSource;
@@ -5,7 +7,9 @@ use ragnarok_packets::ClientTick;
 
 #[cfg(feature = "debug")]
 use crate::graphics::RenderSettings;
-use crate::graphics::{ModelInstruction, PointLightInstruction, PointShadowCamera, PointShadowCasterInstruction};
+use crate::graphics::{
+    Buffer, ModelInstruction, ModelVertex, PointLightInstruction, PointShadowCamera, PointShadowCasterInstruction, Texture,
+};
 use crate::interface::layout::{ScreenPosition, ScreenSize};
 #[cfg(feature = "debug")]
 use crate::renderer::MarkerRenderer;
@@ -86,6 +90,8 @@ impl PointLight {
         instructions: &mut Vec<PointShadowCasterInstruction>,
         camera: &dyn Camera,
         view_projection_matrices: [Matrix4<f32>; 6],
+        model_texture: Arc<Texture>,
+        model_vertex_buffer: Arc<Buffer<ModelVertex>>,
         entity_offset: [usize; 6],
         entity_count: [usize; 6],
         model_offset: [usize; 6],
@@ -99,6 +105,8 @@ impl PointLight {
             screen_size,
             color: self.color,
             range: self.range,
+            model_texture,
+            model_vertex_buffer,
             entity_offset,
             entity_count,
             model_offset,
@@ -300,6 +308,8 @@ impl PointLightSet<'_> {
                 point_light_with_shadow_instructions,
                 current_camera,
                 view_projection_matrices,
+                map.get_texture().clone(),
+                map.get_model_vertex_buffer().clone(),
                 entity_offsets,
                 entity_counts,
                 model_offsets,

--- a/korangar_util/Cargo.toml
+++ b/korangar_util/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 cgmath = { workspace = true }
 derive-new = { workspace = true }
+image = { workspace = true }
 korangar_interface = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/korangar_util/src/lib.rs
+++ b/korangar_util/src/lib.rs
@@ -6,5 +6,6 @@ pub mod collision;
 pub mod container;
 mod loader;
 pub mod math;
+pub mod texture_atlas;
 
 pub use loader::{FileLoader, FileNotFoundError};

--- a/korangar_util/src/texture_atlas.rs
+++ b/korangar_util/src/texture_atlas.rs
@@ -1,0 +1,530 @@
+//! A simple texture atlas for deferred offline generation.
+
+use cgmath::Vector2;
+use image::{imageops, RgbaImage};
+
+use crate::container::{SecondarySimpleSlab, SimpleSlab};
+use crate::create_simple_key;
+
+/// Factor we used to increase the texture size for inefficiency in
+/// the packing algorithm.
+const EFFICIENCY_FACTOR: f32 = 1.05;
+
+/// Represents a rectangle in 2D space.
+#[derive(Copy, Clone, Debug)]
+pub struct Rectangle {
+    /// The minimal point of the rectangle (should be top left).
+    pub min: Vector2<u32>,
+    /// The maximal point of the rectangle (should be bottom right).
+    pub max: Vector2<u32>,
+}
+
+impl Rectangle {
+    /// Creates a new [`Rectangle`] with given minimum and maximum coordinates.
+    pub fn new(min: Vector2<u32>, max: Vector2<u32>) -> Self {
+        Self { min, max }
+    }
+
+    /// Returns the height of the rectangle.
+    pub fn height(&self) -> u32 {
+        self.max.y - self.min.y
+    }
+
+    /// Returns the width of the rectangle.
+    pub fn width(&self) -> u32 {
+        self.max.x - self.min.x
+    }
+
+    /// Checks if this rectangle can fit another rectangle of given size.
+    fn can_fit(&self, size: Vector2<u32>) -> bool {
+        self.width() >= size.x && self.height() >= size.y
+    }
+
+    /// Tests if the two rectangles overlap.
+    fn overlaps(&self, other: Rectangle) -> bool {
+        self.min.x < other.max.x && self.max.x > other.min.x && self.min.y < other.max.y && self.max.y > other.min.y
+    }
+
+    /// Tests if the other rectangle is contained in the current rectangle.
+    fn contains(&self, other: Rectangle) -> bool {
+        self.min.x <= other.min.x && self.min.y <= other.min.y && self.max.x >= other.max.x && self.max.y >= other.max.y
+    }
+}
+
+impl PartialEq for Rectangle {
+    fn eq(&self, other: &Self) -> bool {
+        self.min == other.min && self.max == other.max
+    }
+}
+
+create_simple_key!(AllocationId, "A key for an allocation");
+
+/// Represents an allocated rectangle in the texture atlas.
+#[derive(Copy, Clone, Debug)]
+pub struct AtlasAllocation {
+    /// The rectangle that was allocated.
+    pub rectangle: Rectangle,
+    /// The final size of the atlas.
+    atlas_size: Vector2<u32>,
+}
+
+impl AtlasAllocation {
+    /// Maps normalized input coordinates to normalized atlas coordinates.
+    pub fn map_to_atlas(&self, normalized_coordinates: Vector2<f32>) -> Vector2<f32> {
+        let x = ((normalized_coordinates.x * self.rectangle.width() as f32) + self.rectangle.min.x as f32) / self.atlas_size.x as f32;
+        let y = ((normalized_coordinates.y * self.rectangle.height() as f32) + self.rectangle.min.y as f32) / self.atlas_size.y as f32;
+        Vector2::new(x, y)
+    }
+}
+
+/// A texture atlas implementation using the MAXRECTS-BSSF (Best Short Side Fit)
+/// algorithm.
+///
+/// This implementation is based on the algorithm described in the paper:
+/// "A Thousand Ways to Pack the Bin - A Practical Approach to Two-Dimensional
+/// Rectangle Bin Packing" by Jukka Jylänki (2010).
+///
+/// Key features of this implementation:
+/// - Pre-sorts the input using Descending Short Side Sort (DESCSS) for better
+///   packing efficient.
+/// - Uses the Best Short Side Fit (BSSF) heuristic for rectangle placement,
+///   which has been shown to produce very efficient packings.
+///
+/// Performance characteristics:
+/// - Excellent packing efficiency in both online and offline scenarios.
+/// - In our deferred, offline mode, MAXRECTS-BSSF-DESCSS's performance has been
+///   shown to be excellent.
+/// - Theoretical worst-case time complexity is O(n³), but practical performance
+///   is much better.
+///
+/// This implementation is particularly effective when the input can be sorted.
+pub struct TextureAtlas {
+    size: Vector2<u32>,
+    free_rects: Vec<Rectangle>,
+    deferred_allocation: SimpleSlab<AllocationId, DeferredAllocation>,
+    allocations: SecondarySimpleSlab<AllocationId, AtlasAllocation>,
+    image: Option<RgbaImage>,
+    add_padding: bool,
+}
+
+struct DeferredAllocation {
+    image: RgbaImage,
+    size: Vector2<u32>,
+}
+
+impl TextureAtlas {
+    /// Creates a new texture atlas.
+    pub fn new(add_padding: bool) -> Self {
+        TextureAtlas {
+            size: Vector2::new(0, 0),
+            free_rects: Vec::default(),
+            deferred_allocation: SimpleSlab::default(),
+            allocations: SecondarySimpleSlab::default(),
+            image: None,
+            add_padding,
+        }
+    }
+
+    /// Registers the given image and returns an ID which can be used to get an
+    /// allocation after optimization.
+    pub fn register_image(&mut self, image: RgbaImage) -> AllocationId {
+        if self.image.is_some() {
+            panic!("can't register new images once atlas has been build");
+        }
+
+        let (x, y) = image.dimensions();
+
+        let size = if self.add_padding {
+            // We add two pixel at each side for texture not bleeding into each other.
+            // We copy one pixel later from the edges of the image into the padding, because
+            // how GPU sampling works. The other pixel ist not filled and is mainly done,
+            // because in some empty textures there could occur bleed in extreme angles
+            // otherwise.
+            Vector2::new(x + 4, y + 4)
+        } else {
+            Vector2::new(x, y)
+        };
+
+        self.deferred_allocation
+            .insert(DeferredAllocation { image, size })
+            .expect("deferred allocation slab is full")
+    }
+
+    /// Returns the allocation for the given allocation ID, once data was
+    /// inserted and the atlas was generated.
+    pub fn get_allocation(&self, allocation_id: AllocationId) -> Option<AtlasAllocation> {
+        self.allocations.get(allocation_id).copied()
+    }
+
+    /// Builds the atlas with the optimal atlas size.
+    pub fn build_atlas(&mut self) {
+        if self.image.is_some() {
+            panic!("atlas is already build");
+        }
+
+        let mut deferred_allocations: Vec<(AllocationId, DeferredAllocation)> = self.deferred_allocation.drain().collect();
+
+        // DESCSS (Descending Short Side Sort)
+        deferred_allocations.sort_unstable_by(|a, b| {
+            let a_short_side = a.1.size.x.min(a.1.size.y);
+            let b_short_side = b.1.size.x.min(b.1.size.y);
+            let a_long_side = a.1.size.x.max(a.1.size.y);
+            let b_long_side = b.1.size.x.max(b.1.size.y);
+
+            b_short_side.cmp(&a_short_side).then_with(|| b_long_side.cmp(&a_long_side))
+        });
+
+        let (mut width, mut height) = self.estimate_initial_size(&deferred_allocations);
+        let mut temp_allocations = Vec::new();
+
+        let mut success = false;
+        while !success {
+            self.size = Vector2::new(width, height);
+            self.free_rects = vec![Rectangle::new(Vector2::new(0, 0), self.size)];
+            success = true;
+
+            temp_allocations.clear();
+
+            for (allocation_id, alloc) in deferred_allocations.iter() {
+                if let Some(allocation) = self.allocate(alloc.size) {
+                    temp_allocations.push((*allocation_id, allocation));
+                } else {
+                    success = false;
+                    let current_area = width * height;
+                    let adjusted_area = (current_area as f32 * EFFICIENCY_FACTOR) as u32;
+                    let side = (adjusted_area as f32).sqrt() as u32;
+                    width = side;
+                    height = side;
+                    break;
+                }
+            }
+        }
+
+        self.image = Some(RgbaImage::new(width, height));
+        for (id, allocation) in temp_allocations {
+            let (_, deferred_allocation) = deferred_allocations.iter().find(|(alloc_id, _)| *alloc_id == id).unwrap();
+            self.write_image_data(&allocation, &deferred_allocation.image);
+            self.allocations.insert(id, allocation);
+        }
+    }
+
+    /// Implements the BSSF (Best Short Side Fit) heuristics.
+    fn find_best_rectangle(&self, size: Vector2<u32>) -> Option<usize> {
+        self.free_rects
+            .iter()
+            .enumerate()
+            .filter(|(_, rectangle)| rectangle.can_fit(size))
+            .min_by_key(|(_, rectangle)| {
+                let leftover_horizontal = rectangle.width().saturating_sub(size.x);
+                let leftover_vertical = rectangle.height().saturating_sub(size.y);
+                std::cmp::min(leftover_horizontal, leftover_vertical)
+            })
+            .map(|(index, _)| index)
+    }
+
+    fn estimate_initial_size(&self, deferred_allocations: &[(AllocationId, DeferredAllocation)]) -> (u32, u32) {
+        let total_area: u32 = deferred_allocations.iter().map(|r| r.1.size.x * r.1.size.y).sum();
+        let adjusted_area = (total_area as f32 * EFFICIENCY_FACTOR) as u32;
+        let side = (adjusted_area as f32).sqrt() as u32;
+        (side, side)
+    }
+
+    fn allocate(&mut self, size: Vector2<u32>) -> Option<AtlasAllocation> {
+        let best_rect_index = self.find_best_rectangle(size)?;
+        let free_rect = self.free_rects.remove(best_rect_index);
+
+        let allocation = if self.add_padding {
+            AtlasAllocation {
+                rectangle: Rectangle::new(
+                    Vector2::new(free_rect.min.x + 2, free_rect.min.y + 2),
+                    Vector2::new(free_rect.min.x + size.x - 2, free_rect.min.y + size.y - 2),
+                ),
+                atlas_size: self.size,
+            }
+        } else {
+            AtlasAllocation {
+                rectangle: Rectangle::new(free_rect.min, free_rect.min + size),
+                atlas_size: self.size,
+            }
+        };
+
+        let used_rect = Rectangle::new(free_rect.min, free_rect.min + size);
+        let (f_prime, f_double_prime) = self.maxrects_split(free_rect, used_rect);
+        self.free_rects.extend([f_prime, f_double_prime].into_iter().flatten());
+
+        self.update_free_rectangles(used_rect);
+        self.remove_contained_rectangles();
+
+        Some(allocation)
+    }
+
+    /// The actual MAXRECTS splitting as described in the paper.
+    fn maxrects_split(&self, free_rect: Rectangle, used_rect: Rectangle) -> (Option<Rectangle>, Option<Rectangle>) {
+        let f_prime =
+            (free_rect.max.x > used_rect.max.x).then_some(Rectangle::new(Vector2::new(used_rect.max.x, free_rect.min.y), free_rect.max));
+
+        let f_double_prime =
+            (free_rect.max.y > used_rect.max.y).then_some(Rectangle::new(Vector2::new(free_rect.min.x, used_rect.max.y), free_rect.max));
+
+        (f_prime, f_double_prime)
+    }
+
+    /// After allocating a rectangle (used_rect), we need to update our list of
+    /// free rectangles to reflect the new state of available space.
+    fn update_free_rectangles(&mut self, used_rect: Rectangle) {
+        let mut i = 0;
+
+        while i < self.free_rects.len() {
+            if self.free_rects[i].overlaps(used_rect) {
+                let free_rect = self.free_rects.swap_remove(i);
+                let new_rects = subdivide_rectangle(free_rect, used_rect);
+                self.free_rects.extend(new_rects);
+            } else {
+                i += 1;
+            }
+        }
+    }
+
+    /// Removes rectangles that are fully contained within other rectangles in
+    /// the `free_rects` list.
+    fn remove_contained_rectangles(&mut self) {
+        let mut i = 0;
+
+        while i < self.free_rects.len() {
+            let mut contained = false;
+            let mut j = 0;
+
+            while j < self.free_rects.len() {
+                if i != j && self.free_rects[j].contains(self.free_rects[i]) {
+                    contained = true;
+                    break;
+                }
+                j += 1;
+            }
+
+            if contained {
+                self.free_rects.swap_remove(i);
+            } else {
+                i += 1;
+            }
+        }
+    }
+
+    /// Saves the atlas image at the given path.
+    pub fn save_atlas(&self, path: &str) -> Result<(), image::ImageError> {
+        self.image.as_ref().unwrap().save(path)
+    }
+
+    /// Returns the bytes of the underlying image buffer.
+    pub fn get_atlas(mut self) -> RgbaImage {
+        self.image.take().expect("the atlas has not been build yet")
+    }
+
+    fn write_image_data(&mut self, allocation: &AtlasAllocation, image: &RgbaImage) {
+        let atlas_image = self.image.as_mut().unwrap();
+
+        imageops::replace(
+            atlas_image,
+            image,
+            allocation.rectangle.min.x as _,
+            allocation.rectangle.min.y as _,
+        );
+
+        if self.add_padding {
+            let width = allocation.rectangle.width();
+            let height = allocation.rectangle.height();
+
+            // Top padding
+            for x in 0..width {
+                let color = image.get_pixel(x, 0);
+                atlas_image.put_pixel(allocation.rectangle.min.x + x, allocation.rectangle.min.y - 1, *color);
+            }
+
+            // Bottom padding
+            for x in 0..width {
+                let color = image.get_pixel(x, height - 1);
+                atlas_image.put_pixel(allocation.rectangle.min.x + x, allocation.rectangle.max.y, *color);
+            }
+
+            // Left padding
+            for y in 0..height {
+                let color = image.get_pixel(0, y);
+                atlas_image.put_pixel(allocation.rectangle.min.x - 1, allocation.rectangle.min.y + y, *color);
+            }
+
+            // Right padding
+            for y in 0..height {
+                let color = image.get_pixel(width - 1, y);
+                atlas_image.put_pixel(allocation.rectangle.max.x, allocation.rectangle.min.y + y, *color);
+            }
+
+            // Corner padding
+            let top_left = image.get_pixel(0, 0);
+            let top_right = image.get_pixel(width - 1, 0);
+            let bottom_left = image.get_pixel(0, height - 1);
+            let bottom_right = image.get_pixel(width - 1, height - 1);
+
+            atlas_image.put_pixel(allocation.rectangle.min.x - 1, allocation.rectangle.min.y - 1, *top_left);
+            atlas_image.put_pixel(allocation.rectangle.max.x, allocation.rectangle.min.y - 1, *top_right);
+            atlas_image.put_pixel(allocation.rectangle.min.x - 1, allocation.rectangle.max.y, *bottom_left);
+            atlas_image.put_pixel(allocation.rectangle.max.x, allocation.rectangle.max.y, *bottom_right);
+        }
+    }
+}
+
+fn subdivide_rectangle(free_rect: Rectangle, used_rect: Rectangle) -> Vec<Rectangle> {
+    let mut result = Vec::new();
+
+    // Rectangle on the right side of used_rect.
+    if free_rect.max.x > used_rect.max.x {
+        result.push(Rectangle::new(Vector2::new(used_rect.max.x, free_rect.min.y), free_rect.max));
+    }
+
+    // Rectangle below used_rect.
+    if free_rect.max.y > used_rect.max.y {
+        result.push(Rectangle::new(
+            Vector2::new(free_rect.min.x, used_rect.max.y),
+            Vector2::new(free_rect.max.x, free_rect.max.y),
+        ));
+    }
+
+    // Rectangle on the left side of used_rect.
+    if free_rect.min.x < used_rect.min.x {
+        result.push(Rectangle::new(free_rect.min, Vector2::new(used_rect.min.x, free_rect.max.y)));
+    }
+
+    // Rectangle above used_rect.
+    if free_rect.min.y < used_rect.min.y {
+        result.push(Rectangle::new(free_rect.min, Vector2::new(free_rect.max.x, used_rect.min.y)));
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use image::{Rgba, RgbaImage};
+
+    use super::*;
+
+    #[test]
+    fn test_allocate_single_rectangle() {
+        let mut atlas = TextureAtlas::new(false);
+
+        let image = RgbaImage::new(100, 100);
+        let id = atlas.register_image(image);
+        atlas.build_atlas();
+
+        let allocation = atlas.get_allocation(id);
+        assert!(allocation.is_some());
+
+        let alloc = allocation.unwrap();
+        assert_eq!(alloc.rectangle.width(), 100);
+        assert_eq!(alloc.rectangle.height(), 100);
+    }
+
+    #[test]
+    fn test_multiple_allocations() {
+        let mut atlas = TextureAtlas::new(false);
+        let id1 = atlas.register_image(RgbaImage::new(100, 100));
+        let id2 = atlas.register_image(RgbaImage::new(200, 200));
+        let id3 = atlas.register_image(RgbaImage::new(300, 300));
+        atlas.build_atlas();
+
+        let allocation1 = atlas.get_allocation(id1).unwrap();
+        let allocation2 = atlas.get_allocation(id2).unwrap();
+        let allocation3 = atlas.get_allocation(id3).unwrap();
+
+        assert_eq!(allocation1.rectangle.width(), 100);
+        assert_eq!(allocation1.rectangle.height(), 100);
+        assert_eq!(allocation2.rectangle.width(), 200);
+        assert_eq!(allocation2.rectangle.height(), 200);
+        assert_eq!(allocation3.rectangle.width(), 300);
+        assert_eq!(allocation3.rectangle.height(), 300);
+    }
+
+    #[test]
+    fn test_no_rectangle_overlap() {
+        let mut atlas = TextureAtlas::new(false);
+        let mut ids = Vec::new();
+
+        for _ in 0..10 {
+            ids.push(atlas.register_image(RgbaImage::new(100, 100)));
+        }
+
+        atlas.build_atlas();
+
+        let allocations: Vec<_> = ids.iter().map(|&id| atlas.get_allocation(id).unwrap()).collect();
+
+        for (i, alloc1) in allocations.iter().enumerate() {
+            for (j, alloc2) in allocations.iter().enumerate() {
+                if i != j {
+                    assert!(
+                        !alloc1.rectangle.overlaps(alloc2.rectangle),
+                        "Overlap detected between rectangle {} and rectangle {}",
+                        i,
+                        j
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_no_rectangle_overlap_varied_sizes() {
+        let mut atlas = TextureAtlas::new(false);
+        let sizes = [(50, 50), (200, 200), (100, 100), (300, 100), (100, 300), (25, 25), (400, 400)];
+
+        let mut ids = Vec::new();
+        for &(width, height) in sizes.iter() {
+            ids.push(atlas.register_image(RgbaImage::new(width, height)));
+        }
+
+        for _ in 0..20 {
+            ids.push(atlas.register_image(RgbaImage::new(10, 10)));
+        }
+
+        atlas.build_atlas();
+
+        let allocations: Vec<_> = ids.iter().map(|&id| atlas.get_allocation(id).unwrap()).collect();
+
+        for (i, alloc1) in allocations.iter().enumerate() {
+            for (j, alloc2) in allocations.iter().enumerate() {
+                if i != j {
+                    assert!(
+                        !alloc1.rectangle.overlaps(alloc2.rectangle),
+                        "Overlap detected between rectangle {} ({:?}) and rectangle {} ({:?})",
+                        i,
+                        alloc1.rectangle,
+                        j,
+                        alloc2.rectangle
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_atlas_with_padding() {
+        let mut atlas = TextureAtlas::new(true);
+        let image = RgbaImage::from_pixel(10, 10, Rgba([255, 0, 0, 255]));
+        let id = atlas.register_image(image);
+        atlas.build_atlas();
+        let allocation = atlas.get_allocation(id).unwrap();
+
+        assert_eq!(allocation.rectangle.width(), 10);
+        assert_eq!(allocation.rectangle.height(), 10);
+
+        let atlas_image = atlas.get_atlas();
+
+        let top_padding = atlas_image.get_pixel(allocation.rectangle.min.x, allocation.rectangle.min.y - 1);
+        let bottom_padding = atlas_image.get_pixel(allocation.rectangle.min.x, allocation.rectangle.max.y);
+        let left_padding = atlas_image.get_pixel(allocation.rectangle.min.x - 1, allocation.rectangle.min.y);
+        let right_padding = atlas_image.get_pixel(allocation.rectangle.max.x, allocation.rectangle.min.y);
+
+        assert_eq!(*top_padding, Rgba([255, 0, 0, 255]));
+        assert_eq!(*bottom_padding, Rgba([255, 0, 0, 255]));
+        assert_eq!(*left_padding, Rgba([255, 0, 0, 255]));
+        assert_eq!(*right_padding, Rgba([255, 0, 0, 255]));
+    }
+}


### PR DESCRIPTION
I initially created this for Metal and limited backends, but it seems a good optimization non the less. So it's right now used for all code paths, which should keep the codebase simpler and easier to maintain.

I initially used dynamic uniform buffers in for the model drawer, but in the end didn't needed to do that. I still include the "DynamicUniformBuffer" struct, since it cleans up some other code and might be helpful for future features.

I sepperated "AttachmentTexture" and "Textures", to make clear that they are different things. Textures now have their own bind group, which should help later with Metal and limited backends.