### PR TITLE
Use signed distance to render smooth edges

### DIFF
--- a/korangar/src/graphics/capabilities.rs
+++ b/korangar/src/graphics/capabilities.rs
@@ -4,7 +4,7 @@ use std::num::NonZeroU32;
 use korangar_debug::logging::{print_debug, Colorize};
 use wgpu::{Adapter, Features, Limits, TextureFormat, TextureFormatFeatureFlags};
 
-use crate::graphics::Msaa;
+use crate::graphics::{Msaa, RENDER_TO_TEXTURE_DEPTH_FORMAT, RENDER_TO_TEXTURE_FORMAT};
 
 const MAX_TEXTURES_PER_SHADER_STAGE: u32 = 1024;
 const MAX_TEXTURE_SIZE: u32 = 8192;
@@ -26,7 +26,7 @@ impl Capabilities {
 
         // We need to test all textures that we use for MSAA
         // which sample count they support.
-        let supported_msaa = determine_supported_msaa(adapter, &[TextureFormat::Depth32Float, TextureFormat::Rgba8UnormSrgb]);
+        let supported_msaa = determine_supported_msaa(adapter, &[RENDER_TO_TEXTURE_FORMAT, RENDER_TO_TEXTURE_DEPTH_FORMAT]);
 
         let mut capabilities = Self {
             supported_msaa,

--- a/korangar/src/graphics/instruction.rs
+++ b/korangar/src/graphics/instruction.rs
@@ -121,7 +121,6 @@ pub enum InterfaceRectangleInstruction {
         screen_clip: ScreenClip,
         color: Color,
         corner_radius: CornerRadius,
-        aspect_ratio: f32,
     },
     Sprite {
         screen_position: ScreenPosition,

--- a/korangar/src/graphics/mod.rs
+++ b/korangar/src/graphics/mod.rs
@@ -62,6 +62,7 @@ const LIGHT_TILE_SIZE: u32 = 16;
 /// Bot requirements are needed at the same time, since we want to be able to
 /// re-use the forward color texture, if possible.
 pub const RENDER_TO_TEXTURE_FORMAT: TextureFormat = TextureFormat::Rgba16Float;
+pub const RENDER_TO_TEXTURE_DEPTH_FORMAT: TextureFormat = TextureFormat::Depth32Float;
 
 pub const INTERFACE_TEXTURE_FORMAT: TextureFormat = TextureFormat::Rgba8UnormSrgb;
 pub const FXAA_COLOR_LUMA_TEXTURE_FORMAT: TextureFormat = TextureFormat::Rgba8UnormSrgb;
@@ -527,12 +528,12 @@ impl GlobalContext {
             TextureFormat::Rg32Uint,
             AttachmentTextureType::PickerAttachment,
         );
-        let picker_depth_texture = picker_factory.new_attachment("depth", TextureFormat::Depth32Float, AttachmentTextureType::Depth);
+        let picker_depth_texture = picker_factory.new_attachment("depth", RENDER_TO_TEXTURE_DEPTH_FORMAT, AttachmentTextureType::Depth);
 
         let (forward_color_texture, forward_depth_texture) =
             Self::create_forward_texture(device, screen_size, msaa, screen_space_anti_aliasing);
 
-        let interface_screen_factory = AttachmentTextureFactory::new(device, screen_size, 4, None);
+        let interface_screen_factory = AttachmentTextureFactory::new(device, screen_size, 1, None);
 
         let interface_buffer_texture = interface_screen_factory.new_attachment(
             "interface buffer",
@@ -588,7 +589,7 @@ impl GlobalContext {
 
         let factory = AttachmentTextureFactory::new(device, screen_size, msaa.sample_count(), None);
         let color_texture = factory.new_attachment("forward color", RENDER_TO_TEXTURE_FORMAT, texture_type);
-        let depth_texture = factory.new_attachment("forward depth", TextureFormat::Depth32Float, AttachmentTextureType::Depth);
+        let depth_texture = factory.new_attachment("forward depth", RENDER_TO_TEXTURE_DEPTH_FORMAT, AttachmentTextureType::Depth);
         (color_texture, depth_texture)
     }
 

--- a/korangar/src/graphics/passes/interface/rectangle.rs
+++ b/korangar/src/graphics/passes/interface/rectangle.rs
@@ -32,10 +32,10 @@ struct InstanceData {
     screen_size: [f32; 2],
     texture_position: [f32; 2],
     texture_size: [f32; 2],
-    aspect_ratio: f32,
     rectangle_type: u32,
     texture_index: i32,
     smooth: u32,
+    padding: u32,
 }
 
 pub(crate) struct InterfaceRectangleDrawer {
@@ -191,13 +191,7 @@ impl Drawer<{ BindGroupCount::One }, { ColorAttachmentCount::One }, { DepthAttac
             }),
             multiview: None,
             primitive: Default::default(),
-            multisample: MultisampleState {
-                // We render the interface always with 4x MSAA.
-                // This makes sure to remove hard edges in the GUI elements.
-                // 4x MSAA is guaranteed by WebGPU spec to be available.
-                count: 4,
-                ..Default::default()
-            },
+            multisample: MultisampleState::default(),
             depth_stencil: None,
             cache: None,
         });
@@ -269,7 +263,6 @@ impl Prepare for InterfaceRectangleDrawer {
                         screen_clip,
                         color,
                         corner_radius,
-                        aspect_ratio,
                     } => {
                         self.instance_data.push(InstanceData {
                             color: color.components_linear(),
@@ -279,10 +272,10 @@ impl Prepare for InterfaceRectangleDrawer {
                             screen_size: (*screen_size).into(),
                             texture_position: [0.0, 0.0],
                             texture_size: [1.0, 1.0],
-                            aspect_ratio: *aspect_ratio,
                             rectangle_type: 0,
                             texture_index: 0,
                             smooth: 0,
+                            padding: 0,
                         });
                     }
                     InterfaceRectangleInstruction::Sprite {
@@ -312,10 +305,10 @@ impl Prepare for InterfaceRectangleDrawer {
                             screen_size: (*screen_size).into(),
                             texture_position: [0.0, 0.0],
                             texture_size: [1.0, 1.0],
-                            aspect_ratio: 0.0,
                             rectangle_type: 1,
                             texture_index,
                             smooth: *smooth as u32,
+                            padding: 0,
                         });
                     }
                     InterfaceRectangleInstruction::Text {
@@ -334,10 +327,10 @@ impl Prepare for InterfaceRectangleDrawer {
                             screen_size: (*screen_size).into(),
                             texture_position: (*texture_position).into(),
                             texture_size: (*texture_size).into(),
-                            aspect_ratio: 0.0,
                             rectangle_type: 2,
                             texture_index: 0,
                             smooth: 1,
+                            padding: 0,
                         });
                     }
                 }
