### PR TITLE
Remove the white border in entity

### DIFF
--- a/korangar/src/graphics/instruction.rs
+++ b/korangar/src/graphics/instruction.rs
@@ -186,6 +186,7 @@ pub struct EntityInstruction {
     pub mirror: bool,
     pub entity_id: EntityId,
     pub opaque: bool,
+    pub pickerable: bool,
     pub texture: Arc<Texture>,
 }
 

--- a/korangar/src/graphics/instruction.rs
+++ b/korangar/src/graphics/instruction.rs
@@ -185,6 +185,7 @@ pub struct EntityInstruction {
     pub color: Color,
     pub mirror: bool,
     pub entity_id: EntityId,
+    pub opaque: bool,
     pub texture: Arc<Texture>,
 }
 

--- a/korangar/src/graphics/passes/forward/entity.rs
+++ b/korangar/src/graphics/passes/forward/entity.rs
@@ -36,8 +36,9 @@ pub(crate) struct InstanceData {
     angle: f32,
     curvature: f32,
     mirror: u32,
+    opaque: u32,
     texture_index: i32,
-    padding: [u32; 2],
+    padding: u32,
 }
 
 pub(crate) struct ForwardEntityDrawer {
@@ -265,6 +266,7 @@ impl Prepare for ForwardEntityDrawer {
                     depth_offset: instruction.depth_offset,
                     curvature: instruction.curvature,
                     mirror: instruction.mirror as u32,
+                    opaque: instruction.opaque as u32,
                     texture_index,
                     padding: Default::default(),
                 });
@@ -289,6 +291,7 @@ impl Prepare for ForwardEntityDrawer {
                     depth_offset: instruction.depth_offset,
                     curvature: instruction.curvature,
                     mirror: instruction.mirror as u32,
+                    opaque: instruction.opaque as u32,
                     texture_index: 0,
                     padding: Default::default(),
                 });

--- a/korangar/src/graphics/passes/forward/shader/entity.wgsl
+++ b/korangar/src/graphics/passes/forward/shader/entity.wgsl
@@ -139,7 +139,10 @@ fn fs_main(input: VertexOutput) -> FragmentOutput {
         discard;
     }
 
+    // TODO - OPAQUE: The correct way is to have a pass without blending for opaque entity framepart
+    // and a pass with blending for semi-transparent entity framepart
     diffuse_color.a = select(diffuse_color.a, 1.0, input.opaque != 0u);
+
     // Calculate which tile this fragment belongs to
     let pixel_position = vec2<u32>(floor(input.position.xy));
     let tile_x = pixel_position.x / TILE_SIZE;

--- a/korangar/src/graphics/passes/forward/shader/entity.wgsl
+++ b/korangar/src/graphics/passes/forward/shader/entity.wgsl
@@ -38,6 +38,7 @@ struct InstanceData {
     angle: f32,
     curvature: f32,
     mirror: u32,
+    opaque: u32,
     texture_index: i32,
 }
 
