### PR TITLE
Implement CMAA2

### DIFF
--- a/korangar/src/graphics/capabilities.rs
+++ b/korangar/src/graphics/capabilities.rs
@@ -35,7 +35,7 @@ impl Capabilities {
             #[cfg(feature = "debug")]
             polygon_mode_line: false,
             required_features: Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES,
-            required_limits: Limits::downlevel_defaults().using_resolution(adapter.limits()),
+            required_limits: Limits::default().using_resolution(adapter.limits()),
         };
 
         if capabilities.required_limits.max_texture_dimension_2d < MAX_TEXTURE_SIZE {

--- a/korangar/src/graphics/graphic_settings.rs
+++ b/korangar/src/graphics/graphic_settings.rs
@@ -100,6 +100,7 @@ impl Msaa {
 pub enum ScreenSpaceAntiAliasing {
     Off,
     Fxaa,
+    Cmaa2,
 }
 
 impl Display for ScreenSpaceAntiAliasing {
@@ -107,6 +108,7 @@ impl Display for ScreenSpaceAntiAliasing {
         match self {
             ScreenSpaceAntiAliasing::Off => "Off".fmt(f),
             ScreenSpaceAntiAliasing::Fxaa => "FXAA".fmt(f),
+            ScreenSpaceAntiAliasing::Cmaa2 => "CMAA2".fmt(f),
         }
     }
 }

--- a/korangar/src/graphics/passes/cmaa2/calculate_dispatch_args.rs
+++ b/korangar/src/graphics/passes/cmaa2/calculate_dispatch_args.rs
@@ -1,0 +1,69 @@
+use wgpu::{
+    include_wgsl, ComputePass, ComputePipeline, ComputePipelineDescriptor, Device, PipelineCompilationOptions, PipelineLayoutDescriptor,
+    Queue, ShaderModuleDescriptor,
+};
+
+use crate::graphics::passes::{BindGroupCount, Cmaa2ComputePassContext, ComputePassContext, Dispatch};
+use crate::graphics::{Capabilities, GlobalContext};
+
+const SHADER: ShaderModuleDescriptor = include_wgsl!("shader/calculate_dispatch_args.wgsl");
+const DISPATCHER_NAME: &str = "cmaa2 calculate dispatch args";
+
+#[derive(Copy, Clone)]
+pub(crate) enum Cmaa2CalculateDispatchArgsDispatchData {
+    ProcessCandidates,
+    DeferredColorApply,
+}
+
+pub(crate) struct Cmaa2CalculateDispatchArgsDispatcher {
+    pipeline: ComputePipeline,
+}
+
+impl Dispatch<{ BindGroupCount::One }> for Cmaa2CalculateDispatchArgsDispatcher {
+    type Context = Cmaa2ComputePassContext;
+    type DispatchData<'data> = Cmaa2CalculateDispatchArgsDispatchData;
+
+    fn new(
+        _capabilities: &Capabilities,
+        device: &Device,
+        _queue: &Queue,
+        _global_context: &GlobalContext,
+        _compute_pass_context: &Self::Context,
+    ) -> Self {
+        let shader_module = device.create_shader_module(SHADER);
+
+        let pass_bind_group_layouts = Self::Context::bind_group_layout(device);
+
+        let pipeline_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
+            label: Some(DISPATCHER_NAME),
+            bind_group_layouts: &[pass_bind_group_layouts[0]],
+            push_constant_ranges: &[],
+        });
+
+        let pipeline = device.create_compute_pipeline(&ComputePipelineDescriptor {
+            label: Some(DISPATCHER_NAME),
+            layout: Some(&pipeline_layout),
+            module: &shader_module,
+            entry_point: Some("cs_main"),
+            compilation_options: PipelineCompilationOptions {
+                zero_initialize_workgroup_memory: false,
+                ..Default::default()
+            },
+            cache: None,
+        });
+
+        Self { pipeline }
+    }
+
+    fn dispatch(&mut self, pass: &mut ComputePass<'_>, draw_data: Self::DispatchData<'_>) {
+        pass.set_pipeline(&self.pipeline);
+        match draw_data {
+            Cmaa2CalculateDispatchArgsDispatchData::ProcessCandidates => {
+                pass.dispatch_workgroups(2, 1, 1);
+            }
+            Cmaa2CalculateDispatchArgsDispatchData::DeferredColorApply => {
+                pass.dispatch_workgroups(1, 2, 1);
+            }
+        }
+    }
+}

--- a/korangar/src/graphics/passes/cmaa2/deferred_color_apply.rs
+++ b/korangar/src/graphics/passes/cmaa2/deferred_color_apply.rs
@@ -1,0 +1,62 @@
+use wgpu::{
+    include_wgsl, BindGroup, ComputePass, ComputePipeline, ComputePipelineDescriptor, Device, PipelineCompilationOptions,
+    PipelineLayoutDescriptor, Queue, ShaderModuleDescriptor,
+};
+
+use crate::graphics::passes::{BindGroupCount, Cmaa2ComputePassContext, ComputePassContext, Dispatch, DispatchIndirectArgs};
+use crate::graphics::{Buffer, Capabilities, GlobalContext};
+
+const SHADER_SRC: ShaderModuleDescriptor = include_wgsl!("shader/deferred_color_apply.wgsl");
+const DISPATCHER_NAME: &str = "cmaa2 deferred color apply";
+
+pub(crate) struct Cmaa2DeferredColorApplyDispatchData<'a> {
+    pub(crate) dispatch_indirect_args_buffer: &'a Buffer<DispatchIndirectArgs>,
+    pub(crate) output_bind_group: &'a BindGroup,
+}
+
+pub(crate) struct Cmaa2DeferredColorApplyDispatcher {
+    pipeline: ComputePipeline,
+}
+
+impl Dispatch<{ BindGroupCount::One }> for Cmaa2DeferredColorApplyDispatcher {
+    type Context = Cmaa2ComputePassContext;
+    type DispatchData<'data> = Cmaa2DeferredColorApplyDispatchData<'data>;
+
+    fn new(
+        _capabilities: &Capabilities,
+        device: &Device,
+        _queue: &Queue,
+        _global_context: &GlobalContext,
+        _compute_pass_context: &Self::Context,
+    ) -> Self {
+        let shader_module = device.create_shader_module(SHADER_SRC);
+
+        let pass_bind_group_layouts = Self::Context::bind_group_layout(device);
+
+        let pipeline_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
+            label: Some(DISPATCHER_NAME),
+            bind_group_layouts: &[pass_bind_group_layouts[0], GlobalContext::cmaa2_output_bind_group_layout(device)],
+            push_constant_ranges: &[],
+        });
+
+        let pipeline = device.create_compute_pipeline(&ComputePipelineDescriptor {
+            label: Some(DISPATCHER_NAME),
+            layout: Some(&pipeline_layout),
+            module: &shader_module,
+            entry_point: Some("cs_main"),
+            compilation_options: PipelineCompilationOptions {
+                zero_initialize_workgroup_memory: false,
+                ..Default::default()
+            },
+            cache: None,
+        });
+
+        Self { pipeline }
+    }
+
+    fn dispatch(&mut self, pass: &mut ComputePass<'_>, draw_data: Self::DispatchData<'_>) {
+        pass.set_pipeline(&self.pipeline);
+        pass.set_bind_group(1, draw_data.output_bind_group, &[]);
+        pass.dispatch_workgroups_indirect(draw_data.dispatch_indirect_args_buffer.get_buffer(), 0);
+    }
+}

--- a/korangar/src/graphics/passes/cmaa2/edge_colors.rs
+++ b/korangar/src/graphics/passes/cmaa2/edge_colors.rs
@@ -1,0 +1,66 @@
+use wgpu::{
+    include_wgsl, ComputePass, ComputePipeline, ComputePipelineDescriptor, Device, PipelineCompilationOptions, PipelineLayoutDescriptor,
+    Queue, ShaderModuleDescriptor, TextureSampleType,
+};
+
+use crate::graphics::passes::{BindGroupCount, Cmaa2ComputePassContext, ComputePassContext, Dispatch};
+use crate::graphics::{AttachmentTexture, Capabilities, GlobalContext};
+
+const SHADER: ShaderModuleDescriptor = include_wgsl!("shader/edge_colors.wgsl");
+const DISPATCHER_NAME: &str = "cmaa2 edge colors";
+
+const INPUT_KERNEL_SIZE_X: u32 = 16;
+const INPUT_KERNEL_SIZE_Y: u32 = 16;
+
+pub(crate) struct Cmaa2EdgeColorsDispatcher {
+    pipeline: ComputePipeline,
+}
+
+impl Dispatch<{ BindGroupCount::One }> for Cmaa2EdgeColorsDispatcher {
+    type Context = Cmaa2ComputePassContext;
+    type DispatchData<'data> = &'data AttachmentTexture;
+
+    fn new(
+        _capabilities: &Capabilities,
+        device: &Device,
+        _queue: &Queue,
+        _global_context: &GlobalContext,
+        _compute_pass_context: &Self::Context,
+    ) -> Self {
+        let shader_module = device.create_shader_module(SHADER);
+
+        let pass_bind_group_layouts = Self::Context::bind_group_layout(device);
+
+        let pipeline_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
+            label: Some(DISPATCHER_NAME),
+            bind_group_layouts: &[
+                pass_bind_group_layouts[0],
+                &AttachmentTexture::bind_group_layout(device, TextureSampleType::Float { filterable: true }, false),
+            ],
+            push_constant_ranges: &[],
+        });
+
+        let pipeline = device.create_compute_pipeline(&ComputePipelineDescriptor {
+            label: Some(DISPATCHER_NAME),
+            layout: Some(&pipeline_layout),
+            module: &shader_module,
+            entry_point: Some("cs_main"),
+            compilation_options: PipelineCompilationOptions::default(),
+            cache: None,
+        });
+
+        Self { pipeline }
+    }
+
+    fn dispatch(&mut self, pass: &mut ComputePass<'_>, draw_data: Self::DispatchData<'_>) {
+        let attachment_size = draw_data.get_unpadded_size();
+        let output_kernel_size_x = INPUT_KERNEL_SIZE_X - 2;
+        let output_kernel_size_y = INPUT_KERNEL_SIZE_Y - 2;
+        let dispatch_x = (attachment_size.width + output_kernel_size_x * 2 - 1) / (output_kernel_size_x * 2);
+        let dispatch_y = (attachment_size.height + output_kernel_size_y * 2 - 1) / (output_kernel_size_y * 2);
+
+        pass.set_pipeline(&self.pipeline);
+        pass.set_bind_group(1, draw_data.get_bind_group(), &[]);
+        pass.dispatch_workgroups(dispatch_x, dispatch_y, 1);
+    }
+}