@@ -364,7 +357,6 @@ impl Prepare for InterfaceRectangleDrawer {
                         screen_clip,
                         color,
                         corner_radius,
-                        aspect_ratio,
                     } => {
                         self.instance_data.push(InstanceData {
                             color: color.components_linear(),
@@ -374,10 +366,10 @@ impl Prepare for InterfaceRectangleDrawer {
                             screen_size: (*screen_size).into(),
                             texture_position: [0.0, 0.0],
                             texture_size: [1.0, 1.0],
-                            aspect_ratio: *aspect_ratio,
                             rectangle_type: 0,
                             texture_index: 0,
                             smooth: 0,
+                            padding: 0,
                         });
                     }
                     InterfaceRectangleInstruction::Sprite {
@@ -396,10 +388,10 @@ impl Prepare for InterfaceRectangleDrawer {
                             screen_size: (*screen_size).into(),
                             texture_position: [0.0, 0.0],
                             texture_size: [1.0, 1.0],
-                            aspect_ratio: 0.0,
                             rectangle_type: 1,
                             texture_index: 0,
                             smooth: *smooth as u32,
+                            padding: 0,
                         });
                     }
                     InterfaceRectangleInstruction::Text {
@@ -418,10 +410,10 @@ impl Prepare for InterfaceRectangleDrawer {
                             screen_size: (*screen_size).into(),
                             texture_position: (*texture_position).into(),
                             texture_size: (*texture_size).into(),
-                            aspect_ratio: 0.0,
                             rectangle_type: 2,
                             texture_index: 0,
                             smooth: 1,
+                            padding: 0,
                         });
                     }
                 }

