### PR TITLE
Make MSAA configurable

### DIFF
--- a/korangar/src/graphics/graphic_settings.rs
+++ b/korangar/src/graphics/graphic_settings.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Display, Formatter};
+
 #[cfg(feature = "debug")]
 use korangar_debug::logging::{print_debug, Colorize};
 use ron::ser::PrettyConfig;
@@ -44,12 +46,63 @@ impl ShadowDetail {
     }
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum Msaa {
+    Off,
+    X2,
+    X4,
+    X8,
+    X16,
+}
+
+impl Display for Msaa {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Msaa::Off => "Off".fmt(f),
+            Msaa::X2 => "x2".fmt(f),
+            Msaa::X4 => "x4".fmt(f),
+            Msaa::X8 => "x8".fmt(f),
+            Msaa::X16 => "x16".fmt(f),
+        }
+    }
+}
+
+impl From<u32> for Msaa {
+    fn from(value: u32) -> Self {
+        match value {
+            1 => Msaa::Off,
+            2 => Msaa::X2,
+            4 => Msaa::X4,
+            8 => Msaa::X8,
+            16 => Msaa::X16,
+            _ => panic!("Unknown sample count"),
+        }
+    }
+}
+
+impl Msaa {
+    pub fn sample_count(self) -> u32 {
+        match self {
+            Msaa::Off => 1,
+            Msaa::X2 => 2,
+            Msaa::X4 => 4,
+            Msaa::X8 => 8,
+            Msaa::X16 => 16,
+        }
+    }
+
+    pub fn multisampling_activated(self) -> bool {
+        self != Msaa::Off
+    }
+}
+
 #[derive(Serialize, Deserialize)]
 pub struct GraphicsSettings {
     pub vsync: bool,
     pub limit_framerate: LimitFramerate,
     pub triple_buffering: bool,
     pub texture_filtering: TextureSamplerType,
+    pub msaa: Msaa,
     pub shadow_detail: ShadowDetail,
 }
 
@@ -60,6 +113,7 @@ impl Default for GraphicsSettings {
             limit_framerate: LimitFramerate::Unlimited,
             triple_buffering: true,
             texture_filtering: TextureSamplerType::Linear,
+            msaa: Msaa::X4,
             shadow_detail: ShadowDetail::High,
         }
     }

--- a/korangar/src/graphics/passes/forward/aabb.rs
+++ b/korangar/src/graphics/passes/forward/aabb.rs
@@ -48,7 +48,7 @@ impl Drawer<{ BindGroupCount::Two }, { ColorAttachmentCount::One }, { DepthAttac
         _capabilities: &Capabilities,
         device: &Device,
         queue: &Queue,
-        _global_context: &GlobalContext,
+        global_context: &GlobalContext,
         render_pass_context: &Self::Context,
     ) -> Self {
         let shader_module = device.create_shader_module(SHADER);
@@ -150,7 +150,7 @@ impl Drawer<{ BindGroupCount::Two }, { ColorAttachmentCount::One }, { DepthAttac
                 bias: DepthBiasState::default(),
             }),
             multisample: MultisampleState {
-                count: 4,
+                count: global_context.msaa.sample_count(),
                 ..Default::default()
             },
             cache: None,