--- a/korangar/src/graphics/passes/cmaa2/mod.rs
+++ b/korangar/src/graphics/passes/cmaa2/mod.rs
@@ -1,0 +1,49 @@
+mod calculate_dispatch_args;
+mod deferred_color_apply;
+mod edge_colors;
+mod process_candidates;
+
+pub(crate) use calculate_dispatch_args::{Cmaa2CalculateDispatchArgsDispatchData, Cmaa2CalculateDispatchArgsDispatcher};
+pub(crate) use deferred_color_apply::{Cmaa2DeferredColorApplyDispatchData, Cmaa2DeferredColorApplyDispatcher};
+pub(crate) use edge_colors::Cmaa2EdgeColorsDispatcher;
+pub(crate) use process_candidates::{Cmaa2ProcessCandidatesDispatcher, Cmaa2ProcessCandidatesDispatcherDispatchData};
+use wgpu::{BindGroupLayout, CommandEncoder, ComputePass, ComputePassDescriptor, Device, Queue};
+
+use super::{BindGroupCount, ComputePassContext};
+use crate::graphics::{AntiAliasingResource, GlobalContext};
+
+const PASS_NAME: &str = "cmaa2 compute pass";
+
+pub(crate) struct Cmaa2ComputePassContext {}
+
+impl ComputePassContext<{ BindGroupCount::One }> for Cmaa2ComputePassContext {
+    type PassData<'data> = Option<()>;
+
+    fn new(_device: &Device, _queue: &Queue, _global_context: &GlobalContext) -> Self {
+        Self {}
+    }
+
+    fn create_pass<'encoder>(
+        &mut self,
+        encoder: &'encoder mut CommandEncoder,
+        global_context: &GlobalContext,
+        _pass_data: Self::PassData<'_>,
+    ) -> ComputePass<'encoder> {
+        let AntiAliasingResource::Cmaa2(cmaa2_resource) = &global_context.anti_aliasing_resources else {
+            panic!("cmaa2 resources not set");
+        };
+
+        let mut pass = encoder.begin_compute_pass(&ComputePassDescriptor {
+            label: Some(PASS_NAME),
+            timestamp_writes: None,
+        });
+
+        pass.set_bind_group(0, &cmaa2_resource.bind_group, &[]);
+
+        pass
+    }
+
+    fn bind_group_layout(device: &Device) -> [&'static BindGroupLayout; 1] {
+        [GlobalContext::cmaa2_bind_group_layout(device)]
+    }
+}

--- a/korangar/src/graphics/passes/cmaa2/process_candidates.rs
+++ b/korangar/src/graphics/passes/cmaa2/process_candidates.rs
@@ -1,0 +1,65 @@
+use wgpu::{
+    include_wgsl, ComputePass, ComputePipeline, ComputePipelineDescriptor, Device, PipelineCompilationOptions, PipelineLayoutDescriptor,
+    Queue, ShaderModuleDescriptor, TextureSampleType,
+};
+
+use crate::graphics::passes::{BindGroupCount, Cmaa2ComputePassContext, ComputePassContext, Dispatch, DispatchIndirectArgs};
+use crate::graphics::{AttachmentTexture, Buffer, Capabilities, GlobalContext};
+
+const SHADER: ShaderModuleDescriptor = include_wgsl!("shader/process_candidates.wgsl");
+const DISPATCHER_NAME: &str = "cmaa2 process candidates";
+
+pub(crate) struct Cmaa2ProcessCandidatesDispatcherDispatchData<'a> {
+    pub(crate) color_input_texture: &'a AttachmentTexture,
+    pub(crate) dispatch_indirect_args_buffer: &'a Buffer<DispatchIndirectArgs>,
+}
+
+pub(crate) struct Cmaa2ProcessCandidatesDispatcher {
+    pipeline: ComputePipeline,
+}
+
+impl Dispatch<{ BindGroupCount::One }> for Cmaa2ProcessCandidatesDispatcher {
+    type Context = Cmaa2ComputePassContext;
+    type DispatchData<'data> = Cmaa2ProcessCandidatesDispatcherDispatchData<'data>;
+
+    fn new(
+        _capabilities: &Capabilities,
+        device: &Device,
+        _queue: &Queue,
+        _global_context: &GlobalContext,
+        _compute_pass_context: &Self::Context,
+    ) -> Self {
+        let shader_module = device.create_shader_module(SHADER);
+
+        let pass_bind_group_layouts = Self::Context::bind_group_layout(device);
+
+        let pipeline_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
+            label: Some(DISPATCHER_NAME),
+            bind_group_layouts: &[
+                pass_bind_group_layouts[0],
+                &AttachmentTexture::bind_group_layout(device, TextureSampleType::Float { filterable: true }, false),
+            ],
+            push_constant_ranges: &[],
+        });
+
+        let pipeline = device.create_compute_pipeline(&ComputePipelineDescriptor {
+            label: Some(DISPATCHER_NAME),
+            layout: Some(&pipeline_layout),
+            module: &shader_module,
+            entry_point: Some("cs_main"),
+            compilation_options: PipelineCompilationOptions {
+                zero_initialize_workgroup_memory: false,
+                ..Default::default()
+            },
+            cache: None,
+        });
+
+        Self { pipeline }
+    }
+
+    fn dispatch(&mut self, pass: &mut ComputePass<'_>, draw_data: Self::DispatchData<'_>) {
+        pass.set_pipeline(&self.pipeline);
+        pass.set_bind_group(1, draw_data.color_input_texture.get_bind_group(), &[]);
+        pass.dispatch_workgroups_indirect(draw_data.dispatch_indirect_args_buffer.get_buffer(), 0);
+    }
+}

--- a/korangar/src/graphics/passes/cmaa2/shader/calculate_dispatch_args.wgsl
+++ b/korangar/src/graphics/passes/cmaa2/shader/calculate_dispatch_args.wgsl
@@ -1,0 +1,64 @@
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018, Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 ( the "License" );
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+struct DispatchIndirectArgs {
+    x: u32,
+    y: u32,
+    z: u32,
+}
+
+@group(0) @binding(1) var<storage, read_write> control_buffer: array<atomic<u32>>;
+@group(0) @binding(3) var<storage, read_write> indirect_buffer: DispatchIndirectArgs;
+
+const PROCESS_CANDIDATES_NUM_THREADS: u32 = 128;
+const DEFERRED_APPLY_NUM_THREADS: u32 = 32;
+
+@compute @workgroup_size(1, 1, 1)
+fn cs_main(
+    @builtin(global_invocation_id) global_id: vec3<u32>,
+) {
+    // Activated once on Dispatch(2, 1, 1)
+    if (global_id.x == 1u) {
+        // Get current count
+        let shape_candidate_count = atomicLoad(&control_buffer[1]);
+
+        // Write dispatch indirect arguments for process_candidates shader
+        indirect_buffer.x = (shape_candidate_count + PROCESS_CANDIDATES_NUM_THREADS - 1u) / PROCESS_CANDIDATES_NUM_THREADS;
+        indirect_buffer.y = 1u;
+        indirect_buffer.z = 1u;
+
+        // Write actual number of items to process in process_candidates shader
+        atomicStore(&control_buffer[0], shape_candidate_count);
+    }
+    // Activated once on Dispatch(1, 2, 1)
+    else if (global_id.y == 1u) {
+        // Get current count
+        let blend_location_count = atomicLoad(&control_buffer[2]);
+
+        // Write dispatch indirect arguments for deferred_color_apply shader
+        indirect_buffer.x = 1u;
+        indirect_buffer.y = (blend_location_count + DEFERRED_APPLY_NUM_THREADS - 1u) / DEFERRED_APPLY_NUM_THREADS;
+        indirect_buffer.z = 1u;
+
+        // Write actual number of items to process in deferred_color_apply shader
+        atomicStore(&control_buffer[0], blend_location_count);
+
+        // Clear counters for next frame
+        atomicStore(&control_buffer[1], 0u);  // Shape candidates counter
+        atomicStore(&control_buffer[2], 0u);  // Blend locations counter
+        atomicStore(&control_buffer[3], 0u);  // Deferred blend items counter
+    }
+}