--- a/korangar/src/graphics/passes/interface/shader/rectangle.wgsl
+++ b/korangar/src/graphics/passes/interface/shader/rectangle.wgsl
@@ -1,3 +1,19 @@
+struct GlobalUniforms {
+    view_projection: mat4x4<f32>,
+    view: mat4x4<f32>,
+    inverse_view: mat4x4<f32>,
+    inverse_projection: mat4x4<f32>,
+    indicator_positions: mat4x4<f32>,
+    indicator_color: vec4<f32>,
+    ambient_color: vec4<f32>,
+    screen_size: vec2<u32>,
+    pointer_position: vec2<u32>,
+    animation_timer: f32,
+    day_timer: f32,
+    water_level: f32,
+    point_light_count: u32,
+}
+
 struct InstanceData {
     color: vec4<f32>,
     corner_radius: vec4<f32>,
@@ -6,7 +22,6 @@ struct InstanceData {
     screen_size: vec2<f32>,
     texture_position: vec2<f32>,
     texture_size: vec2<f32>,
-    aspect_ratio: f32,
     rectangle_type: u32,
     texture_index: i32,
     linear_filtering: u32,
@@ -19,6 +34,7 @@ struct VertexOutput {
     @location(2) instance_index: u32,
 }
 
+@group(0) @binding(0) var<uniform> global_uniforms: GlobalUniforms;
 @group(0) @binding(1) var nearest_sampler: sampler;
 @group(0) @binding(2) var linear_sampler: sampler;
 @group(1) @binding(0) var<storage, read> instance_data: array<InstanceData>;
@@ -38,7 +54,7 @@ fn vs_main(
 
     var output: VertexOutput;
     output.position = vec4<f32>(position, 0.0, 1.0);
-    output.fragment_position = vertex.zw;
+    output.fragment_position = clip_to_screen_space(position);
     output.texture_coordinates = instance.texture_position + vertex.zw * instance.texture_size;
     output.instance_index = instance_index;
     return output;
@@ -48,80 +64,78 @@ fn vs_main(
 fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     let instance = instance_data[input.instance_index];
 
+    if (input.position.x < instance.screen_clip.x || input.position.y < instance.screen_clip.y ||
+        input.position.x > instance.screen_clip.z || input.position.y > instance.screen_clip.w) {
+        return vec4<f32>(0.0);
+    }
+
     switch (instance.rectangle_type) {
         case 0u: {
-            return draw_solid(instance, input.position, input.fragment_position);
+            return draw_solid(instance, input.fragment_position);
         }
         case 1u: {
-            return draw_sprite(instance, input.position, input.texture_coordinates, instance.linear_filtering);
+            return draw_sprite(instance, input.texture_coordinates);
         }
         default: {
-            return draw_text(instance, input.position, input.texture_coordinates);
+            return draw_text(instance, input.texture_coordinates);
         }
     }
 }
 
 fn draw_solid(
     instance: InstanceData,
-    position: vec4<f32>,
     fragment_position: vec2<f32>
 ) -> vec4<f32> {
-    var coords = fragment_position * instance.screen_size;
-    var screen_size = instance.screen_size;
-    let corner_radius = instance.corner_radius * 0.5;
+    let corner_radii = instance.corner_radius;
 
-    coords.x /= instance.aspect_ratio;
-    screen_size.x /= instance.aspect_ratio;
-
-    // top-left
-    if (length(coords - corner_radius.x) > corner_radius.x && coords.x < corner_radius.x &&
-        coords.y < corner_radius.x) {
-        discard;
+    if (all(corner_radii == vec4<f32>(0.0))) {
+        return instance.color;
     }
 
-    // top-right
-    if (length(coords - vec2<f32>(screen_size.x - corner_radius.y, corner_radius.y)) > corner_radius.y &&
-        screen_size.x - coords.x < corner_radius.y && coords.y < corner_radius.y) {
-        discard;
+    // Convert normalized screen space coordinates to pixel space.
+    let window_size = vec2<f32>(global_uniforms.screen_size);
+    let position = fragment_position * window_size;
+    let screen_position = instance.screen_position * window_size;
+    let screen_size = instance.screen_size * window_size;
+
+    // Calculate position relative to rectangle center.
+    let half_screen_size = screen_size * 0.5;
+    let rectangle_center = screen_position + half_screen_size;
+    let relative_position = position - rectangle_center;
+
+    // Determine which corner radius to use based on the quadrant this fragment is in.
+    let is_right = relative_position.x > 0.0;
+    let is_bottom = relative_position.y > 0.0;
+    let radii_pair = select(corner_radii.xy, corner_radii.zw, is_bottom);
+    let corner_radius = select(radii_pair.x, radii_pair.y, is_right);
+
+    if (corner_radius == 0.0) {
+        return instance.color;
     }
 
-    // bottom-right
-    if (length(coords - screen_size + corner_radius.z) > corner_radius.z &&
-        screen_size.x - coords.x < corner_radius.z && screen_size.y - coords.y < corner_radius.z) {
-        discard;
-    }
+    let distance = rectangle_sdf(
+        relative_position,
+        half_screen_size,
+        corner_radius,
+    );
 
-    // bottom-left
-    if (length(coords - vec2<f32>(corner_radius.w, screen_size.y - corner_radius.w)) > corner_radius.w &&
-        coords.x < corner_radius.w && screen_size.y - coords.y < corner_radius.w) {
-        discard;
-    }
+    // Apply smoothing using screen space derivatives.
+    let pixel_size = length(vec2(dpdx(distance), dpdy(distance))) * 2.0;
+    let alpha = smoothstep(0.5, -0.5, distance / pixel_size);
 
-    if (position.x < instance.screen_clip.x || position.y < instance.screen_clip.y ||
-        position.x > instance.screen_clip.z || position.y > instance.screen_clip.w) {
-        discard;
-    }
-
-    return instance.color;
+    return vec4<f32>(instance.color.rgb, instance.color.a * alpha);
 }
 
 fn draw_sprite(
     instance: InstanceData,
-    position: vec4<f32>,
     texture_coordinates: vec2<f32>,
-    linear_filtering: u32
 ) -> vec4<f32> {
     var color: vec4<f32>;
 
-    if linear_filtering == 0u {
+    if instance.linear_filtering == 0u {
         color = textureSample(texture, nearest_sampler, texture_coordinates);
     } else {
         color = textureSample(texture, linear_sampler, texture_coordinates);
-    }
-
-    if (position.x < instance.screen_clip.x || position.y < instance.screen_clip.y ||
-        position.x > instance.screen_clip.z || position.y > instance.screen_clip.w) {
-        discard;
     }
 
     return color * instance.color;
@@ -129,16 +143,9 @@ fn draw_sprite(
 
 fn draw_text(
     instance: InstanceData,
-    position: vec4<f32>,
     texture_coordinates: vec2<f32>,
 ) -> vec4<f32> {
     let coverage = textureSample(font_atlas, linear_sampler, texture_coordinates).r;
-
-    if (position.x < instance.screen_clip.x || position.y < instance.screen_clip.y ||
-        position.x > instance.screen_clip.z || position.y > instance.screen_clip.w) {
-        discard;
-    }
-
     return vec4<f32>(instance.color.rgb, coverage * instance.color.a);
 }
 
@@ -165,4 +172,23 @@ fn screen_to_clip_space(screen_coords: vec2<f32>) -> vec2<f32> {
     let x = (screen_coords.x * 2.0) - 1.0;
     let y = -(screen_coords.y * 2.0) + 1.0;
     return vec2<f32>(x, y);
+}
+
+fn clip_to_screen_space(ndc: vec2<f32>) -> vec2<f32> {
+    let u = (ndc.x + 1.0) / 2.0;
+    let v = (1.0 - ndc.y) / 2.0;
+    return vec2<f32>(u, v);
+}
+
+// Calculation based on:
+// "Leveraging Rust and the GPU to render user interfaces at 120 FPS"
+// https://zed.dev/blog/videogame
+fn rectangle_sdf(
+    relative_position: vec2<f32>,
+    half_size: vec2<f32>,
+    corner_radius: f32
+) -> f32 {
+    let shrunk_corner_position = half_size - corner_radius;
+    let pixel_to_shrunk_corner = max(vec2<f32>(0.0), abs(relative_position) - shrunk_corner_position);
+    return length(pixel_to_shrunk_corner) - corner_radius;
 }

--- a/korangar/src/graphics/passes/interface/shader/rectangle_bindless.wgsl
+++ b/korangar/src/graphics/passes/interface/shader/rectangle_bindless.wgsl
@@ -1,3 +1,19 @@
+struct GlobalUniforms {
+    view_projection: mat4x4<f32>,
+    view: mat4x4<f32>,
+    inverse_view: mat4x4<f32>,
+    inverse_projection: mat4x4<f32>,
+    indicator_positions: mat4x4<f32>,
+    indicator_color: vec4<f32>,
+    ambient_color: vec4<f32>,
+    screen_size: vec2<u32>,
+    pointer_position: vec2<u32>,
+    animation_timer: f32,
+    day_timer: f32,
+    water_level: f32,
+    point_light_count: u32,
+}
+
 struct InstanceData {
     color: vec4<f32>,
     corner_radius: vec4<f32>,
@@ -6,7 +22,6 @@ struct InstanceData {
     screen_size: vec2<f32>,
     texture_position: vec2<f32>,
     texture_size: vec2<f32>,
-    aspect_ratio: f32,
     rectangle_type: u32,
     texture_index: i32,
     linear_filtering: u32,
@@ -19,6 +34,7 @@ struct VertexOutput {
     @location(2) instance_index: u32,
 }
 
+@group(0) @binding(0) var<uniform> global_uniforms: GlobalUniforms;
 @group(0) @binding(1) var nearest_sampler: sampler;
 @group(0) @binding(2) var linear_sampler: sampler;
 @group(1) @binding(0) var<storage, read> instance_data: array<InstanceData>;
@@ -38,7 +54,7 @@ fn vs_main(
 
     var output: VertexOutput;
     output.position = vec4<f32>(position, 0.0, 1.0);
-    output.fragment_position = vertex.zw;
+    output.fragment_position = clip_to_screen_space(position);
     output.texture_coordinates = instance.texture_position + vertex.zw * instance.texture_size;
     output.instance_index = instance_index;
     return output;
@@ -48,81 +64,78 @@ fn vs_main(
 fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     let instance = instance_data[input.instance_index];
 
+    if (input.position.x < instance.screen_clip.x || input.position.y < instance.screen_clip.y ||
+        input.position.x > instance.screen_clip.z || input.position.y > instance.screen_clip.w) {
+        return vec4<f32>(0.0);
+    }
+
     switch (instance.rectangle_type) {
         case 0u: {
-            return draw_solid(instance, input.position, input.fragment_position);
+            return draw_solid(instance, input.fragment_position);
         }
         case 1u: {
-            return draw_sprite(instance, input.position, input.texture_coordinates, instance.texture_index, instance.linear_filtering);
+            return draw_sprite(instance, input.texture_coordinates);
         }
         default: {
-            return draw_text(instance, input.position, input.texture_coordinates);
+            return draw_text(instance, input.texture_coordinates);
         }
     }
 }
 
 fn draw_solid(
     instance: InstanceData,
-    position: vec4<f32>,
     fragment_position: vec2<f32>
 ) -> vec4<f32> {
-    var coords = fragment_position * instance.screen_size;
-    var screen_size = instance.screen_size;
-    let corner_radius = instance.corner_radius * 0.5;
+    let corner_radii = instance.corner_radius;
 
-    coords.x /= instance.aspect_ratio;
-    screen_size.x /= instance.aspect_ratio;
-
-    // top-left
-    if (length(coords - corner_radius.x) > corner_radius.x && coords.x < corner_radius.x &&
-        coords.y < corner_radius.x) {
-        discard;
+    if (all(corner_radii == vec4<f32>(0.0))) {
+        return instance.color;
     }
 
-    // top-right
-    if (length(coords - vec2<f32>(screen_size.x - corner_radius.y, corner_radius.y)) > corner_radius.y &&
-        screen_size.x - coords.x < corner_radius.y && coords.y < corner_radius.y) {
-        discard;
+    // Convert normalized screen space coordinates to pixel space.
+    let window_size = vec2<f32>(global_uniforms.screen_size);
+    let position = fragment_position * window_size;
+    let screen_position = instance.screen_position * window_size;
+    let screen_size = instance.screen_size * window_size;
+
+    // Calculate position relative to rectangle center.
+    let half_screen_size = screen_size * 0.5;
+    let rectangle_center = screen_position + half_screen_size;
+    let relative_position = position - rectangle_center;
+
+    // Determine which corner radius to use based on the quadrant this fragment is in.
+    let is_right = relative_position.x > 0.0;
+    let is_bottom = relative_position.y > 0.0;
+    let radii_pair = select(corner_radii.xy, corner_radii.zw, is_bottom);
+    let corner_radius = select(radii_pair.x, radii_pair.y, is_right);
+
+    if (corner_radius == 0.0) {
+        return instance.color;
     }
 
-    // bottom-right
-    if (length(coords - screen_size + corner_radius.z) > corner_radius.z &&
-        screen_size.x - coords.x < corner_radius.z && screen_size.y - coords.y < corner_radius.z) {
-        discard;
-    }
+    let distance = rectangle_sdf(
+        relative_position,
+        half_screen_size,
+        corner_radius,
+    );
 
-    // bottom-left
-    if (length(coords - vec2<f32>(corner_radius.w, screen_size.y - corner_radius.w)) > corner_radius.w &&
-        coords.x < corner_radius.w && screen_size.y - coords.y < corner_radius.w) {
-        discard;
-    }
+    // Apply smoothing using screen space derivatives.
+    let pixel_size = length(vec2(dpdx(distance), dpdy(distance))) * 2.0;
+    let alpha = smoothstep(0.5, -0.5, distance / pixel_size);
 
-    if (position.x < instance.screen_clip.x || position.y < instance.screen_clip.y ||
-        position.x > instance.screen_clip.z || position.y > instance.screen_clip.w) {
-        discard;
-    }
-
-    return instance.color;
+    return vec4<f32>(instance.color.rgb, instance.color.a * alpha);
 }
 
 fn draw_sprite(
     instance: InstanceData,
-    position: vec4<f32>,
     texture_coordinates: vec2<f32>,
-    texture_index: i32,
-    linear_filtering: u32
 ) -> vec4<f32> {
     var color: vec4<f32>;
 
-    if linear_filtering == 0u {
-        color = textureSample(textures[texture_index], nearest_sampler, texture_coordinates);
+    if instance.linear_filtering == 0u {
+        color = textureSample(textures[instance.texture_index], nearest_sampler, texture_coordinates);
     } else {
-        color = textureSample(textures[texture_index], linear_sampler, texture_coordinates);
-    }
-
-    if (position.x < instance.screen_clip.x || position.y < instance.screen_clip.y ||
-        position.x > instance.screen_clip.z || position.y > instance.screen_clip.w) {
-        discard;
+        color = textureSample(textures[instance.texture_index], linear_sampler, texture_coordinates);
     }
 
     return color * instance.color;
@@ -130,16 +143,9 @@ fn draw_sprite(
 
 fn draw_text(
     instance: InstanceData,
-    position: vec4<f32>,
     texture_coordinates: vec2<f32>,
 ) -> vec4<f32> {
     let coverage = textureSample(font_atlas, linear_sampler, texture_coordinates).r;
-
-    if (position.x < instance.screen_clip.x || position.y < instance.screen_clip.y ||
-        position.x > instance.screen_clip.z || position.y > instance.screen_clip.w) {
-        discard;
-    }
-
     return vec4<f32>(instance.color.rgb, coverage * instance.color.a);
 }
 
@@ -166,4 +172,23 @@ fn screen_to_clip_space(screen_coords: vec2<f32>) -> vec2<f32> {
     let x = (screen_coords.x * 2.0) - 1.0;
     let y = -(screen_coords.y * 2.0) + 1.0;
     return vec2<f32>(x, y);
+}
+
+fn clip_to_screen_space(ndc: vec2<f32>) -> vec2<f32> {
+    let u = (ndc.x + 1.0) / 2.0;
+    let v = (1.0 - ndc.y) / 2.0;
+    return vec2<f32>(u, v);
+}
+
+// Calculation based on:
+// "Leveraging Rust and the GPU to render user interfaces at 120 FPS"
+// https://zed.dev/blog/videogame
+fn rectangle_sdf(
+    relative_position: vec2<f32>,
+    half_size: vec2<f32>,
+    corner_radius: f32
+) -> f32 {
+    let shrunk_corner_position = half_size - corner_radius;
+    let pixel_to_shrunk_corner = max(vec2<f32>(0.0), abs(relative_position) - shrunk_corner_position);
+    return length(pixel_to_shrunk_corner) - corner_radius;
 }

--- a/korangar/src/graphics/passes/postprocessing/blitter.rs
+++ b/korangar/src/graphics/passes/postprocessing/blitter.rs
@@ -60,8 +60,8 @@ impl Drawer<{ BindGroupCount::One }, { ColorAttachmentCount::One }, { DepthAttac
         if !modes.contains(&(color_texture_format, Msaa::Off, false, false)) {
             modes.push((color_texture_format, Msaa::Off, false, false));
         }
-        if !modes.contains(&(color_texture_format, Msaa::X4, false, true)) {
-            modes.push((color_texture_format, Msaa::X4, false, true));
+        if !modes.contains(&(color_texture_format, Msaa::Off, false, true)) {
+            modes.push((color_texture_format, Msaa::Off, false, true));
         }
 
         for (format, msaa, luma_in_alpha, alpha_blending) in modes {

--- a/korangar/src/interface/elements/profiler/frame.rs
+++ b/korangar/src/interface/elements/profiler/frame.rs
@@ -103,8 +103,9 @@ impl Element<InterfaceSettings> for FrameView {
 
         let (entries, statistics_map, longest_frame) = korangar_debug::profiling::get_statistics_data(*self.visible_thread.get());
 
-        let bar_width = (self.state.cached_size.width - 50.0) / entries.len() as f32;
-        let gap_width = 50.0 / entries.len() as f32;
+        let gap_width = 1.0;
+        let total_gaps = (entries.len() - 1) as f32 * gap_width;
+        let bar_width = (self.state.cached_size.width - total_gaps) / entries.len() as f32;
         let height_unit = self.state.cached_size.height / longest_frame.as_secs_f32();
         let mut x_position = 0.0;
         let mut color_lookup = super::ColorLookup::default();

--- a/korangar/src/interface/layout.rs
+++ b/korangar/src/interface/layout.rs
@@ -371,6 +371,6 @@ impl std::ops::Mul<f32> for CornerRadius {
 
 impl From<CornerRadius> for [f32; 4] {
     fn from(val: CornerRadius) -> Self {
-        [val.top_left, val.top_right, val.bottom_right, val.bottom_left]
+        [val.top_left, val.top_right, val.bottom_left, val.bottom_right]
     }
 }

--- a/korangar/src/renderer/interface.rs
+++ b/korangar/src/renderer/interface.rs
@@ -69,22 +69,22 @@ impl korangar_interface::application::InterfaceRenderer<InterfaceSettings> for I
         &self,
         position: <InterfaceSettings as Application>::Position,
         size: <InterfaceSettings as Application>::Size,
-        clip: <InterfaceSettings as Application>::Clip,
+        screen_clip: <InterfaceSettings as Application>::Clip,
         corner_radius: <InterfaceSettings as Application>::CornerRadius,
         color: <InterfaceSettings as Application>::Color,
     ) {
         let screen_position = position / self.window_size;
         let screen_size = size / self.window_size;
-        let pixel_size = 1.0 / self.window_size.height;
-        let corner_radius = corner_radius * pixel_size;
+        // TODO: NHA It seems that corners are currently defined as "double" their
+        //       actual size. We currently compensate for that.
+        let corner_radius = corner_radius * 0.5;
 
         self.instructions.borrow_mut().push(InterfaceRectangleInstruction::Solid {
             screen_position,
             screen_size,
-            screen_clip: clip,
+            screen_clip,
             color,
             corner_radius,
-            aspect_ratio: self.window_size.height / self.window_size.width,
         });
     }
 


### PR DESCRIPTION
First of all, I removed MSAA on the interface buffer. MSAA doesn't really help with the interface, because we essentially only render rectangles with no real edges.

We instead will now always try to use analytical antialiasing where ever possible.

Currently, we need smoothing for the edges of rectangles. This is now done by using a signed distance based approach, which mathematically defines the properties of our rectangle with rounded edges. We then use the signed distance to properly antialias the edges, using the screen space derivative and the smoothstep function.

I also tried to fix visual defects that became visible because of the lack of MSAA (profiler).