### PR TITLE
Fix internal name of Thief and Royal Guard jobs

### DIFF
--- a/korangar/src/world/entity/mod.rs
+++ b/korangar/src/world/entity/mod.rs
@@ -95,7 +95,7 @@ fn get_sprite_path_for_player_job(job_id: usize) -> &'static str {
         3 => "±Ã¼Ö",               // ARCHER
         4 => "¼ºÁ÷ÀÚ",             // ACOLYTE
         5 => "»ÓÀÎ",               // MERCHANT
-        6 => "ΜΜΜÏ",               // THIEF
+        6 => "µµµÏ",               // THIEF
         7 => "±â»ç",               // KNIGHT
         8 => "¼ºÅõ»ç",             // PRIEST
         9 => "¸¶¹Ý»Ç",             // WIZARD
@@ -119,7 +119,7 @@ fn get_sprite_path_for_player_job(job_id: usize) -> &'static str {
         4004 => "±Ã¼Ö",            // ARCHER_H
         4005 => "¼ºÁ÷ÀÚ",          // ACOLYTE_H
         4006 => "»ÓÀÎ",            // MERCHANT_H
-        4007 => "ΜΜΜÏ",            // THIEF_H
+        4007 => "µµµÏ",            // THIEF_H
         4008 => "·Îµå³ªÀÌÆ®",      // KNIGHT_H
         4009 => "ÇÏÀÌÇÁ¸®",        // PRIEST_H
         4010 => "ÇÏÀÌÀ§Àúµå",      // WIZARD_H

--- a/korangar/src/world/entity/mod.rs
+++ b/korangar/src/world/entity/mod.rs
@@ -161,7 +161,7 @@ fn get_sprite_path_for_player_job(job_id: usize) -> &'static str {
         4057 => "¾ÆÅ©ºñ¼ó",        // ARCH_BISHOP
         4058 => "¹ÌÄÉ´Ð",          // MECHANIC
         4059 => "±æ·ÎÆ¾Å©·Î½º",    // GUILLOTINE_CROSS
-        4066 => "°¡ΜÅ",            // ROYAL_GUARD
+        4066 => "°¡µå",            // ROYAL_GUARD
         4067 => "¼Ò¼­·¯",           // SORCERER
         4068 => "¹Î½ºÆ®·²",        // MINSTREL
         4069 => "¿ø´õ·¯",          // WANDERER
@@ -174,7 +174,7 @@ fn get_sprite_path_for_player_job(job_id: usize) -> &'static str {
         4063 => "¾ÆÅ©ºñ¼ó",        // ARCH_BISHOP_H
         4064 => "¹ÌÄÉ´Ð",          // MECHANIC_H
         4065 => "±æ·ÎÆ¾Å©·Î½º",    // GUILLOTINE_CROSS_H
-        4073 => "°¡ΜÅ",            // ROYAL_GUARD_H
+        4073 => "°¡µÅ",            // ROYAL_GUARD_H
         4074 => "¼Ò¼­·¯",           // SORCERER_H
         4075 => "¹Î½ºÆ®·²",        // MINSTREL_H
         4076 => "¿ø´õ·¯",          // WANDERER_H


### PR DESCRIPTION
Korangar would crash when trying to load assets for Thief job (id: 6), Royal Guard (id: 4066) and Royal Guard H (id: 4073)
With this fix Korangar can load their assets and display them.