--- a/korangar/src/graphics/passes/cmaa2/shader/deferred_color_apply.wgsl
+++ b/korangar/src/graphics/passes/cmaa2/shader/deferred_color_apply.wgsl
@@ -1,0 +1,100 @@
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018, Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 ( the "License" );
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+const DEFERRED_APPLY_NUM_THREADS: u32 = 32;
+
+@group(0) @binding(1) var<storage, read_write> control_buffer: array<atomic<u32>>;
+@group(0) @binding(4) var<storage, read_write> deferred_blend_item_list_heads: array<atomic<u32>>;
+@group(0) @binding(5) var<storage, read_write> deferred_blend_item_list: array<vec2<u32>>;
+@group(0) @binding(6) var<storage, read_write> deferred_blend_location_list: array<u32>;
+@group(1) @binding(0) var output_texture: texture_storage_2d<rgba16float, write>;
+
+@compute @workgroup_size(4, DEFERRED_APPLY_NUM_THREADS, 1)
+fn cs_main(
+    @builtin(global_invocation_id) global_id: vec3<u32>,
+    @builtin(local_invocation_id) local_id: vec3<u32>,
+) {
+    let num_candidates = atomicLoad(&control_buffer[0]);
+    let deferred_blend_location_list_length = arrayLength(&deferred_blend_location_list);
+
+    let current_candidate = global_id.y;
+    let current_quad_offset_xy = local_id.x;
+
+    if (current_candidate >= num_candidates || current_candidate >= deferred_blend_location_list_length) {
+        return;
+    }
+
+    let output_texture_size = vec2<f32>(textureDimensions(output_texture));
+    let deferred_blend_item_list_heads_width = ((u32(output_texture_size.x) + 1u) / 2u);
+
+    let pixel_id = deferred_blend_location_list[current_candidate];
+    let quad_pos = vec2<u32>((pixel_id >> 16u), pixel_id & 0xFFFFu);
+    let pixel_pos = quad_pos * 2u + qe_offsets(current_quad_offset_xy);
+    let quad_index = quad_pos.y * deferred_blend_item_list_heads_width + quad_pos.x;
+
+    var counter_index_with_header = atomicLoad(&deferred_blend_item_list_heads[quad_index]);
+
+    var out_color = vec4<f32>(0.0);
+
+    // Do the loop to prevent bad data hanging the GPU.
+    let MAX_LOOPS = 32u;
+
+    for (var i = 0u; counter_index_with_header != 0xFFFFFFFFu && i < MAX_LOOPS; i++) {
+        // Decode item-specific info:
+        // - 2 bits for 2x2 quad location
+        // - 1 bit for isComplexShape flag
+        // - 29 bits left for address (counter_index)
+        let offset_xy = (counter_index_with_header >> 30u) & 0x03u;
+        let is_complex_shape = ((counter_index_with_header >> 29u) & 0x01u) != 0u;
+
+        let index = counter_index_with_header & ((1u << 29u) - 1u);
+        let value = deferred_blend_item_list[index];
+        counter_index_with_header = value.x;
+
+        if (offset_xy == current_quad_offset_xy) {
+            let color = unpack_r11g11b10_u32(value.y);
+            let weight = 0.8 + f32(is_complex_shape);
+            out_color += vec4<f32>(color * weight, weight);
+        }
+    }
+
+    if (out_color.a == 0.0) {
+        return;
+    }
+
+    let final_color = out_color.rgb / out_color.a;
+
+    textureStore(output_texture, pixel_pos, vec4<f32>(final_color, 1.0));
+}
+
+// Truth table:
+// index | x | y
+//   0   | 0 | 0
+//   1   | 1 | 0
+//   2   | 0 | 1
+//   3   | 1 | 1
+fn qe_offsets(index: u32) -> vec2<u32> {
+    let x = index & 1u;
+    let y = (index >> 1u) & 1u;
+    return vec2<u32>(x, y);
+}
+
+fn unpack_r11g11b10_u32(packed: u32) -> vec3<f32> {
+    let r = f32(packed & 0x7FFu) / 2047.0;
+    let g = f32((packed >> 11u) & 0x7FFu) / 2047.0;
+    let b = f32((packed >> 22u) & 0x3FFu) / 1023.0;
+    return vec3<f32>(r, g, b);
+}

