### PR TITLE
Check bounds when rendering the indicator

### DIFF
--- a/korangar/src/world/map/mod.rs
+++ b/korangar/src/world/map/mod.rs
@@ -308,6 +308,13 @@ impl Map {
         const HALF_TILE_SIZE: f32 = MAP_TILE_SIZE / 2.0;
         const OFFSET: f32 = 1.0;
 
+        // Since the picker buffer is always one frame behind the current scene, a map
+        // transition can cause the picked tile to be out of bounds. To avoid a
+        // panic we ensure the coordinates are in bounds.
+        if position.x >= self.width || position.y >= self.height {
+            return;
+        }
+
         let tile = self.get_tile(position);
 
         if tile.flags.contains(TileFlags::WALKABLE) {


### PR DESCRIPTION
The crash occurs when you are transitioning from map 1 to map 2 and set your mouse position in a place that in the map 2 doesn't have a tile.
The game crashes resulting in the following error:
> index out of bounds: the len is 36000 but the index is 56465