@@ -63,6 +64,7 @@ struct VertexOutput {
     @location(6) @interpolate(flat) original_curvature: f32,
     @location(7) angle: f32,
     @location(8) color: vec4<f32>,
+    @location(9) opaque: u32,
 }
 
 struct FragmentOutput {
@@ -118,6 +120,7 @@ fn vs_main(
     output.original_curvature = instance.curvature;
     output.angle = instance.angle;
     output.color = instance.color;
+    output.opaque = instance.opaque;
     return output;
 }
 
@@ -129,13 +132,14 @@ fn fs_main(input: VertexOutput) -> FragmentOutput {
     let rotate = vec2(input.texture_coordinates.x - 0.5, input.texture_coordinates.y - 0.5) * mat2x2(cos_factor, sin_factor, -sin_factor, cos_factor);
     let texture_coordinates = vec2(clamp(rotate.x + 0.5, 0.0, 1.0), clamp(rotate.y + 0.5, 0.0, 1.0));
 
-    let diffuse_color = textureSample(texture, texture_sampler, texture_coordinates);
+    var diffuse_color = textureSample(texture, texture_sampler, texture_coordinates);
     let alpha_channel = textureSample(texture, nearest_sampler, texture_coordinates).a;
 
     if (alpha_channel == 0.0) {
         discard;
     }
 
+    diffuse_color.a = select(diffuse_color.a, 1.0, input.opaque != 0u);
     // Calculate which tile this fragment belongs to
     let pixel_position = vec2<u32>(floor(input.position.xy));
     let tile_x = pixel_position.x / TILE_SIZE;

--- a/korangar/src/graphics/passes/forward/shader/entity_bindless.wgsl
+++ b/korangar/src/graphics/passes/forward/shader/entity_bindless.wgsl
@@ -142,7 +142,10 @@ fn fs_main(input: VertexOutput) -> FragmentOutput {
         discard;
     }
 
+    // TODO - OPAQUE: The correct way is to have a pass without blending for opaque entity framepart
+    // and a pass with blending for semi-transparent entity framepart.
     diffuse_color.a = select(diffuse_color.a, 1.0, input.opaque != 0u);
+
     // Calculate which tile this fragment belongs to
     let pixel_position = vec2<u32>(floor(input.position.xy));
     let tile_x = pixel_position.x / TILE_SIZE;

--- a/korangar/src/graphics/passes/picker/entity.rs
+++ b/korangar/src/graphics/passes/picker/entity.rs
@@ -214,6 +214,7 @@ impl Drawer<{ BindGroupCount::One }, { ColorAttachmentCount::One }, { DepthAttac
 
 impl Prepare for PickerEntityDrawer {
     fn prepare(&mut self, device: &Device, instructions: &RenderInstruction) {
+        // TODO: Pass the player size directly
         let player_size = 2;
         self.draw_count = instructions.entities.len().saturating_sub(player_size);
 
@@ -232,7 +233,7 @@ impl Prepare for PickerEntityDrawer {
             // We skip the first entity, because we don't want the player entity to show up
             // in the picker buffer.
             // TODO: Remove the player entity correctly.
-            for instruction in instructions.entities.iter().skip(player_size) {
+            for instruction in instructions.entities.iter().filter(|instruction| instruction.pickerable == true) {
                 let picker_target = PickerTarget::Entity(instruction.entity_id);
                 let (identifier_high, identifier_low) = picker_target.into();
 
@@ -267,7 +268,7 @@ impl Prepare for PickerEntityDrawer {
             // We skip the first entity, because we don't want the player entity to show up
             // in the picker buffer.
             // TODO: Remove the player entity correctly.
-            for instruction in instructions.entities.iter().skip(player_size) {
+            for instruction in instructions.entities.iter().filter(|instruction| instruction.pickerable == true) {
                 let picker_target = PickerTarget::Entity(instruction.entity_id);
                 let (identifier_high, identifier_low) = picker_target.into();
 

--- a/korangar/src/main.rs
+++ b/korangar/src/main.rs
@@ -2035,6 +2035,17 @@ impl Client {
             #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_entities))]
             self.map
                 .render_entities(&mut self.entity_instructions, entities, current_camera, true);
+            // TODO - OPAQUE: Separate entity_instruction into opaque and semi-transparent.
+            // For opaque pipeline, disable alpha blending; for semi-transparent pipeline,
+            // enable alpha blending.
+            self.entity_instructions.sort_by(|a, b| {
+                if a.opaque == b.opaque {
+                    // As we use reverse depth offset, the comparisor is inverted
+                    a.depth_offset.partial_cmp(&b.depth_offset).unwrap()
+                } else {
+                    b.opaque.cmp(&a.opaque)
+                }
+            });
 
             #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_water))]
             self.map.render_water(&mut map_water_vertex_buffer);

--- a/korangar/src/world/animation/mod.rs
+++ b/korangar/src/world/animation/mod.rs
@@ -82,6 +82,7 @@ impl AnimationData {
         entity_position: Point3<f32>,
         animation_state: &AnimationState,
         head_direction: usize,
+        pickerable: bool,
     ) {
         let camera_direction = camera.camera_direction();
         let direction = (camera_direction + head_direction) % 8;
@@ -147,6 +148,7 @@ impl AnimationData {
                 color: frame_part.color,
                 mirror: frame_part.mirror,
                 opaque: **opaque && (frame_part.color.alpha == 1.0),
+                pickerable,
                 entity_id,
                 texture: texture.clone(),
             });

--- a/korangar/src/world/animation/mod.rs
+++ b/korangar/src/world/animation/mod.rs
@@ -113,6 +113,7 @@ impl AnimationData {
             let animation_index = frame_part.animation_index;
             let sprite_number = frame_part.sprite_number;
             let texture = &self.animation_pair[animation_index].sprites.textures[sprite_number];
+            let opaque = &self.animation_pair[animation_index].sprites.vec_opaque[sprite_number];
 
             // The constant 10.0 is a magic scale factor of an image.
             // The vertex position is calculated from the center of image, so we need to
@@ -145,6 +146,7 @@ impl AnimationData {
                 angle: frame_part.angle,
                 color: frame_part.color,
                 mirror: frame_part.mirror,
+                opaque: **opaque && (frame_part.color.alpha == 1.0),
                 entity_id,
                 texture: texture.clone(),
             });

--- a/korangar/src/world/entity/mod.rs
+++ b/korangar/src/world/entity/mod.rs
@@ -762,7 +762,7 @@ impl Common {
         }
     }
 
-    pub fn render(&self, instructions: &mut Vec<EntityInstruction>, camera: &dyn Camera) {
+    pub fn render(&self, instructions: &mut Vec<EntityInstruction>, camera: &dyn Camera, pickerable: bool) {
         self.animation_data.render(
             instructions,
             camera,
@@ -770,6 +770,7 @@ impl Common {
             self.position,
             &self.animation_state,
             self.head_direction,
+            pickerable,
         );
     }
 
@@ -1130,8 +1131,8 @@ impl Entity {
             .generate_pathing_mesh(device, queue, map, pathing_texture_mapping);
     }
 
-    pub fn render(&self, instructions: &mut Vec<EntityInstruction>, camera: &dyn Camera) {
-        self.get_common().render(instructions, camera);
+    pub fn render(&self, instructions: &mut Vec<EntityInstruction>, camera: &dyn Camera, pickerable: bool) {
+        self.get_common().render(instructions, camera, pickerable);
     }
 
     #[cfg(feature = "debug")]

--- a/korangar/src/world/map/mod.rs
+++ b/korangar/src/world/map/mod.rs
@@ -267,7 +267,7 @@ impl Map {
     pub fn render_entities(&self, instructions: &mut Vec<EntityInstruction>, entities: &[Entity], camera: &dyn Camera, include_self: bool) {
         let mut is_current_player = true || include_self;
         entities.iter().skip(!include_self as usize).for_each(|entity| {
-            entity.render(instructions, camera, is_current_player);
+            entity.render(instructions, camera, !is_current_player);
             is_current_player = false;
         });
     }

--- a/korangar/src/world/map/mod.rs
+++ b/korangar/src/world/map/mod.rs
@@ -265,10 +265,11 @@ impl Map {
 
     #[cfg_attr(feature = "debug", korangar_debug::profile)]
     pub fn render_entities(&self, instructions: &mut Vec<EntityInstruction>, entities: &[Entity], camera: &dyn Camera, include_self: bool) {
-        entities
-            .iter()
-            .skip(!include_self as usize)
-            .for_each(|entity| entity.render(instructions, camera));
+        let mut is_current_player = true || include_self;
+        entities.iter().skip(!include_self as usize).for_each(|entity| {
+            entity.render(instructions, camera, is_current_player);
+            is_current_player = false;
+        });
     }
 
     #[cfg(feature = "debug")]


### PR DESCRIPTION
The goal is to remove the white border in entity.
The alpha blending is bleeding in the border of the texture, because is sampling the transparent part of picture in weighted average, resulting in a white pixel. To correct the problem, the transparent border that is used in weighted average is recolored with color close to the opaque border.
![with_border_recoloring](https://github.com/user-attachments/assets/95f9674b-1b1e-43a3-8467-008249845801)
![without_border_recoloring](https://github.com/user-attachments/assets/6185b7bb-7e4b-4518-9fa7-ad220b29757f)

The depth buffer depends on the order of drawing, if you draw a transparent pixel, you can't draw a opaque pixel before the transparent pixel, to fix the problem, we sort by the value of the distance between the camera and the entity and render from farthest to nearest distance to camera. 
![depth_buffer](https://github.com/user-attachments/assets/c581a4b0-fb58-4f0a-b598-893b07278484)
![depth_buffer_transparent](https://github.com/user-attachments/assets/adb74c36-ecb6-4689-b5cf-c76505cb5ffe)

A small fix is made in the picker, after sorting the entities, the initial entries is not the current player anymore.