--- a/korangar/src/graphics/passes/cmaa2/shader/edge_colors.wgsl
+++ b/korangar/src/graphics/passes/cmaa2/shader/edge_colors.wgsl
@@ -1,0 +1,253 @@
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018, Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 ( the "License" );
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+const INPUT_KERNEL_SIZE_X: u32 = 16;
+const INPUT_KERNEL_SIZE_Y: u32 = 16;
+const OUTPUT_KERNEL_SIZE_X = INPUT_KERNEL_SIZE_X - 2;
+const OUTPUT_KERNEL_SIZE_Y = INPUT_KERNEL_SIZE_Y - 2;
+const LOCAL_CONTRAST_ADAPTATION_AMOUNT: f32 = 0.10;
+const EDGE_THRESHOLD: f32 = 0.12;
+
+@group(0) @binding(0) var edges: texture_storage_2d<r8uint, read_write>;
+@group(0) @binding(1) var<storage, read_write> control_buffer: array<atomic<u32>>;
+@group(0) @binding(2) var<storage, read_write> shape_candidates: array<u32>;
+@group(0) @binding(4) var<storage, read_write> deferred_blend_item_list_heads: array<atomic<u32>>;
+@group(1) @binding(0) var input_texture: texture_2d<f32>;
+
+var<workgroup> edges_v: array<vec4<f32>, 256>;
+var<workgroup> edges_h: array<vec4<f32>, 256>;
+
+var<private> pixel_colors: array<vec3<f32>, 8>;
+var<private> neighbourhood: array<mat4x2<f32>, 4>;
+
+@compute @workgroup_size(16, 16, 1)
+fn cs_main(
+    @builtin(global_invocation_id) global_id: vec3<u32>,
+    @builtin(workgroup_id) workgroup_id: vec3<u32>,
+    @builtin(local_invocation_id) local_id: vec3<u32>,
+) {
+    // Screen position in the input (expanded) kernel (shifted one 2x2 block up/left)
+    let pixel_pos = (workgroup_id.xy * vec2<u32>(OUTPUT_KERNEL_SIZE_X, OUTPUT_KERNEL_SIZE_Y)
+                     + local_id.xy - vec2<u32>(1u, 1u)) * vec2<u32>(2u, 2u);
+
+    let row_stride_2x2 = INPUT_KERNEL_SIZE_X;
+    let center_addr_2x2 = local_id.x + local_id.y * row_stride_2x2;
+    let in_output_kernel = !(local_id.x == (INPUT_KERNEL_SIZE_X - 1u) ||
+                            local_id.x == 0u ||
+                            local_id.y == (INPUT_KERNEL_SIZE_Y - 1u) ||
+                            local_id.y == 0u);
+
+    for (var i = 0; i < 8; i++) {
+        pixel_colors[i] = load_source_color(pixel_pos, vec2<i32>(i % 3, i / 3)).rgb;
+    }
+
+    for (var i = 0; i < 8; i++) {
+        pixel_colors[i] = process_color_for_edge_detect(pixel_colors[i]);
+    }
+
+    let qe0 = compute_edge(0, 0, &pixel_colors);
+    let qe1 = compute_edge(1, 0, &pixel_colors);
+    let qe2 = compute_edge(0, 1, &pixel_colors);
+    let qe3 = compute_edge(1, 1, &pixel_colors);
+
+    // Store edges in workgroup shared memory
+    edges_v[center_addr_2x2 + row_stride_2x2 * 0] = vec4<f32>(qe0.x, qe1.x, qe2.x, qe3.x);
+    edges_h[center_addr_2x2 + row_stride_2x2 * 0] = vec4<f32>(qe0.y, qe1.y, qe2.y, qe3.y);
+
+    workgroupBarrier();
+
+    if (in_output_kernel) {
+        let shape_candidates_length = arrayLength(&shape_candidates);
+
+        var out_edges = vec4<u32>(0);
+
+        // top row's bottom edge
+        var top_row = edges_h[center_addr_2x2 - row_stride_2x2].zw;
+        // left column's right edge
+        var left_column = edges_v[center_addr_2x2 - 1].yw;
+
+        let some_non_zero_edges = any(abs(qe0) + abs(qe1) + abs(qe2) + abs(qe3) > vec2<f32>(0.0)) ||
+            any(vec4<f32>(top_row.x, top_row.y, left_column.x, left_column.y) > vec4<f32>(0.0));
+
+        if (some_non_zero_edges) {
+            // Clear deferred color list heads to empty (if potentially needed - even though some edges might get culled by local contrast adaptation
+            // step below, it's still cheaper to just clear it without additional logic).
+            let input_texture_size = vec2<f32>(textureDimensions(input_texture));
+            let deferred_blend_item_list_heads_width = ((u32(input_texture_size.x) + 1u) / 2u);
+            let quad_pos = pixel_pos >> vec2<u32>(1u);
+            let quad_index = quad_pos.y * deferred_blend_item_list_heads_width + quad_pos.x;
+            atomicStore(&deferred_blend_item_list_heads[quad_index], 0xFFFFFFFFu);
+
+            // Load neighborhood data from workgroup memory
+            let n00 = load_quad_hv(center_addr_2x2 - row_stride_2x2 - 1u);
+            let n10 = load_quad_hv(center_addr_2x2 - row_stride_2x2);
+            let n20 = load_quad_hv(center_addr_2x2 - row_stride_2x2 + 1u);
+            let n01 = load_quad_hv(center_addr_2x2 - 1u);
+            let n21 = load_quad_hv(center_addr_2x2 + 1u);
+            let n02 = load_quad_hv(center_addr_2x2 - 1u + row_stride_2x2);
+            let n12 = load_quad_hv(center_addr_2x2 + row_stride_2x2);
+
+            neighbourhood[0][0] = n00[3];
+            neighbourhood[0][1] = vec2<f32>(left_column[0], n01[1].y);
+            neighbourhood[0][2] = vec2<f32>(left_column[1], n01[3].y);
+            neighbourhood[0][3] = n02[1];
+
+            neighbourhood[1][0] = vec2<f32>(n10[2].x, top_row[0]);
+            neighbourhood[1][1] = qe0;
+            neighbourhood[1][2] = qe2;
+            neighbourhood[1][3] = n12[0];
+
+            neighbourhood[2][0] = vec2<f32>(n10[3].x, top_row[1]);
+            neighbourhood[2][1] = qe1;
+            neighbourhood[2][2] = qe3;
+            neighbourhood[2][3] = n12[1];
+
+            neighbourhood[3][0] = n20[2];
+            neighbourhood[3][1] = n21[0];
+            neighbourhood[3][2] = n21[2];
+            neighbourhood[3][3] = vec2<f32>(0.0);
+
+            top_row.x = f32((top_row.x -         compute_local_contrast_h(0, -1, &neighbourhood)) > EDGE_THRESHOLD);
+            top_row.y = f32((top_row.y -         compute_local_contrast_h(1, -1, &neighbourhood)) > EDGE_THRESHOLD);
+            left_column.x = f32((left_column.x - compute_local_contrast_v(-1, 0, &neighbourhood)) > EDGE_THRESHOLD);
+            left_column.y = f32((left_column.y - compute_local_contrast_v(-1, 1, &neighbourhood)) > EDGE_THRESHOLD);
+
+            var ce: mat4x4<f32>;
+
+            ce[0].x = f32((qe0.x - compute_local_contrast_v(0, 0, &neighbourhood)) > EDGE_THRESHOLD);
+            ce[0].y = f32((qe0.y - compute_local_contrast_h(0, 0, &neighbourhood)) > EDGE_THRESHOLD);
+            ce[1].x = f32((qe1.x - compute_local_contrast_v(1, 0, &neighbourhood)) > EDGE_THRESHOLD);
+            ce[1].y = f32((qe1.y - compute_local_contrast_h(1, 0, &neighbourhood)) > EDGE_THRESHOLD);
+            ce[2].x = f32((qe2.x - compute_local_contrast_v(0, 1, &neighbourhood)) > EDGE_THRESHOLD);
+            ce[2].y = f32((qe2.y - compute_local_contrast_h(0, 1, &neighbourhood)) > EDGE_THRESHOLD);
+            ce[3].x = f32((qe3.x - compute_local_contrast_v(1, 1, &neighbourhood)) > EDGE_THRESHOLD);
+            ce[3].y = f32((qe3.y - compute_local_contrast_h(1, 1, &neighbourhood)) > EDGE_THRESHOLD);
+
+            // left
+            ce[0].z = left_column.x;
+            ce[1].z = ce[0].x;
+            ce[2].z = left_column.y;
+            ce[3].z = ce[2].x;
+
+            // top
+            ce[0].w = top_row.x;
+            ce[1].w = top_row.y;
+            ce[2].w = ce[0].y;
+            ce[3].w = ce[1].y;
+
+            for (var i: u32 = 0u; i < 4u; i++) {
+                let local_pixel_pos = pixel_pos + qe_offsets(i);
+                let edges = ce[i];
+
+                // If there's at least one two-edge corner, this is a candidate
+                // for simple or complex shape processing.
+                let is_candidate = (edges.x * edges.y + edges.y * edges.z + edges.z * edges.w + edges.w * edges.x) != 0.0;
+                if (is_candidate) {
+                    let counter_index = atomicAdd(&control_buffer[1], 1u);
+                    if counter_index < shape_candidates_length {
+                        shape_candidates[counter_index] = (local_pixel_pos.x << 16u) | local_pixel_pos.y;
+                    }
+                }
+
+                // Write out edges - we write out all, including empty pixels,
+                // to make sure shape detection edge tracing doesn't continue
+                // on previous frame's edges that no longer exist.
+                out_edges[i] = pack_edges(edges);
+            }
+        }
+
+        // Finally, write the edges!
+        textureStore(edges,
+            vec2<i32>(i32(pixel_pos.x/2u), i32(pixel_pos.y)),
+            vec4<u32>((out_edges[1] << 4u) | out_edges[0], 0u, 0u, 0u)
+        );
+        textureStore(edges,
+            vec2<i32>(i32(pixel_pos.x/2u), i32(pixel_pos.y + 1u)),
+            vec4<u32>((out_edges[3] << 4u) | out_edges[2], 0u, 0u, 0u)
+        );
+    }
+}
+
+// Truth table:
+// index | x | y
+//   0   | 0 | 0
+//   1   | 1 | 0
+//   2   | 0 | 1
+//   3   | 1 | 1
+fn qe_offsets(index: u32) -> vec2<u32> {
+    let x = index & 1u;
+    let y = (index >> 1u) & 1u;
+    return vec2<u32>(x, y);
+}
+
+fn load_source_color(pixel_pos: vec2<u32>, offset: vec2<i32>) -> vec4<f32> {
+    return textureLoad(input_texture, vec2<i32>(pixel_pos) + offset, 0);
+}
+
+/// Apply custom curve / processing to put input color (linear)
+/// to convert it into the perceptional space / gamma.
+fn process_color_for_edge_detect(color: vec3<f32>) -> vec3<f32> {
+    // Just very roughly approximate RGB curve.
+    return sqrt(color);
+}
+
+fn compute_edge(x: i32, y: i32, pixel_colors: ptr<private,array<vec3<f32>, 8>>) -> vec2<f32> {
+    return vec2<f32>(
+        edge_detect_color_calc_diff((*pixel_colors)[x + y * 3], (*pixel_colors)[x + 1 + y * 3]),
+        edge_detect_color_calc_diff((*pixel_colors)[x + y * 3], (*pixel_colors)[x + (y + 1) * 3])
+    );
+}
+
+fn edge_detect_color_calc_diff(color_a: vec3<f32>, color_b: vec3<f32>) -> f32 {
+    let lum_weights = vec3<f32>(0.299, 0.587, 0.114);
+    let diff = abs(color_a - color_b);
+    return dot(diff, lum_weights);
+}
+
+fn load_quad_hv(addr: u32) -> mat4x2<f32> {
+    let h = edges_h[addr];
+    let v = edges_v[addr];
+    let e00 = vec2<f32>(v.x, h.x);
+    let e10 = vec2<f32>(v.y, h.y);
+    let e01 = vec2<f32>(v.z, h.z);
+    let e11 = vec2<f32>(v.w, h.w);
+    return mat4x2<f32>(e00, e10, e01, e11);
+}
+
+fn compute_local_contrast_v(x: i32, y: i32, neighbourhood: ptr<private,array<mat4x2<f32>, 4>>) -> f32 {
+    let max1 = max((*neighbourhood)[x + 1][y].y, (*neighbourhood)[x + 1][y + 1].y);
+    let max2 = max((*neighbourhood)[x + 2][y].y, (*neighbourhood)[x + 2][y + 1].y);
+    return max(max1, max2) * LOCAL_CONTRAST_ADAPTATION_AMOUNT;
+}
+
+fn compute_local_contrast_h(x: i32, y: i32, neighbourhood: ptr<private,array<mat4x2<f32>, 4>>) -> f32 {
+    let max1 = max((*neighbourhood)[x][y + 1].x, (*neighbourhood)[x + 1][y + 1].x);
+    let max2 = max((*neighbourhood)[x][y + 2].x, (*neighbourhood)[x + 1][y + 2].x);
+    return max(max1, max2) * LOCAL_CONTRAST_ADAPTATION_AMOUNT;
+}
+
+/// How .rgba channels from the edge texture maps to pixel edges:
+///
+///                   A - 0x08               (A - there's an edge between us and a pixel above us)
+///              |---------|                 (R - there's an edge between us and a pixel to the right)
+///              |         |                 (G - there's an edge between us and a pixel at the bottom)
+///     0x04 - B |  pixel  | R - 0x01        (B - there's an edge between us and a pixel to the left)
+///              |         |
+///              |_________|
+///                   G - 0x02
+fn pack_edges(edges: vec4<f32>) -> u32 {
+    return u32(dot(edges, vec4<f32>(1.0, 2.0, 4.0, 8.0)));
+}

