### PR TITLE
Unifies the fallback loading

### DIFF
--- a/korangar/src/loaders/mod.rs
+++ b/korangar/src/loaders/mod.rs
@@ -24,3 +24,10 @@ pub use self::script::{ResourceMetadata, ScriptLoader};
 pub use self::server::{load_client_info, ClientInfo, ServiceId};
 pub use self::sprite::*;
 pub use self::texture::{TextureAtlasFactory, TextureLoader};
+
+pub const FALLBACK_PNG_FILE: &str = "missing.png";
+pub const FALLBACK_BMP_FILE: &str = "missing.bmp";
+pub const FALLBACK_TGA_FILE: &str = "missing.tga";
+pub const FALLBACK_MODEL_FILE: &str = "missing.rsm";
+pub const FALLBACK_SPRITE_FILE: &str = "npc\\missing.spr";
+pub const FALLBACK_ACTIONS_FILE: &str = "npc\\missing.act";

--- a/korangar/src/loaders/sprite/mod.rs
+++ b/korangar/src/loaders/sprite/mod.rs
@@ -39,10 +39,18 @@ impl SpriteLoader {
         #[cfg(feature = "debug")]
         let timer = Timer::new_dynamic(format!("load sprite from {}", path.magenta()));
 
-        let bytes = self
-            .game_file_loader
-            .get(&format!("data\\sprite\\{path}"))
-            .map_err(LoadError::File)?;
+        let bytes = match self.game_file_loader.get(&format!("data\\sprite\\{path}")) {
+            Ok(bytes) => bytes,
+            Err(_error) => {
+                #[cfg(feature = "debug")]
+                {
+                    print_debug!("Failed to load sprite: {:?}", _error);
+                    print_debug!("Replacing with fallback");
+                }
+
+                return self.get(FALLBACK_SPRITE_FILE);
+            }
+        };
         let mut byte_stream: ByteStream<Option<InternalVersion>> = ByteStream::without_metadata(&bytes);
 
         let sprite_data = match SpriteData::from_bytes(&mut byte_stream) {

--- a/korangar/src/loaders/texture/mod.rs
+++ b/korangar/src/loaders/texture/mod.rs
@@ -63,13 +63,29 @@ impl TextureLoader {
             ".png" => ImageFormat::Png,
             ".bmp" | ".BMP" => ImageFormat::Bmp,
             ".tga" | ".TGA" => ImageFormat::Tga,
-            extension => return Err(LoadError::UnsupportedFormat(extension.to_owned())),
+            _ => {
+                #[cfg(feature = "debug")]
+                {
+                    print_debug!("File with unknown image format found: {:?}", path);
+                    print_debug!("Replacing with fallback");
+                }
+
+                return self.load_texture_data(FALLBACK_PNG_FILE);
+            }
         };
 
-        let file_data = self
-            .game_file_loader
-            .get(&format!("data\\texture\\{path}"))
-            .map_err(LoadError::File)?;
+        let file_data = match self.game_file_loader.get(&format!("data\\texture\\{path}")) {
+            Ok(file_data) => file_data,
+            Err(_error) => {
+                #[cfg(feature = "debug")]
+                {
+                    print_debug!("Failed to load image: {:?}", _error);
+                    print_debug!("Replacing with fallback");
+                }
+
+                return self.load_texture_data(FALLBACK_PNG_FILE);
+            }
+        };
         let reader = ImageReader::with_format(Cursor::new(file_data), image_format);
 
         let mut image_buffer = match reader.decode() {

--- a/korangar_util/src/loader.rs
+++ b/korangar_util/src/loader.rs
@@ -1,5 +1,4 @@
 /// Error that is thrown when a file loader can't find the requested file.
-#[derive(Debug)]
 #[repr(transparent)]
 pub struct FileNotFoundError(String);
 
@@ -7,6 +6,12 @@ impl FileNotFoundError {
     /// Create a new [`FileNotFoundError`] with a given path.
     pub fn new(path: String) -> Self {
         Self(path)
+    }
+}
+
+impl std::fmt::Debug for FileNotFoundError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "can't find file: {}", self.0)
     }
 }
 


### PR DESCRIPTION
Moved the fallback handling in the specific loader of the resource. The specific loader can then decide, if it's a hard error or a fallback is needed.

This also adds a fallback in case an image format is not supported yet (for example BINK video files).