### PR TITLE
RSM bytestream compatible to 2.3

### DIFF
--- a/korangar/src/loaders/model/mod.rs
+++ b/korangar/src/loaders/model/mod.rs
@@ -66,7 +66,7 @@ impl ModelLoader {
     fn make_vertices(node: &NodeData, main_matrix: &Matrix4<f32>, reverse_order: bool) -> Vec<NativeModelVertex> {
         let mut native_vertices = Vec::new();
 
-        let array: [f32; 3] = node.scale.into();
+        let array: [f32; 3] = node.scale.unwrap().into();
         let reverse_node_order = array.into_iter().fold(1.0, |a, b| a * b).is_sign_negative();
 
         if reverse_node_order {
@@ -115,10 +115,10 @@ impl ModelLoader {
     }
 
     fn calculate_matrices(node: &NodeData, parent_matrix: &Matrix4<f32>) -> (Matrix4<f32>, Matrix4<f32>, Matrix4<f32>) {
-        let main = Matrix4::from_translation(node.translation1) * Matrix4::from(node.offset_matrix);
-
-        let scale_matrix = Matrix4::from_nonuniform_scale(node.scale.x, node.scale.y, node.scale.z);
-        let rotation_matrix = Matrix4::from_axis_angle(node.rotation_axis, Rad(node.rotation_angle));
+        let main = Matrix4::from_translation(node.translation1.unwrap()) * Matrix4::from(node.offset_matrix);
+        let scale = node.scale.unwrap();
+        let scale_matrix = Matrix4::from_nonuniform_scale(scale.x, scale.y, scale.z);
+        let rotation_matrix = Matrix4::from_axis_angle(node.rotation_axis.unwrap(), Rad(node.rotation_angle.unwrap()));
         let translation_matrix = Matrix4::from_translation(node.translation2);
 
         let transform = match node.rotation_keyframe_count > 0 {
@@ -247,6 +247,9 @@ impl ModelLoader {
         };
 
         // TODO: Temporary check until we support more versions.
+        // TODO: The model operation to scale keyframe is not implemented yet.
+        // TODO: The model operation to translate keyframe is not implemented yet.
+        // TODO: The model operation to modify texture keyframe is not implemented yet.
         let version: InternalVersion = model_data.version.into();
         if version.equals_or_above(2, 2) {
             #[cfg(feature = "debug")]
@@ -265,7 +268,7 @@ impl ModelLoader {
             .collect();
         let texture_mapping: Vec<i32> = (0..model_data.texture_names.len()).map(|index| index as i32).collect();
 
-        let root_node_name = &model_data.root_node_name;
+        let root_node_name = &model_data.root_node_name.clone().unwrap();
         let root_node = model_data
             .nodes
             .iter()

--- a/ragnarok_formats/src/model.rs
+++ b/ragnarok_formats/src/model.rs
@@ -6,7 +6,7 @@ use ragnarok_bytes::{
 use crate::signature::Signature;
 use crate::version::{InternalVersion, MajorFirst, Version};
 
-/// A string that can either have a fixed lenght or be length prefixed, based on
+/// A string that can either have a fixed length or be length prefixed, based on
 /// the file format version.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ModelString<const LENGTH: usize> {
@@ -57,11 +57,11 @@ where
 
 #[derive(Debug, ByteConvertable)]
 #[cfg_attr(feature = "interface", derive(korangar_interface::elements::PrototypeElement))]
-pub struct PositionKeyframeData {
+pub struct ScaleKeyframeData {
     pub frame: u32,
-    pub position: Point3<f32>,
+    pub scale: Vector3<f32>,
+    reserved: f32,
 }
-
 #[derive(Clone, Debug, ByteConvertable)]
 #[cfg_attr(feature = "interface", derive(korangar_interface::elements::PrototypeElement))]
 pub struct RotationKeyframeData {
@@ -71,13 +71,70 @@ pub struct RotationKeyframeData {
 
 #[derive(Debug, ByteConvertable)]
 #[cfg_attr(feature = "interface", derive(korangar_interface::elements::PrototypeElement))]
+pub struct TranslationKeyframeData {
+    pub frame: u32,
+    pub translation: Vector3<f32>,
+    reserved: f32,
+}
+
+#[derive(Debug, ByteConvertable)]
+#[cfg_attr(feature = "interface", derive(korangar_interface::elements::PrototypeElement))]
+pub struct TexturesKeyframeData {
+    pub texture_index: u32,
+    #[new_derive]
+    pub texture_keyframe_count: u32,
+    #[repeating(texture_keyframe_count)]
+    pub texture_keyframes: Vec<TextureKeyframeData>,
+}
+
+/// List of texture operation types.
+/// See: https://rathena.org/board/topic/127587-rsm2-file-format/
+#[derive(Debug, ByteConvertable)]
+#[cfg_attr(feature = "interface", derive(korangar_interface::elements::PrototypeElement))]
+pub enum TextureOperation {
+    /// Texture translation on the X axis. The texture is tiled.
+    TranslationX,
+    /// Texture translation on the Y axis. The texture is tiled.
+    TranslationY,
+    /// Texture multiplication on the X axis. The texture is tiled.
+    ScaleX,
+    /// Texture multiplication on the Y axis. The texture is tiled
+    ScaleY,
+    /// Texture rotation around (0, 0). The texture is not tiled.
+    Rotation,
+}
+
+#[derive(Debug, ByteConvertable)]
+#[cfg_attr(feature = "interface", derive(korangar_interface::elements::PrototypeElement))]
+pub struct TextureKeyframeData {
+    pub operation_type: TextureOperation,
+    #[new_derive]
+    pub frame_count: u32,
+    #[repeating(frame_count)]
+    pub texture_frames: Vec<TextureFrameData>,
+}
+
+#[derive(Debug, ByteConvertable)]
+#[cfg_attr(feature = "interface", derive(korangar_interface::elements::PrototypeElement))]
+pub struct TextureFrameData {
+    pub frame: u32,
+    pub operation_value: f32,
+}
+
+#[derive(Debug, ByteConvertable)]
+#[cfg_attr(feature = "interface", derive(korangar_interface::elements::PrototypeElement))]
 pub struct FaceData {
+    #[version_equals_or_above(2, 2)]
+    pub length: Option<u32>,
     pub vertex_position_indices: [u16; 3],
     pub texture_coordinate_indices: [u16; 3],
     pub texture_index: u16,
     pub padding: u16,
     pub two_sided: i32,
     pub smooth_group: i32,
+    #[version_equals_or_above(2, 2)]
+    #[repeating_expr((length.unwrap() as usize).saturating_sub(24) / 4)]
+    pub smooth_group_extra: Option<Vec<i32>>,
 }
 
 #[derive(Debug, ByteConvertable)]
@@ -92,17 +149,28 @@ pub struct TextureCoordinateData {
 #[cfg_attr(feature = "interface", derive(korangar_interface::elements::PrototypeElement))]
 pub struct NodeData {
     pub node_name: ModelString<40>,
-    pub parent_node_name: ModelString<40>, // This is where 2.2 starts failing
-    pub texture_count: u32,
-    #[repeating(texture_count)]
+    pub parent_node_name: ModelString<40>,
+    #[version_smaller(2, 3)]
+    #[new_derive]
+    pub texture_count: Option<u32>,
+    #[repeating_option(texture_count)]
     pub texture_indices: Vec<u32>,
+    #[version_equals_or_above(2, 3)]
+    #[new_derive]
+    pub texture_name_count: Option<u32>,
+    #[repeating_option(texture_name_count)]
+    pub texture_names: Vec<ModelString<40>>,
     #[cfg_attr(feature = "interface", hidden_element)]
     pub offset_matrix: Matrix3<f32>,
-    pub translation1: Vector3<f32>,
+    #[version_smaller(2, 2)]
+    pub translation1: Option<Vector3<f32>>,
     pub translation2: Vector3<f32>,
-    pub rotation_angle: f32,
-    pub rotation_axis: Vector3<f32>,
-    pub scale: Vector3<f32>,
+    #[version_smaller(2, 2)]
+    pub rotation_angle: Option<f32>,
+    #[version_smaller(2, 2)]
+    pub rotation_axis: Option<Vector3<f32>>,
+    #[version_smaller(2, 2)]
+    pub scale: Option<Vector3<f32>>,
     #[new_derive]
     pub vertex_position_count: u32,
     #[repeating(vertex_position_count)]
@@ -115,15 +183,25 @@ pub struct NodeData {
     pub face_count: u32,
     #[repeating(face_count)]
     pub faces: Vec<FaceData>,
-    #[version_equals_or_above(2, 5)] // unsure what vesion this is supposed to be (must be > 1.5)
+    #[version_equals_or_above(1, 6)]
     #[new_derive]
-    pub position_keyframe_count: Option<u32>,
-    #[repeating_option(position_keyframe_count)]
-    pub position_keyframes: Vec<PositionKeyframeData>,
+    pub scale_keyframe_count: Option<u32>,
+    #[repeating_option(scale_keyframe_count)]
+    pub scale_keyframes: Vec<ScaleKeyframeData>,
     #[new_derive]
     pub rotation_keyframe_count: u32,
     #[repeating(rotation_keyframe_count)]
     pub rotation_keyframes: Vec<RotationKeyframeData>,
+    #[version_equals_or_above(2, 2)]
+    #[new_derive]
+    pub translation_keyframe_count: Option<u32>,
+    #[repeating_option(translation_keyframe_count)]
+    pub translation_keyframes: Vec<TranslationKeyframeData>,
+    #[version_equals_or_above(2, 3)]
+    #[new_derive]
+    pub textures_keyframe_count: Option<u32>,
+    #[repeating_option(textures_keyframe_count)]
+    pub textures_keyframes: Vec<TexturesKeyframeData>,
 }
 
 #[derive(Debug, ByteConvertable)]
@@ -139,18 +217,21 @@ pub struct ModelData {
     pub alpha: Option<u8>,
     #[version_smaller(2, 2)]
     #[new_default]
-    pub reserved0: Option<[u8; 16]>,
+    pub reserved: Option<[u8; 16]>,
     #[version_equals_or_above(2, 2)]
-    #[new_default]
-    pub reserved1: Option<[u8; 4]>,
+    pub frames_per_second: Option<f32>,
+    #[version_smaller(2, 3)]
     #[new_derive]
-    pub texture_count: u32,
-    #[repeating(texture_count)]
+    pub texture_count: Option<u32>,
+    #[repeating_option(texture_count)]
     pub texture_names: Vec<ModelString<40>>,
+    #[version_smaller(2, 2)]
+    pub root_node_name: Option<ModelString<40>>,
     #[version_equals_or_above(2, 2)]
-    #[new_default]
-    pub skip: Option<u32>,
-    pub root_node_name: ModelString<40>,
+    #[new_derive]
+    pub root_node_count: Option<u32>,
+    #[repeating_option(root_node_count)]
+    pub root_node_names: Vec<ModelString<40>>,
     #[new_derive]
     pub node_count: u32,
     #[repeating(node_count)]


### PR DESCRIPTION
Update the RSM bytestream to be compatible with version 2.2 and 2.3.