--- a/korangar/src/graphics/passes/cmaa2/shader/process_candidates.wgsl
+++ b/korangar/src/graphics/passes/cmaa2/shader/process_candidates.wgsl
@@ -1,0 +1,488 @@
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2018, Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 ( the "License" );
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+const PROCESS_CANDIDATES_NUM_THREADS: u32 = 128;
+const BLEND_ITEM_SLM_SIZE: u32 = 768;
+const SIMPLE_SHAPE_BLURINESS_AMOUNT: f32 = 0.10;
+/// Longest line search distance; must be even number; for high perf low quality start from ~32 - the bigger the number,
+/// the nicer the gradients but more costly. Max supported is 128!
+const MAX_LINE_LENGTH: f32 = 86.0;
+const SYMETRY_CORRECTION_OFFSET: f32 = 0.22;
+const DAMPENING_EFFECT: f32 = 0.15;
+
+@group(0) @binding(0) var edges: texture_storage_2d<r8uint, read_write>;
+@group(0) @binding(1) var<storage, read_write> control_buffer: array<atomic<u32>>;
+@group(0) @binding(2) var<storage, read_write> shape_candidates: array<u32>;
+@group(0) @binding(4) var<storage, read_write> deferred_blend_item_list_heads: array<atomic<u32>>;
+@group(0) @binding(5) var<storage, read_write> deferred_blend_item_list: array<vec2<u32>>;
+@group(0) @binding(6) var<storage, read_write> deferred_blend_location_list: array<u32>;
+@group(1) @binding(0) var input_texture: texture_2d<f32>;
+
+var<workgroup> blend_item_count: atomic<u32>;
+var<workgroup> blend_items: array<vec2<u32>, BLEND_ITEM_SLM_SIZE>;
+var<workgroup> deferred_blend_item_list_heads_width: u32;
+var<workgroup> deferred_blend_item_list_length: u32;
+var<workgroup> deferred_blend_location_list_length: u32;
+
+@compute @workgroup_size(PROCESS_CANDIDATES_NUM_THREADS, 1, 1)
+fn cs_main(
+    @builtin(global_invocation_id) global_id: vec3<u32>,
+    @builtin(local_invocation_id) local_id: vec3<u32>,
+) {
+    if (local_id.x == 0u) {
+        atomicStore(&blend_item_count, 0u);
+
+        let input_texture_size = vec2<f32>(textureDimensions(input_texture));
+        deferred_blend_item_list_heads_width = ((u32(input_texture_size.x) + 1u) / 2u);
+        deferred_blend_item_list_length = arrayLength(&deferred_blend_item_list);
+        deferred_blend_location_list_length = arrayLength(&deferred_blend_location_list);
+    }
+
+    workgroupBarrier();
+
+    let num_candidates = atomicLoad(&control_buffer[0]);
+
+    if (global_id.x < num_candidates) {
+        let pixel_id = shape_candidates[global_id.x];
+        let pixel_pos = vec2<u32>((pixel_id >> 16u), pixel_id & 0xFFFFu);
+
+        let edges_center_packed = load_edge(pixel_pos, vec2<i32>(0, 0));
+        let edges        = unpack_edges_float(edges_center_packed);
+        let edges_left   = unpack_edges_float(load_edge(pixel_pos, vec2<i32>(-1, 0)));
+        let edges_right  = unpack_edges_float(load_edge(pixel_pos, vec2<i32>(1, 0)));
+        let edges_bottom = unpack_edges_float(load_edge(pixel_pos, vec2<i32>(0, 1)));
+        let edges_top    = unpack_edges_float(load_edge(pixel_pos, vec2<i32>(0, -1)));
+
+        // Simple shapes
+        {
+            let blend_val = compute_simple_shape_blend_values(edges, edges_left, edges_right, edges_top, edges_bottom, true);
+
+            let four_weight_sum = dot(blend_val, vec4<f32>(1.0));
+            let center_weight = 1.0 - four_weight_sum;
+
+            var out_color = load_source_color(pixel_pos, vec2<i32>(0, 0)).rgb * center_weight;
+
+            // from left
+            if (blend_val.x > 0.0) {
+                let pixel_l = load_source_color(pixel_pos, vec2<i32>(-1, 0)).rgb;
+                out_color += blend_val.x * pixel_l;
+            }
+            // from above
+            if (blend_val.y > 0.0) {
+                let pixel_t = load_source_color(pixel_pos, vec2<i32>(0, -1)).rgb;
+                out_color += blend_val.y * pixel_t;
+            }
+            // from right
+            if (blend_val.z > 0.0) {
+                let pixel_r = load_source_color(pixel_pos, vec2<i32>(1, 0)).rgb;
+                out_color += blend_val.z * pixel_r;
+            }
+            // from below
+            if (blend_val.w > 0.0) {
+                let pixel_b = load_source_color(pixel_pos, vec2<i32>(0, 1)).rgb;
+                out_color += blend_val.w * pixel_b;
+            }
+
+            store_color_sample(pixel_pos, out_color, false);
+        }
+
+        // Complex shapes - detect
+        {
+            var inverted_z_score: f32 = 0.0;
+            var normal_z_score: f32 = 0.0;
+            var max_score: f32 = 0.0;
+            var horizontal = true;
+            var inverted_z = false;
+
+            // Horizontal
+            {
+                let edges_m1p0 = edges_left;
+                let edges_p1p0 = edges_right;
+                let edges_p2p0 = unpack_edges_float(load_edge(pixel_pos, vec2<i32>(2, 0)));
+
+                detect_zs_horizontal(edges, edges_m1p0, edges_p1p0, edges_p2p0, &inverted_z_score, &normal_z_score);
+                max_score = max(inverted_z_score, normal_z_score);
+
+                if (max_score > 0.0) {
+                    inverted_z = inverted_z_score > normal_z_score;
+                }
+            }
+
+            // Vertical
+            {
+                // Reuse the same code for vertical (used for horizontal above), but rotate
+                // input data 90 degrees counter-clockwise, so that:
+                //
+                // left     becomes     bottom
+                // top      becomes     left
+                // right    becomes     top
+                // bottom   becomes     right
+
+                // We also have to rotate edges, thus .argb
+                let edges_m1p0 = edges_bottom;
+                let edges_p1p0 = edges_top;
+                let edges_p2p0 = unpack_edges_float(load_edge(pixel_pos, vec2<i32>(0, -2)));
+
+                detect_zs_horizontal(edges.argb, edges_m1p0.argb, edges_p1p0.argb, edges_p2p0.argb, &inverted_z_score, &normal_z_score);
+                let vert_score = max(inverted_z_score, normal_z_score);
+
+                if (vert_score > max_score) {
+                    max_score = vert_score;
+                    horizontal = false;
+                    inverted_z = inverted_z_score > normal_z_score;
+                }
+            }
+
+            if (max_score > 0.0) {
+                let shape_quality_score = floor(clamp(4.0 - max_score, 0.0, 3.0));
+                let step_right = select(vec2<f32>(0.0, -1.0), vec2<f32>(1.0, 0.0), horizontal);
+
+                var line_length_left: f32 = 0.0;
+                var line_length_right: f32 = 0.0;
+
+                find_z_line_lengths(&line_length_left, &line_length_right, pixel_pos, horizontal, inverted_z, step_right);
+
+                line_length_left -= shape_quality_score;
+                line_length_right -= shape_quality_score;
+
+                if ((line_length_left + line_length_right) >= 5.0) {
+                    // Try adding to SLM but fall back to in-place processing if full (which only really happens in synthetic test cases)
+                    if (!collect_blend_zs(pixel_pos, horizontal, inverted_z, shape_quality_score, line_length_left, line_length_right, step_right)) {
+                        blend_zs(pixel_pos, horizontal, inverted_z, shape_quality_score, line_length_left, line_length_right, step_right);
+                    }
+                }
+            }
+        }
+    }
+
+    workgroupBarrier();
+
+    let total_item_count = min(BLEND_ITEM_SLM_SIZE, atomicLoad(&blend_item_count));
+
+    // Spread items into waves
+    let loops = (total_item_count + (PROCESS_CANDIDATES_NUM_THREADS - 1u) - local_id.x) / PROCESS_CANDIDATES_NUM_THREADS;
+
+    for (var loop_index = 0u; loop_index < loops; loop_index++) {
+        let index = loop_index * PROCESS_CANDIDATES_NUM_THREADS + local_id.x;
+        let item_val = blend_items[index];
+
+        let starting_pos = vec2<u32>((item_val.x >> 16u), item_val.x & 0xFFFFu);
+
+        let item_horizontal = bool((item_val.y >> 31u) & 1u);
+        let item_inverted_z = bool((item_val.y >> 30u) & 1u);
+        let item_step_index = f32((item_val.y >> 20u) & 0x3FFu) - 256.0;
+        let item_src_offset = f32((item_val.y >> 10u) & 0x3FFu) - 256.0;
+        let item_lerp_k = f32(item_val.y & 0x3FFu) / 1023.0;
+
+        let item_step_right = select(vec2<f32>(0.0, -1.0), vec2<f32>(1.0, 0.0), item_horizontal);
+        var item_blend_dir = select(vec2<f32>(-1.0, 0.0), vec2<f32>(0.0, -1.0), item_horizontal);
+        if (item_inverted_z) {
+            item_blend_dir = -item_blend_dir;
+        }
+
+        let item_pixel_pos = vec2<u32>(vec2<f32>(starting_pos) + item_step_right * item_step_index);
+
+        let color_center = load_source_color(item_pixel_pos, vec2<i32>(0, 0)).rgb;
+        let color_from = load_source_color(
+            vec2<u32>(vec2<f32>(item_pixel_pos) + item_blend_dir * vec2<f32>(item_src_offset, item_src_offset)),
+            vec2<i32>(0, 0)
+        ).rgb;
+
+        let output_color = mix(color_center, color_from, item_lerp_k);
+        store_color_sample(item_pixel_pos, output_color, true);
+    }
+}
+
+fn unpack_edges_float(value: u32) -> vec4<f32> {
+    return vec4<f32>(
+        f32((value & 0x01u) != 0u),
+        f32((value & 0x02u) != 0u),
+        f32((value & 0x04u) != 0u),
+        f32((value & 0x08u) != 0u)
+    );
+}
+
+fn load_edge(pixel_pos: vec2<u32>, offset: vec2<i32>) -> u32 {
+    let a = (pixel_pos.x + u32(offset.x)) % 2u;
+    let edge = textureLoad(edges,
+        vec2<i32>(i32((pixel_pos.x + u32(offset.x))/2u),
+        i32(pixel_pos.y) + offset.y)
+    ).x;
+    return (edge >> (a * 4u)) & 0xFu;
+}
+
+
+fn load_source_color(pixel_pos: vec2<u32>, offset: vec2<i32>) -> vec3<f32> {
+    return textureLoad(input_texture, pixel_pos + vec2<u32>(offset), 0).rgb;
+}
+
+fn store_color_sample(
+    pixel_pos: vec2<u32>,
+    color: vec3<f32>,
+    is_complex_shape: bool,
+) {
+    let counter_index = atomicAdd(&control_buffer[3], 1u);
+
+    if counter_index >= deferred_blend_item_list_length {
+        return;
+    }
+
+    // Quad coordinates
+    let quad_pos = pixel_pos >> vec2<u32>(1u);
+    let quad_index = quad_pos.y * deferred_blend_item_list_heads_width + quad_pos.x;
+
+    // 2x2 inter-quad coordinates
+    let offset_xy = (pixel_pos.y % 2u) * 2u + (pixel_pos.x % 2u);
+
+    // Encode item-specific info:
+    // - 2 bits for 2x2 quad location
+    // - 1 bit for isComplexShape flag
+    // - 29 bits left for address (counter_index)
+    let header = (offset_xy << 30u) | (u32(is_complex_shape) << 29u);
+    let counter_index_with_header = counter_index | header;
+    var original_index = atomicExchange(&deferred_blend_item_list_heads[quad_index], counter_index_with_header);
+
+    deferred_blend_item_list[counter_index] = vec2<u32>(original_index, pack_r11g11b10_u32(color));
+
+    // First one added?
+    if (original_index == 0xFFFFFFFFu) {
+        // Make a list of all edge pixels - these cover all potential pixels where AA is applied
+        let edge_list_counter = atomicAdd(&control_buffer[2], 1u);
+        if edge_list_counter < deferred_blend_location_list_length {
+                deferred_blend_location_list[edge_list_counter] = (quad_pos.x << 16u) | quad_pos.y;
+        }
+    }
+}
+
+fn pack_r11g11b10_u32(rgb: vec3<f32>) -> u32 {
+    let r = u32(clamp(rgb.r, 0.0, 1.0) * 2047.0); // 11 bits (0-2047)
+    let g = u32(clamp(rgb.g, 0.0, 1.0) * 2047.0); // 11 bits (0-2047)
+    let b = u32(clamp(rgb.b, 0.0, 1.0) * 1023.0); // 10 bits (0-1023)
+    return (r & 0x7FFu) | ((g & 0x7FFu) << 11u) | ((b & 0x3FFu) << 22u);
+}
+
+fn compute_simple_shape_blend_values(
+    edges: vec4<f32>,
+    edges_left: vec4<f32>,
+    edges_right: vec4<f32>,
+    edges_top: vec4<f32>,
+    edges_bottom: vec4<f32>,
+    dont_test_shape_validity: bool,
+) -> vec4<f32> {
+    var from_right = edges.r;
+    var from_below = edges.g;
+    var from_left = edges.b;
+    var from_above = edges.a;
+
+    var blur_coeff = SIMPLE_SHAPE_BLURINESS_AMOUNT;
+    let number_of_edges = dot(edges, vec4<f32>(1.0));
+
+    let number_of_edges_all_around = dot(
+        edges_left.bga + edges_right.rga + edges_top.rba + edges_bottom.rgb,
+        vec3<f32>(1.0)
+    );
+
+    // Skip if already tested for before calling this function
+    if (!dont_test_shape_validity) {
+        // No blur for straight edge
+        if (number_of_edges == 1.0) {
+            blur_coeff = 0.0;
+        }
+        // L-like step shape (only blur if it's a corner, not if it's two parallel edges)
+        if (number_of_edges == 2.0) {
+            blur_coeff *= (1.0 - from_below * from_above) * (1.0 - from_right * from_left);
+        }
+    }
+
+    // L-like step shape
+    if (number_of_edges == 2.0) {
+        blur_coeff *= 0.75;
+        let k = 0.9;
+
+        from_right += k * (edges.g * edges_top.r * (1.0 - edges_left.g) + edges.a * edges_bottom.r * (1.0 - edges_left.a));
+        from_below += k * (edges.b * edges_right.g * (1.0 - edges_top.b) + edges.r * edges_left.g * (1.0 - edges_top.r));
+        from_left += k * (edges.a * edges_bottom.b * (1.0 - edges_right.a) + edges.g * edges_top.b * (1.0 - edges_right.g));
+        from_above += k * (edges.r * edges_left.a * (1.0 - edges_bottom.r) + edges.b * edges_right.a * (1.0 - edges_bottom.b));
+    }
+
+    // Dampen blurring effect when lots of neighbouring edges
+    blur_coeff *= saturate(1.30 - number_of_edges_all_around / 10.0);
+
+    return vec4<f32>(from_left, from_above, from_right, from_below) * blur_coeff;
+}
+
+fn detect_zs_horizontal(
+    edges: vec4<f32>,
+    edges_m1p0: vec4<f32>,
+    edges_p1p0: vec4<f32>,
+    edges_p2p0: vec4<f32>,
+    inverted_z_score: ptr<function, f32>,
+    normal_z_score: ptr<function, f32>
+) {
+    // Inverted Z case:
+    //   __
+    //  X|
+    // --
+    *inverted_z_score = edges.r * edges.g * edges_p1p0.a;
+    *inverted_z_score *= 2.0 + (edges_m1p0.g + edges_p2p0.a) - (edges.a + edges_p1p0.g)
+        - 0.7 * (edges_p2p0.g + edges_m1p0.a + edges.b + edges_p1p0.r);
+
+    // Normal Z case:
+    // __
+    //  X|
+    //   --
+    *normal_z_score = edges.r * edges.a * edges_p1p0.g;
+    *normal_z_score *= 2.0 + (edges_m1p0.a + edges_p2p0.g) - (edges.g + edges_p1p0.a)
+        - 0.7 * (edges_p2p0.a + edges_m1p0.g + edges.b + edges_p1p0.r);
+}
+
+fn find_z_line_lengths(
+    line_length_left: ptr<function, f32>,
+    line_length_right: ptr<function, f32>,
+    screen_pos: vec2<u32>,
+    horizontal: bool,
+    inverted_z_shape: bool,
+    step_right: vec2<f32>,
+) {
+    // Horizontal (vertical is the same, just rotated 90- counter-clockwise)
+    // Inverted Z case:              // Normal Z case:
+    //   __                          // __
+    //  X|                           //  X|
+    // --                            //   --
+    let mask_trace_left = select(0x04u, 0x08u, horizontal);
+    let mask_trace_right = select(0x01u, 0x02u, horizontal);
+
+    let mask_left = select(mask_trace_left, mask_trace_right, inverted_z_shape);
+    let mask_right = select(mask_trace_right, mask_trace_left, inverted_z_shape);
+    let bits_continue_left = mask_left;
+    let bits_continue_right = mask_right;
+
+    var continue_left = true;
+    var continue_right = true;
+    *line_length_left = 1.0;
+    *line_length_right = 1.0;
+
+    loop {
+        let edge_left  = load_edge(screen_pos - vec2<u32>(step_right * *line_length_left), vec2<i32>(0));
+        let edge_right = load_edge(screen_pos + vec2<u32>(step_right * (*line_length_right + 1.0)), vec2<i32>(0));
+
+        // Stop on encountering 'stopping' edge (as defined by masks)
+        continue_left  = continue_left  && ((edge_left  & mask_left)  == bits_continue_left);
+        continue_right = continue_right && ((edge_right & mask_right) == bits_continue_right);
+
+        *line_length_left  += f32(continue_left);
+        *line_length_right += f32(continue_right);
+
+        var max_lr = max(*line_length_right, *line_length_left);
+
+        // Both stopped? Cause the search end by setting max_lr to MAX_LINE_LENGTH.
+        if (!continue_left && !continue_right) {
+            max_lr = MAX_LINE_LENGTH;
+        }
+
+        if (max_lr >= min(MAX_LINE_LENGTH, 1.25 * min(*line_length_right, *line_length_left) - 0.25)) {
+            break;
+        }
+    }
+}
+
+fn collect_blend_zs(
+    screen_pos: vec2<u32>,
+    horizontal: bool,
+    inverted_z_shape: bool,
+    shape_quality_score: f32,
+    line_length_left: f32,
+    line_length_right: f32,
+    step_right: vec2<f32>,
+) -> bool {
+    let left_odd  = SYMETRY_CORRECTION_OFFSET * f32(u32(line_length_left) % 2u);
+    let right_odd = SYMETRY_CORRECTION_OFFSET * f32(u32(line_length_right) % 2u);
+
+    let dampen_effect = saturate(f32(line_length_left + line_length_right - shape_quality_score) * DAMPENING_EFFECT);
+
+    let loop_from = -floor((line_length_left + 1.0) / 2.0) + 1.0;
+    let loop_to = floor((line_length_right + 1.0) / 2.0);
+
+    let item_count = u32(loop_to - loop_from + 1.0);
+    var item_index = atomicAdd(&blend_item_count, item_count);
+
+    if ((item_index + item_count) > BLEND_ITEM_SLM_SIZE) {
+        return false;
+    }
+
+    let total_length = (loop_to - loop_from) + 1.0 - left_odd - right_odd;
+    let lerp_step = 1.0 / total_length;
+    let lerp_from_k = (0.5 - left_odd - loop_from) * lerp_step;
+
+    let item_header = (screen_pos.x << 16u) | screen_pos.y;
+    let item_val_static = (u32(horizontal) << 31u) | (u32(inverted_z_shape) << 30u);
+
+    for(var i = loop_from; i <= loop_to; i += 1.0) {
+        let second_part = f32(i > 0.0);
+        let src_offset = 1.0 - second_part * 2.0;
+
+        let lerp_k = ((lerp_step * i + lerp_from_k) * src_offset + second_part) * dampen_effect;
+
+        let encoded_Item = vec2<u32>(
+            item_header,
+            item_val_static | (u32(i + 256.0) << 20u) | (u32(src_offset + 256.0) << 10u) | u32(saturate(lerp_k) * 1023.0 + 0.5)
+        );
+        blend_items[item_index] = encoded_Item;
+        item_index += 1u;
+    }
+
+    return true;
+}
+
+fn blend_zs(
+    screen_pos: vec2<u32>,
+    horizontal: bool,
+    inverted_z_shape: bool,
+    shape_quality_score: f32,
+    line_length_left: f32,
+    line_length_right: f32,
+    step_right: vec2<f32>,
+) {
+    let blend_dir = select(vec2<f32>(-1.0, 0.0), vec2<f32>(0.0, -1.0), horizontal);
+    let final_blend_dir = select(blend_dir, -blend_dir, inverted_z_shape);
+
+    let left_odd  = SYMETRY_CORRECTION_OFFSET * f32(u32(line_length_left) % 2u);
+    let right_odd = SYMETRY_CORRECTION_OFFSET * f32(u32(line_length_right) % 2u);
+
+    let dampen_effect = saturate(f32(line_length_left + line_length_right - shape_quality_score) * DAMPENING_EFFECT);
+
+    let loop_from = -floor((line_length_left + 1.0) / 2.0) + 1.0;
+    let loop_to = floor((line_length_right + 1.0) / 2.0);
+
+    let total_length = (loop_to - loop_from) + 1.0 - left_odd - right_odd;
+    let lerp_step = 1.0 / total_length;
+    let lerp_from_k = (0.5 - left_odd - loop_from) * lerp_step;
+
+    for(var i = loop_from; i <= loop_to; i += 1.0) {
+        let second_part = f32(i > 0.0);
+        let src_offset = 1.0 - second_part * 2.0;
+
+        let lerp_k = ((lerp_step * i + lerp_from_k) * src_offset + second_part) * dampen_effect;
+
+        let pixel_pos = vec2<u32>(vec2<f32>(screen_pos) + step_right * i);
+
+        let color_center = load_source_color(pixel_pos, vec2<i32>(0)).rgb;
+        let color_from = load_source_color(pixel_pos + vec2<u32>(final_blend_dir * src_offset), vec2<i32>(0)).rgb;
+
+        let output = mix(color_center, color_from, lerp_k);
+        store_color_sample(pixel_pos, output, true);
+    }
+}