--- a/korangar/src/graphics/passes/forward/buffer.rs
+++ b/korangar/src/graphics/passes/forward/buffer.rs
@@ -79,7 +79,7 @@ impl Drawer<{ BindGroupCount::Two }, { ColorAttachmentCount::One }, { DepthAttac
             }),
             primitive: PrimitiveState::default(),
             multisample: MultisampleState {
-                count: 4,
+                count: global_context.msaa.sample_count(),
                 ..Default::default()
             },
             depth_stencil: Some(DepthStencilState {

--- a/korangar/src/graphics/passes/forward/circle.rs
+++ b/korangar/src/graphics/passes/forward/circle.rs
@@ -44,7 +44,7 @@ impl Drawer<{ BindGroupCount::Two }, { ColorAttachmentCount::One }, { DepthAttac
         _capabilities: &Capabilities,
         device: &Device,
         _queue: &Queue,
-        _global_context: &GlobalContext,
+        global_context: &GlobalContext,
         render_pass_context: &Self::Context,
     ) -> Self {
         let shader_module = device.create_shader_module(SHADER);
@@ -108,7 +108,7 @@ impl Drawer<{ BindGroupCount::Two }, { ColorAttachmentCount::One }, { DepthAttac
                 bias: DepthBiasState::default(),
             }),
             multisample: MultisampleState {
-                count: 4,
+                count: global_context.msaa.sample_count(),
                 ..Default::default()
             },
             multiview: None,

--- a/korangar/src/graphics/passes/forward/entity.rs
+++ b/korangar/src/graphics/passes/forward/entity.rs
@@ -169,7 +169,7 @@ impl Drawer<{ BindGroupCount::Two }, { ColorAttachmentCount::One }, { DepthAttac
                 ..Default::default()
             },
             multisample: MultisampleState {
-                count: 4,
+                count: global_context.msaa.sample_count(),
                 ..Default::default()
             },
             depth_stencil: Some(DepthStencilState {

--- a/korangar/src/graphics/passes/forward/indicator.rs
+++ b/korangar/src/graphics/passes/forward/indicator.rs
@@ -90,7 +90,7 @@ impl Drawer<{ BindGroupCount::Two }, { ColorAttachmentCount::One }, { DepthAttac
                 ..Default::default()
             },
             multisample: MultisampleState {
-                count: 4,
+                count: global_context.msaa.sample_count(),
                 ..Default::default()
             },
             depth_stencil: Some(DepthStencilState {

--- a/korangar/src/graphics/passes/forward/model.rs
+++ b/korangar/src/graphics/passes/forward/model.rs
@@ -15,7 +15,7 @@ use crate::graphics::passes::forward::ForwardRenderPassContext;
 use crate::graphics::passes::{
     BindGroupCount, ColorAttachmentCount, DepthAttachmentCount, DrawIndirectArgs, Drawer, ModelBatchDrawData, RenderPassContext,
 };
-use crate::graphics::{Buffer, Capabilities, GlobalContext, ModelVertex, Prepare, RenderInstruction, Texture};
+use crate::graphics::{Buffer, Capabilities, GlobalContext, ModelVertex, Msaa, Prepare, RenderInstruction, Texture};
 
 const SHADER: ShaderModuleDescriptor = include_wgsl!("shader/model.wgsl");
 #[cfg(feature = "debug")]
@@ -53,7 +53,7 @@ impl Drawer<{ BindGroupCount::Two }, { ColorAttachmentCount::One }, { DepthAttac
         capabilities: &Capabilities,
         device: &Device,
         _queue: &Queue,
-        _global_context: &GlobalContext,
+        global_context: &GlobalContext,
         render_pass_context: &Self::Context,
     ) -> Self {
         let shader_module = device.create_shader_module(SHADER);
@@ -126,6 +126,7 @@ impl Drawer<{ BindGroupCount::Two }, { ColorAttachmentCount::One }, { DepthAttac
             Self::create_pipeline(
                 device,
                 render_pass_context,
+                global_context.msaa,
                 &shader_module_wireframe,
                 instance_index_buffer_layout.clone(),
                 &pipeline_layout,
@@ -135,6 +136,7 @@ impl Drawer<{ BindGroupCount::Two }, { ColorAttachmentCount::One }, { DepthAttac
             Self::create_pipeline(
                 device,
                 render_pass_context,
+                global_context.msaa,
                 &shader_module_wireframe,
                 instance_index_buffer_layout.clone(),
                 &pipeline_layout,
@@ -145,6 +147,7 @@ impl Drawer<{ BindGroupCount::Two }, { ColorAttachmentCount::One }, { DepthAttac
         let pipeline = Self::create_pipeline(
             device,
             render_pass_context,
+            global_context.msaa,
             &shader_module,
             instance_index_buffer_layout,
             &pipeline_layout,
@@ -281,6 +284,7 @@ impl ForwardModelDrawer {
     fn create_pipeline(
         device: &Device,
         render_pass_context: &ForwardRenderPassContext,
+        msaa: Msaa,
         shader_module: &ShaderModule,
         instance_index_buffer_layout: VertexBufferLayout,
         pipeline_layout: &PipelineLayout,
@@ -313,7 +317,7 @@ impl ForwardModelDrawer {
                 ..Default::default()
             },
             multisample: MultisampleState {
-                count: 4,
+                count: msaa.sample_count(),
                 ..Default::default()
             },
             depth_stencil: Some(DepthStencilState {

--- a/korangar/src/graphics/passes/forward/overlay.rs
+++ b/korangar/src/graphics/passes/forward/overlay.rs
@@ -23,7 +23,7 @@ impl Drawer<{ BindGroupCount::Two }, { ColorAttachmentCount::One }, { DepthAttac
         _capabilities: &Capabilities,
         device: &Device,
         _queue: &Queue,
-        _global_context: &GlobalContext,
+        global_context: &GlobalContext,
         render_pass_context: &Self::Context,
     ) -> Self {
         let shader_module = device.create_shader_module(SHADER);
@@ -64,7 +64,7 @@ impl Drawer<{ BindGroupCount::Two }, { ColorAttachmentCount::One }, { DepthAttac
                 bias: DepthBiasState::default(),
             }),
             multisample: MultisampleState {
-                count: 4,
+                count: global_context.msaa.sample_count(),
                 ..Default::default()
             },
             multiview: None,

--- a/korangar/src/graphics/passes/forward/rectangle.rs
+++ b/korangar/src/graphics/passes/forward/rectangle.rs
@@ -182,7 +182,7 @@ impl Drawer<{ BindGroupCount::Two }, { ColorAttachmentCount::One }, { DepthAttac
             multiview: None,
             primitive: PrimitiveState::default(),
             multisample: MultisampleState {
-                count: 4,
+                count: global_context.msaa.sample_count(),
                 ..Default::default()
             },
             depth_stencil: Some(DepthStencilState {

--- a/korangar/src/graphics/passes/forward/shader/overlay.wgsl
+++ b/korangar/src/graphics/passes/forward/shader/overlay.wgsl
@@ -11,6 +11,7 @@ fn vs_main(@builtin(vertex_index) vertex_index: u32) -> @builtin(position) vec4<
 fn fs_main(@builtin(position) position: vec4<f32>) -> @location(0) vec4<f32> {
     let pixel_coord = vec2<i32>(position.xy);
     var blended = vec4<f32>(0.0);
+
     for (var sample_id: i32 = 0; sample_id < 4; sample_id++) {
         blended += textureLoad(interface_buffer, pixel_coord, sample_id);
     }

--- a/korangar/src/graphics/passes/forward/water.rs
+++ b/korangar/src/graphics/passes/forward/water.rs
@@ -24,7 +24,7 @@ impl Drawer<{ BindGroupCount::Two }, { ColorAttachmentCount::One }, { DepthAttac
         _capabilities: &Capabilities,
         device: &Device,
         _queue: &Queue,
-        _global_context: &GlobalContext,
+        global_context: &GlobalContext,
         render_pass_context: &Self::Context,
     ) -> Self {
         let shader_module = device.create_shader_module(SHADER);
@@ -57,7 +57,7 @@ impl Drawer<{ BindGroupCount::Two }, { ColorAttachmentCount::One }, { DepthAttac
             multiview: None,
             primitive: PrimitiveState::default(),
             multisample: MultisampleState {
-                count: 4,
+                count: global_context.msaa.sample_count(),
                 ..Default::default()
             },
             depth_stencil: Some(DepthStencilState {

--- a/korangar/src/graphics/passes/interface/rectangle.rs
+++ b/korangar/src/graphics/passes/interface/rectangle.rs
@@ -192,6 +192,9 @@ impl Drawer<{ BindGroupCount::One }, { ColorAttachmentCount::One }, { DepthAttac
             multiview: None,
             primitive: Default::default(),
             multisample: MultisampleState {
+                // We render the interface always with 4x MSAA.
+                // This makes sure to remove hard edges in the GUI elements.
+                // 4x MSAA is guaranteed by WebGPU spec to be available.
                 count: 4,
                 ..Default::default()
             },

--- a/korangar/src/interface/windows/settings/graphics.rs
+++ b/korangar/src/interface/windows/settings/graphics.rs
@@ -3,64 +3,73 @@ use korangar_interface::state::{TrackedState, TrackedStateBinary};
 use korangar_interface::windows::{PrototypeWindow, Window, WindowBuilder};
 use korangar_interface::{dimension_bound, size_bound};
 
-use crate::graphics::{LimitFramerate, PresentModeInfo, ShadowDetail, TextureSamplerType};
+use crate::graphics::{LimitFramerate, Msaa, PresentModeInfo, ShadowDetail, TextureSamplerType};
 use crate::interface::application::InterfaceSettings;
 use crate::interface::layout::ScreenSize;
 use crate::interface::windows::WindowCache;
 
-pub struct GraphicsSettingsWindow<Vsync, FramerateLimit, TripleBuffering, TextureFiltering, Shadow>
+pub struct GraphicsSettingsWindow<Vsync, FramerateLimit, TripleBuffering, TextureFiltering, Multisampling, Shadow>
 where
     Vsync: TrackedStateBinary<bool>,
     FramerateLimit: TrackedState<LimitFramerate> + 'static,
     TripleBuffering: TrackedStateBinary<bool>,
     TextureFiltering: TrackedState<TextureSamplerType> + 'static,
+    Multisampling: TrackedState<Msaa> + 'static,
     Shadow: TrackedState<ShadowDetail> + 'static,
 {
     present_mode_info: PresentModeInfo,
+    supported_msaa: Vec<(String, Msaa)>,
     vsync: Vsync,
     limit_framerate: FramerateLimit,
     triple_buffering: TripleBuffering,
     texture_filtering: TextureFiltering,
+    msaa: Multisampling,
     shadow_detail: Shadow,
 }
 
-impl<Vsync, FramerateLimit, TripleBuffering, TextureFiltering, Shadow>
-    GraphicsSettingsWindow<Vsync, FramerateLimit, TripleBuffering, TextureFiltering, Shadow>
+impl<Vsync, FramerateLimit, TripleBuffering, TextureFiltering, Multisampling, Shadow>
+    GraphicsSettingsWindow<Vsync, FramerateLimit, TripleBuffering, TextureFiltering, Multisampling, Shadow>
 where
     Vsync: TrackedStateBinary<bool>,
     FramerateLimit: TrackedState<LimitFramerate> + 'static,
     TripleBuffering: TrackedStateBinary<bool>,
     TextureFiltering: TrackedState<TextureSamplerType> + 'static,
+    Multisampling: TrackedState<Msaa> + 'static,
     Shadow: TrackedState<ShadowDetail> + 'static,
 {
     pub const WINDOW_CLASS: &'static str = "graphics_settings";
 
     pub fn new(
         present_mode_info: PresentModeInfo,
+        supported_msaa: Vec<(String, Msaa)>,
         vsync: Vsync,
         limit_framerate: FramerateLimit,
         triple_buffering: TripleBuffering,
         texture_filtering: TextureFiltering,
+        msaa: Multisampling,
         shadow_detail: Shadow,
     ) -> Self {
         Self {
             present_mode_info,
+            supported_msaa,
             vsync,
             limit_framerate,
             triple_buffering,
             texture_filtering,
+            msaa,
             shadow_detail,
         }
     }
 }
 
-impl<Vsync, FramerateLimit, TripleBuffering, TextureFiltering, Shadow> PrototypeWindow<InterfaceSettings>
-    for GraphicsSettingsWindow<Vsync, FramerateLimit, TripleBuffering, TextureFiltering, Shadow>
+impl<Vsync, FramerateLimit, TripleBuffering, TextureFiltering, Multisampling, Shadow> PrototypeWindow<InterfaceSettings>
+    for GraphicsSettingsWindow<Vsync, FramerateLimit, TripleBuffering, TextureFiltering, Multisampling, Shadow>
 where
     Vsync: TrackedStateBinary<bool>,
     FramerateLimit: TrackedState<LimitFramerate> + 'static,
     TripleBuffering: TrackedStateBinary<bool>,
     TextureFiltering: TrackedState<TextureSamplerType> + 'static,
+    Multisampling: TrackedState<Msaa> + 'static,
     Shadow: TrackedState<ShadowDetail> + 'static,
 {
     fn window_class(&self) -> Option<&str> {
@@ -93,6 +102,13 @@ where
                     ("Anisotropic x16", TextureSamplerType::Anisotropic(16)),
                 ])
                 .with_selected(self.texture_filtering.clone())
+                .with_event(Box::new(Vec::new))
+                .with_width(dimension_bound!(!))
+                .wrap(),
+            Text::default().with_text("MSAA").with_width(dimension_bound!(50%)).wrap(),
+            PickList::default()
+                .with_options(self.supported_msaa.clone())
+                .with_selected(self.msaa.clone())
                 .with_event(Box::new(Vec::new))
                 .with_width(dimension_bound!(!))
                 .wrap(),


### PR DESCRIPTION
THe interface is always rendered with 4x MSAA, since otherwise the it looks pretty rough. 4x MSAA guranteed to be supported by WebGPU specs.