### PR TITLE
Seperate forward and postprocessing

### DIFF
--- a/korangar/src/graphics/passes/forward/mod.rs
+++ b/korangar/src/graphics/passes/forward/mod.rs
@@ -1,29 +1,19 @@
 #[cfg(feature = "debug")]
 mod aabb;
 #[cfg(feature = "debug")]
-mod buffer;
-#[cfg(feature = "debug")]
 mod circle;
-mod effect;
 mod entity;
 mod indicator;
 mod model;
-mod overlay;
-mod rectangle;
 mod water;
 
 #[cfg(feature = "debug")]
 pub(crate) use aabb::ForwardAabbDrawer;
 #[cfg(feature = "debug")]
-pub(crate) use buffer::ForwardBufferDrawer;
-#[cfg(feature = "debug")]
 pub(crate) use circle::ForwardCircleDrawer;
-pub(crate) use effect::ForwardEffectDrawer;
 pub(crate) use entity::ForwardEntityDrawer;
 pub(crate) use indicator::ForwardIndicatorDrawer;
 pub(crate) use model::ForwardModelDrawer;
-pub(crate) use overlay::ForwardOverlayDrawer;
-pub(crate) use rectangle::{ForwardRectangleDrawInstruction, ForwardRectangleDrawer, ForwardRectangleLayer};
 pub(crate) use water::ForwardWaterDrawer;
 use wgpu::{
     BindGroupLayout, Color, CommandEncoder, Device, LoadOp, Operations, Queue, RenderPass, RenderPassColorAttachment,
@@ -55,33 +45,21 @@ impl RenderPassContext<{ BindGroupCount::Two }, { ColorAttachmentCount::One }, {
 
     fn create_pass<'encoder>(
         &mut self,
-        frame_view: &TextureView,
+        _frame_view: &TextureView,
         encoder: &'encoder mut CommandEncoder,
         global_context: &GlobalContext,
         _pass_data: Option<()>,
     ) -> RenderPass<'encoder> {
-        let color_attachment = match global_context.forward_multisample_texture.as_ref() {
-            Some(attachment) => RenderPassColorAttachment {
-                view: attachment.get_texture_view(),
-                resolve_target: Some(frame_view),
-                ops: Operations {
-                    load: LoadOp::Clear(Color::BLACK),
-                    store: StoreOp::Store,
-                },
-            },
-            None => RenderPassColorAttachment {
-                view: frame_view,
+        let mut pass = encoder.begin_render_pass(&RenderPassDescriptor {
+            label: Some(PASS_NAME),
+            color_attachments: &[Some(RenderPassColorAttachment {
+                view: global_context.forward_color_texture.get_texture_view(),
                 resolve_target: None,
                 ops: Operations {
                     load: LoadOp::Clear(Color::BLACK),
                     store: StoreOp::Store,
                 },
-            },
-        };
-
-        let mut pass = encoder.begin_render_pass(&RenderPassDescriptor {
-            label: Some(PASS_NAME),
-            color_attachments: &[Some(color_attachment)],
+            })],
             depth_stencil_attachment: Some(RenderPassDepthStencilAttachment {
                 view: global_context.forward_depth_texture.get_texture_view(),
                 depth_ops: Some(Operations {

--- a/korangar/src/graphics/passes/mod.rs
+++ b/korangar/src/graphics/passes/mod.rs
@@ -4,6 +4,7 @@ mod interface;
 mod light_culling;
 mod picker;
 mod point_shadow;
+mod postprocessing;
 
 use std::marker::ConstParamTy;
 
@@ -14,6 +15,7 @@ pub(crate) use interface::*;
 pub(crate) use light_culling::*;
 pub(crate) use picker::*;
 pub(crate) use point_shadow::*;
+pub(crate) use postprocessing::*;
 use wgpu::{BindGroupLayout, CommandEncoder, ComputePass, Device, Queue, RenderPass, TextureFormat, TextureView};
 
 use crate::graphics::{Capabilities, GlobalContext, ModelBatch, ModelInstruction};

--- a/korangar/src/graphics/passes/postprocessing/blitter.rs
+++ b/korangar/src/graphics/passes/postprocessing/blitter.rs
@@ -1,0 +1,141 @@
+use std::collections::HashMap;
+
+use wgpu::{
+    include_wgsl, BindGroupLayout, BlendState, ColorTargetState, ColorWrites, Device, FragmentState, MultisampleState,
+    PipelineCompilationOptions, PipelineLayoutDescriptor, PrimitiveState, Queue, RenderPass, RenderPipeline, RenderPipelineDescriptor,
+    ShaderModule, ShaderModuleDescriptor, TextureSampleType, VertexState,
+};
+
+use crate::graphics::passes::{
+    BindGroupCount, ColorAttachmentCount, DepthAttachmentCount, Drawer, PostProcessingRenderPassContext, RenderPassContext,
+};
+use crate::graphics::{AttachmentTexture, Capabilities, GlobalContext, Msaa};
+
+const SHADER: ShaderModuleDescriptor = include_wgsl!("shader/blitter.wgsl");
+const SHADER_MSAA: ShaderModuleDescriptor = include_wgsl!("shader/blitter_msaa.wgsl");
+const DRAWER_NAME: &str = "post processing blitter";
+
+pub(crate) struct PostProcessingBlitterDrawer {
+    pipeline_x1: RenderPipeline,
+    pipeline_x2: RenderPipeline,
+    pipeline_x4: RenderPipeline,
+    pipeline_x8: RenderPipeline,
+    pipeline_x16: RenderPipeline,
+}
+
+impl Drawer<{ BindGroupCount::One }, { ColorAttachmentCount::One }, { DepthAttachmentCount::None }> for PostProcessingBlitterDrawer {
+    type Context = PostProcessingRenderPassContext;
+    type DrawData<'data> = &'data AttachmentTexture;
+
+    fn new(
+        _capabilities: &Capabilities,
+        device: &Device,
+        _queue: &Queue,
+        _global_context: &GlobalContext,
+        render_pass_context: &Self::Context,
+    ) -> Self {
+        let shader_module = device.create_shader_module(SHADER);
+        let msaa_module = device.create_shader_module(SHADER_MSAA);
+
+        let pass_bind_group_layouts = Self::Context::bind_group_layout(device);
+
+        let pipeline_x1 = Self::create_pipeline(device, render_pass_context, &shader_module, &pass_bind_group_layouts, Msaa::Off);
+        let pipeline_x2 = Self::create_pipeline(device, render_pass_context, &msaa_module, &pass_bind_group_layouts, Msaa::X2);
+        let pipeline_x4 = Self::create_pipeline(device, render_pass_context, &msaa_module, &pass_bind_group_layouts, Msaa::X4);
+        let pipeline_x8 = Self::create_pipeline(device, render_pass_context, &msaa_module, &pass_bind_group_layouts, Msaa::X8);
+        let pipeline_x16 = Self::create_pipeline(device, render_pass_context, &msaa_module, &pass_bind_group_layouts, Msaa::X16);
+
+        Self {
+            pipeline_x1,
+            pipeline_x2,
+            pipeline_x4,
+            pipeline_x8,
+            pipeline_x16,
+        }
+    }
+
+    fn draw(&mut self, pass: &mut RenderPass<'_>, draw_data: Self::DrawData<'_>) {
+        match draw_data.get_texture().sample_count() {
+            1 => {
+                pass.set_pipeline(&self.pipeline_x1);
+            }
+            2 => {
+                pass.set_pipeline(&self.pipeline_x2);
+            }
+            4 => {
+                pass.set_pipeline(&self.pipeline_x4);
+            }
+            8 => {
+                pass.set_pipeline(&self.pipeline_x8);
+            }
+            16 => {
+                pass.set_pipeline(&self.pipeline_x16);
+            }
+            sample_count => panic!("Unsupported sample count: {sample_count}"),
+        }
+
+        pass.set_bind_group(1, draw_data.get_bind_group(), &[]);
+        pass.draw(0..3, 0..1);
+    }
+}
+
+impl PostProcessingBlitterDrawer {
+    fn create_pipeline(
+        device: &Device,
+        render_pass_context: &PostProcessingRenderPassContext,
+        shader_module: &ShaderModule,
+        pass_bind_group_layouts: &[&BindGroupLayout; 1],
+        msaa: Msaa,
+    ) -> RenderPipeline {
+        let label = format!("{DRAWER_NAME} {msaa}");
+
+        let texture_bind_group_layout = AttachmentTexture::bind_group_layout(
+            device,
+            TextureSampleType::Float {
+                filterable: !msaa.multisampling_activated(),
+            },
+            msaa.multisampling_activated(),
+        );
+
+        let pipeline_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
+            label: Some(&label),
+            bind_group_layouts: &[pass_bind_group_layouts[0], &texture_bind_group_layout],
+            push_constant_ranges: &[],
+        });
+
+        let mut constants = HashMap::new();
+        constants.insert("SAMPLE_COUNT".to_string(), f64::from(msaa.sample_count()));
+
+        device.create_render_pipeline(&RenderPipelineDescriptor {
+            label: Some(&label),
+            layout: Some(&pipeline_layout),
+            vertex: VertexState {
+                module: shader_module,
+                entry_point: Some("vs_main"),
+                compilation_options: PipelineCompilationOptions {
+                    constants: &constants,
+                    ..Default::default()
+                },
+                buffers: &[],
+            },
+            fragment: Some(FragmentState {
+                module: shader_module,
+                entry_point: Some("fs_main"),
+                compilation_options: PipelineCompilationOptions {
+                    constants: &constants,
+                    ..Default::default()
+                },
+                targets: &[Some(ColorTargetState {
+                    format: render_pass_context.color_attachment_formats()[0],
+                    blend: Some(BlendState::ALPHA_BLENDING),
+                    write_mask: ColorWrites::default(),
+                })],
+            }),
+            primitive: PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        })
+    }
+}

--- a/korangar/src/graphics/passes/postprocessing/mod.rs
+++ b/korangar/src/graphics/passes/postprocessing/mod.rs
@@ -1,0 +1,73 @@
+mod blitter;
+#[cfg(feature = "debug")]
+mod buffer;
+mod effect;
+mod rectangle;
+
+pub(crate) use blitter::PostProcessingBlitterDrawer;
+#[cfg(feature = "debug")]
+pub(crate) use buffer::{PostProcessingBufferDrawData, PostProcessingBufferDrawer};
+pub(crate) use effect::PostProcessingEffectDrawer;
+pub(crate) use rectangle::{PostProcessingRectangleDrawInstruction, PostProcessingRectangleDrawer, PostProcessingRectangleLayer};
+use wgpu::{
+    BindGroupLayout, Color, CommandEncoder, Device, LoadOp, Operations, Queue, RenderPass, RenderPassColorAttachment, RenderPassDescriptor,
+    StoreOp, TextureFormat, TextureView,
+};
+
+use super::{BindGroupCount, ColorAttachmentCount, DepthAttachmentCount, RenderPassContext};
+use crate::graphics::GlobalContext;
+use crate::loaders::TextureLoader;
+const PASS_NAME: &str = "post processing render pass";
+
+pub(crate) struct PostProcessingRenderPassContext {
+    surface_texture_format: TextureFormat,
+}
+
+impl RenderPassContext<{ BindGroupCount::One }, { ColorAttachmentCount::One }, { DepthAttachmentCount::None }>
+    for PostProcessingRenderPassContext
+{
+    type PassData<'data> = Option<()>;
+
+    fn new(_device: &Device, _queue: &Queue, _texture_loader: &TextureLoader, global_context: &GlobalContext) -> Self {
+        let surface_texture_format = global_context.surface_texture_format;
+        Self { surface_texture_format }
+    }
+
+    fn create_pass<'encoder>(
+        &mut self,
+        frame_view: &TextureView,
+        encoder: &'encoder mut CommandEncoder,
+        global_context: &GlobalContext,
+        _pass_data: Option<()>,
+    ) -> RenderPass<'encoder> {
+        let mut pass = encoder.begin_render_pass(&RenderPassDescriptor {
+            label: Some(PASS_NAME),
+            color_attachments: &[Some(RenderPassColorAttachment {
+                view: frame_view,
+                resolve_target: None,
+                ops: Operations {
+                    load: LoadOp::Clear(Color::BLACK),
+                    store: StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+        });
+
+        pass.set_bind_group(0, &global_context.global_bind_group, &[]);
+        pass
+    }
+
+    fn bind_group_layout(device: &Device) -> [&'static BindGroupLayout; 1] {
+        [GlobalContext::global_bind_group_layout(device)]
+    }
+
+    fn color_attachment_formats(&self) -> [TextureFormat; 1] {
+        [self.surface_texture_format]
+    }
+
+    fn depth_attachment_output_format(&self) -> [TextureFormat; 0] {
+        []
+    }
+}

--- a/korangar/src/graphics/passes/postprocessing/shader/blitter.wgsl
+++ b/korangar/src/graphics/passes/postprocessing/shader/blitter.wgsl
@@ -1,4 +1,4 @@
-@group(1) @binding(6) var interface_buffer: texture_multisampled_2d<f32>;
+@group(1) @binding(0) var texture: texture_2d<f32>;
 
 @vertex
 fn vs_main(@builtin(vertex_index) vertex_index: u32) -> @builtin(position) vec4<f32> {
@@ -9,11 +9,5 @@ fn vs_main(@builtin(vertex_index) vertex_index: u32) -> @builtin(position) vec4<
 
 @fragment
 fn fs_main(@builtin(position) position: vec4<f32>) -> @location(0) vec4<f32> {
-    let pixel_coord = vec2<i32>(position.xy);
-    var blended = vec4<f32>(0.0);
-
-    for (var sample_id: i32 = 0; sample_id < 4; sample_id++) {
-        blended += textureLoad(interface_buffer, pixel_coord, sample_id);
-    }
-    return blended / 4.0;
+    return textureLoad(texture, vec2<i32>(position.xy), 0);
 }

--- a/korangar/src/graphics/passes/postprocessing/shader/blitter_msaa.wgsl
+++ b/korangar/src/graphics/passes/postprocessing/shader/blitter_msaa.wgsl
@@ -1,0 +1,21 @@
+@group(1) @binding(0) var texture: texture_multisampled_2d<f32>;
+
+override SAMPLE_COUNT: i32;
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_index: u32) -> @builtin(position) vec4<f32> {
+    // Full screen triangle.
+    let uv = vec2<f32>(f32((vertex_index << 1u) & 2u), f32(vertex_index & 2u));
+    return vec4<f32>(uv * vec2<f32>(2.0, -2.0) + vec2<f32>(-1.0, 1.0), 0.0, 1.0);
+}
+
+@fragment
+fn fs_main(@builtin(position) position: vec4<f32>) -> @location(0) vec4<f32> {
+    let pixel_coord = vec2<i32>(position.xy);
+    var blended = vec4<f32>(0.0);
+
+    for (var sample_id: i32 = 0; sample_id < SAMPLE_COUNT; sample_id++) {
+        blended += textureLoad(texture, pixel_coord, sample_id);
+    }
+    return blended / f32(SAMPLE_COUNT);
+}

--- a/korangar/src/graphics/passes/postprocessing/shader/buffer.wgsl
+++ b/korangar/src/graphics/passes/postprocessing/shader/buffer.wgsl
@@ -30,11 +30,11 @@ struct VertexOutput {
 const TILE_SIZE: u32 = 16;
 
 @group(0) @binding(1) var nearest_sampler: sampler;
-@group(1) @binding(1) var directional_shadow_map: texture_depth_2d;
+@group(1) @binding(0) var<uniform> debug_uniforms: DebugUniforms;
+@group(1) @binding(1) var picker_texture: texture_2d<u32>;
+@group(1) @binding(2) var directional_shadow_map: texture_depth_2d;
 @group(1) @binding(3) var light_count_texture: texture_2d<u32>;
-@group(1) @binding(5) var point_shadow_maps: texture_depth_cube_array;
-@group(1) @binding(7) var<uniform> debug_uniforms: DebugUniforms;
-@group(1) @binding(8) var picker_texture: texture_2d<u32>;
+@group(1) @binding(4) var point_shadow_maps: texture_depth_cube_array;
 @group(2) @binding(0) var font_atlas: texture_2d<f32>;
 
 @vertex

--- a/korangar/src/graphics/passes/postprocessing/shader/effect.wgsl
+++ b/korangar/src/graphics/passes/postprocessing/shader/effect.wgsl
@@ -14,8 +14,8 @@ struct InstanceData {
 }
 
 @group(0) @binding(2) var linear_sampler: sampler;
-@group(2) @binding(0) var<storage, read> instance_data: array<InstanceData>;
-@group(3) @binding(0) var texture: texture_2d<f32>;
+@group(1) @binding(0) var<storage, read> instance_data: array<InstanceData>;
+@group(2) @binding(0) var texture: texture_2d<f32>;
 
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,

--- a/korangar/src/graphics/passes/postprocessing/shader/effect_bindless.wgsl
+++ b/korangar/src/graphics/passes/postprocessing/shader/effect_bindless.wgsl
@@ -14,8 +14,8 @@ struct InstanceData {
 }
 
 @group(0) @binding(2) var linear_sampler: sampler;
-@group(2) @binding(0) var<storage, read> instance_data: array<InstanceData>;
-@group(2) @binding(1) var textures: binding_array<texture_2d<f32>>;
+@group(1) @binding(0) var<storage, read> instance_data: array<InstanceData>;
+@group(1) @binding(1) var textures: binding_array<texture_2d<f32>>;
 
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,

--- a/korangar/src/graphics/passes/postprocessing/shader/rectangle.wgsl
+++ b/korangar/src/graphics/passes/postprocessing/shader/rectangle.wgsl
@@ -16,8 +16,8 @@ struct VertexOutput {
 
 @group(0) @binding(1) var nearest_sampler: sampler;
 @group(0) @binding(2) var linear_sampler: sampler;
-@group(2) @binding(0) var<storage, read> instance_data: array<InstanceData>;
-@group(2) @binding(1) var textures: binding_array<texture_2d<f32>>;
+@group(1) @binding(0) var<storage, read> instance_data: array<InstanceData>;
+@group(2) @binding(0) var texture: texture_2d<f32>;
 
 @vertex
 fn vs_main(
@@ -47,9 +47,9 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     }
 
     if instance.linear_filtering == 0 {
-        return textureSample(textures[instance.texture_index], nearest_sampler, input.texture_coordinates) * instance.color;
+        return textureSample(texture, nearest_sampler, input.texture_coordinates) * instance.color;
     } else {
-        return textureSample(textures[instance.texture_index], linear_sampler, input.texture_coordinates) * instance.color;
+        return textureSample(texture, linear_sampler, input.texture_coordinates) * instance.color;
     }
 }
 

--- a/korangar/src/graphics/passes/postprocessing/shader/rectangle_bindless.wgsl
+++ b/korangar/src/graphics/passes/postprocessing/shader/rectangle_bindless.wgsl
@@ -16,8 +16,8 @@ struct VertexOutput {
 
 @group(0) @binding(1) var nearest_sampler: sampler;
 @group(0) @binding(2) var linear_sampler: sampler;
-@group(2) @binding(0) var<storage, read> instance_data: array<InstanceData>;
-@group(3) @binding(0) var texture: texture_2d<f32>;
+@group(1) @binding(0) var<storage, read> instance_data: array<InstanceData>;
+@group(1) @binding(1) var textures: binding_array<texture_2d<f32>>;
 
 @vertex
 fn vs_main(
@@ -47,9 +47,9 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     }
 
     if instance.linear_filtering == 0 {
-        return textureSample(texture, nearest_sampler, input.texture_coordinates) * instance.color;
+        return textureSample(textures[instance.texture_index], nearest_sampler, input.texture_coordinates) * instance.color;
     } else {
-        return textureSample(texture, linear_sampler, input.texture_coordinates) * instance.color;
+        return textureSample(textures[instance.texture_index], linear_sampler, input.texture_coordinates) * instance.color;
     }
 }
 

--- a/korangar/src/loaders/texture/mod.rs
+++ b/korangar/src/loaders/texture/mod.rs
@@ -127,6 +127,7 @@ pub struct TextureAtlasFactory {
 }
 
 impl TextureAtlasFactory {
+    #[cfg(feature = "debug")]
     pub fn create_from_group(
         texture_loader: Arc<TextureLoader>,
         name: impl Into<String>,


### PR DESCRIPTION
This PR is based #129.

Since we want to have post-processing effects, we need to render to texture and then composite the rest later.

This enables us to do post-processing like DoF, CMAA2, vignetting, tone-mapping etc.