--- a/korangar/src/graphics/passes/mod.rs
+++ b/korangar/src/graphics/passes/mod.rs
@@ -1,3 +1,4 @@
+mod cmaa2;
 mod directional_shadow;
 mod forward;
 mod interface;
@@ -5,10 +6,12 @@ mod light_culling;
 mod picker;
 mod point_shadow;
 mod postprocessing;
+mod screen_blit;
 
 use std::marker::ConstParamTy;
 
 use bytemuck::{Pod, Zeroable};
+pub(crate) use cmaa2::*;
 pub(crate) use directional_shadow::*;
 pub(crate) use forward::*;
 pub(crate) use interface::*;
@@ -16,6 +19,7 @@ pub(crate) use light_culling::*;
 pub(crate) use picker::*;
 pub(crate) use point_shadow::*;
 pub(crate) use postprocessing::*;
+pub(crate) use screen_blit::*;
 use wgpu::{BindGroupLayout, CommandEncoder, ComputePass, Device, Queue, RenderPass, TextureFormat};
 
 use crate::graphics::{Capabilities, GlobalContext, ModelBatch, ModelInstruction};
@@ -23,6 +27,7 @@ use crate::loaders::TextureLoader;
 
 #[derive(Clone, Copy, PartialEq, Eq, ConstParamTy)]
 pub(crate) enum BindGroupCount {
+    None = 0,
     One = 1,
     Two = 2,
 }
@@ -124,11 +129,20 @@ pub(crate) trait Dispatch<const BIND: BindGroupCount> {
 /// We reimplement the WGPU type, since we want to have bytemuck support.
 #[repr(C)]
 #[derive(Copy, Clone, Pod, Zeroable)]
-struct DrawIndirectArgs {
+pub(crate) struct DrawIndirectArgs {
     vertex_count: u32,
     instance_count: u32,
     first_vertex: u32,
     first_instance: u32,
+}
+
+/// We reimplement the WGPU type, since we want to have bytemuck support.
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable)]
+pub(crate) struct DispatchIndirectArgs {
+    x: u32,
+    y: u32,
+    z: u32,
 }
 
 /// A batch of models that share a specific texture group and model vertex

--- a/korangar/src/graphics/passes/screen_blit/blitter.rs
+++ b/korangar/src/graphics/passes/screen_blit/blitter.rs
@@ -1,0 +1,81 @@
+use wgpu::{
+    include_wgsl, ColorTargetState, ColorWrites, Device, FragmentState, MultisampleState, PipelineCompilationOptions,
+    PipelineLayoutDescriptor, PrimitiveState, Queue, RenderPass, RenderPipeline, RenderPipelineDescriptor, ShaderModuleDescriptor,
+    TextureSampleType, VertexState,
+};
+
+use crate::graphics::passes::screen_blit::ScreenBlitRenderPassContext;
+use crate::graphics::passes::{BindGroupCount, ColorAttachmentCount, DepthAttachmentCount, Drawer};
+use crate::graphics::{AttachmentTexture, Capabilities, GlobalContext};
+
+const SHADER: ShaderModuleDescriptor = include_wgsl!("shader/blitter.wgsl");
+const SHADER_SRGB: ShaderModuleDescriptor = include_wgsl!("shader/blitter_srgb.wgsl");
+const DRAWER_NAME: &str = "screen blit blitter";
+
+pub(crate) struct ScreenBlitBlitterDrawer {
+    pipeline: RenderPipeline,
+}
+
+impl Drawer<{ BindGroupCount::None }, { ColorAttachmentCount::One }, { DepthAttachmentCount::None }> for ScreenBlitBlitterDrawer {
+    type Context = ScreenBlitRenderPassContext;
+    type DrawData<'data> = &'data AttachmentTexture;
+
+    fn new(
+        _capabilities: &Capabilities,
+        device: &Device,
+        _queue: &Queue,
+        global_context: &GlobalContext,
+        _render_pass_context: &Self::Context,
+    ) -> Self {
+        let surface_texture_format = global_context.surface_texture_format;
+
+        let shader_module = match surface_texture_format.is_srgb() {
+            true => device.create_shader_module(SHADER_SRGB),
+            false => device.create_shader_module(SHADER),
+        };
+
+        let label = format!("{DRAWER_NAME} {surface_texture_format:?}");
+
+        let texture_bind_group_layout = AttachmentTexture::bind_group_layout(device, TextureSampleType::Float { filterable: true }, false);
+
+        let pipeline_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
+            label: Some(&label),
+            bind_group_layouts: &[&texture_bind_group_layout],
+            push_constant_ranges: &[],
+        });
+
+        let pipeline = device.create_render_pipeline(&RenderPipelineDescriptor {
+            label: Some(&label),
+            layout: Some(&pipeline_layout),
+            vertex: VertexState {
+                module: &shader_module,
+                entry_point: Some("vs_main"),
+                compilation_options: PipelineCompilationOptions::default(),
+                buffers: &[],
+            },
+            fragment: Some(FragmentState {
+                module: &shader_module,
+                entry_point: Some("fs_main"),
+                compilation_options: PipelineCompilationOptions::default(),
+                targets: &[Some(ColorTargetState {
+                    format: surface_texture_format,
+                    blend: None,
+                    write_mask: ColorWrites::default(),
+                })],
+            }),
+            primitive: PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+
+        Self { pipeline }
+    }
+
+    fn draw(&mut self, pass: &mut RenderPass<'_>, draw_data: Self::DrawData<'_>) {
+        pass.set_pipeline(&self.pipeline);
+        pass.set_bind_group(0, draw_data.get_bind_group(), &[]);
+        pass.draw(0..3, 0..1);
+    }
+}

--- a/korangar/src/graphics/passes/screen_blit/mod.rs
+++ b/korangar/src/graphics/passes/screen_blit/mod.rs
@@ -1,0 +1,62 @@
+mod blitter;
+
+pub(crate) use blitter::ScreenBlitBlitterDrawer;
+use wgpu::{
+    BindGroupLayout, Color, CommandEncoder, Device, LoadOp, Operations, Queue, RenderPass, RenderPassColorAttachment, RenderPassDescriptor,
+    StoreOp, TextureFormat, TextureView,
+};
+
+use super::{BindGroupCount, ColorAttachmentCount, DepthAttachmentCount, RenderPassContext};
+use crate::graphics::GlobalContext;
+use crate::loaders::TextureLoader;
+const PASS_NAME: &str = "screen blit render pass";
+
+pub(crate) struct ScreenBlitRenderPassContext {
+    surface_texture_format: TextureFormat,
+}
+
+impl RenderPassContext<{ BindGroupCount::None }, { ColorAttachmentCount::One }, { DepthAttachmentCount::None }>
+    for ScreenBlitRenderPassContext
+{
+    type PassData<'data> = &'data TextureView;
+
+    fn new(_device: &Device, _queue: &Queue, _texture_loader: &TextureLoader, global_context: &GlobalContext) -> Self {
+        Self {
+            surface_texture_format: global_context.surface_texture_format,
+        }
+    }
+
+    fn create_pass<'encoder>(
+        &mut self,
+        encoder: &'encoder mut CommandEncoder,
+        _global_context: &GlobalContext,
+        pass_data: Self::PassData<'_>,
+    ) -> RenderPass<'encoder> {
+        encoder.begin_render_pass(&RenderPassDescriptor {
+            label: Some(PASS_NAME),
+            color_attachments: &[Some(RenderPassColorAttachment {
+                view: pass_data,
+                resolve_target: None,
+                ops: Operations {
+                    load: LoadOp::Clear(Color::BLACK),
+                    store: StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+        })
+    }
+
+    fn bind_group_layout(_device: &Device) -> [&'static BindGroupLayout; 0] {
+        []
+    }
+
+    fn color_attachment_formats(&self) -> [TextureFormat; 1] {
+        [self.surface_texture_format]
+    }
+
+    fn depth_attachment_output_format(&self) -> [TextureFormat; 0] {
+        []
+    }
+}

--- a/korangar/src/graphics/passes/screen_blit/shader/blitter.wgsl
+++ b/korangar/src/graphics/passes/screen_blit/shader/blitter.wgsl
@@ -1,0 +1,30 @@
+@group(0) @binding(0) var texture: texture_2d<f32>;
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_index: u32) -> @builtin(position) vec4<f32> {
+    // Full screen triangle.
+    let uv = vec2<f32>(f32((vertex_index << 1u) & 2u), f32(vertex_index & 2u));
+    return vec4<f32>(uv * vec2<f32>(2.0, -2.0) + vec2<f32>(-1.0, 1.0), 0.0, 1.0);
+}
+
+@fragment
+fn fs_main(@builtin(position) position: vec4<f32>) -> @location(0) vec4<f32> {
+    let color = textureLoad(texture, vec2<i32>(position.xy), 0);
+    let srgb = linear_to_srgb_vec3(color.rgb);
+    return vec4<f32>(srgb.rgb, color.a);
+}
+
+fn linear_to_srgb_vec3(color: vec3<f32>) -> vec3<f32> {
+    return vec3<f32>(
+        linear_to_srgb(color.x),
+        linear_to_srgb(color.y),
+        linear_to_srgb(color.z)
+    );
+}
+
+fn linear_to_srgb(value: f32) -> f32 {
+    let is_linear = value < 0.0031308;
+    let linear_result = value * 12.92;
+    let power_result = 1.055 * pow(abs(value), 1.0 / 2.4) - 0.055;
+    return select(power_result, linear_result, is_linear);
+}

--- a/korangar/src/graphics/passes/screen_blit/shader/blitter_srgb.wgsl
+++ b/korangar/src/graphics/passes/screen_blit/shader/blitter_srgb.wgsl
@@ -1,0 +1,13 @@
+@group(0) @binding(0) var texture: texture_2d<f32>;
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_index: u32) -> @builtin(position) vec4<f32> {
+    // Full screen triangle.
+    let uv = vec2<f32>(f32((vertex_index << 1u) & 2u), f32(vertex_index & 2u));
+    return vec4<f32>(uv * vec2<f32>(2.0, -2.0) + vec2<f32>(-1.0, 1.0), 0.0, 1.0);
+}
+
+@fragment
+fn fs_main(@builtin(position) position: vec4<f32>) -> @location(0) vec4<f32> {
+    return textureLoad(texture, vec2<i32>(position.xy), 0);
+}

--- a/korangar/src/graphics/surface.rs
+++ b/korangar/src/graphics/surface.rs
@@ -70,11 +70,8 @@ impl Surface {
         }
 
         let present_mode_info = PresentModeInfo::from_adapter(adapter, &surface);
-        let srgb_formats: Vec<TextureFormat> = surfaces_formats.iter().copied().filter(|format| format.is_srgb()).collect();
-        let srgb_format = *srgb_formats.first().expect("Surface does not support sRGB");
 
-        config.format = srgb_format;
-        config.view_formats.push(srgb_format);
+        config.format = surfaces_formats.first().copied().expect("not surface formats found");
         config.desired_maximum_frame_latency = match triple_buffering {
             true => 2,
             false => 1,

--- a/korangar/src/graphics/texture.rs
+++ b/korangar/src/graphics/texture.rs
@@ -237,6 +237,7 @@ impl CubeArrayTexture {
 pub(crate) enum AttachmentTextureType {
     PickerAttachment,
     ColorAttachment,
+    ColorStorageAttachment,
     DepthAttachment,
     Depth,
 }
@@ -248,6 +249,9 @@ impl From<AttachmentTextureType> for TextureUsages {
                 TextureUsages::TEXTURE_BINDING | TextureUsages::RENDER_ATTACHMENT | TextureUsages::COPY_SRC
             }
             AttachmentTextureType::ColorAttachment => TextureUsages::TEXTURE_BINDING | TextureUsages::RENDER_ATTACHMENT,
+            AttachmentTextureType::ColorStorageAttachment => {
+                TextureUsages::TEXTURE_BINDING | TextureUsages::RENDER_ATTACHMENT | TextureUsages::STORAGE_BINDING
+            }
             AttachmentTextureType::DepthAttachment => TextureUsages::TEXTURE_BINDING | TextureUsages::RENDER_ATTACHMENT,
             AttachmentTextureType::Depth => TextureUsages::TEXTURE_BINDING | TextureUsages::RENDER_ATTACHMENT,
         }
@@ -353,7 +357,7 @@ impl AttachmentTexture {
                     label: None,
                     entries: &[BindGroupLayoutEntry {
                         binding: 0,
-                        visibility: ShaderStages::FRAGMENT,
+                        visibility: ShaderStages::FRAGMENT | ShaderStages::COMPUTE,
                         ty: BindingType::Texture {
                             sample_type,
                             view_dimension: TextureViewDimension::D2,

--- a/korangar/src/interface/windows/settings/graphics.rs
+++ b/korangar/src/interface/windows/settings/graphics.rs
@@ -126,6 +126,7 @@ where
                 .with_options(vec![
                     ("Off", ScreenSpaceAntiAliasing::Off),
                     ("FXAA", ScreenSpaceAntiAliasing::Fxaa),
+                    ("CMAA2", ScreenSpaceAntiAliasing::Cmaa2),
                 ])
                 .with_selected(self.screen_space_anti_aliasing.clone())
                 .with_event(Box::new(Vec::new))


### PR DESCRIPTION
It's shaper than FXAA. I found it best used with x2 or x4 MSAA, since they compliment each other well. I didn't port the MSAA mode, since it didn't increased to better overall image quality and was very performance hungry.

We could fine tune the overall parameters, but currently I think I hit a good sweet spot.

I had to return to the standard WebGPU limits, since we use compute shader more (shouldn't be a problem, since we don't support the downleveled backends, like DX11 or OpenGL anyhow).

I also hand to simplify the surface management by always rendering to texture and blitting as the last step to the surface. This enabled me to remove the limitation, that we only supported sRGB compatible surfaces. This isn't the case anymore and we now support normal UNORM and UNORM_SRGB now.

Please don't touch the shader code, since I explicitly left some quirks of the HLSL code in there, so that I could better compare bith versions, if such need should arise later.