### PR TITLE
Implement and use premultiplied alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,6 +718,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
 
 [[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
+
+[[package]]
 name = "fastrand"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1406,7 +1412,7 @@ name = "korangar_util"
 version = "0.1.0"
 dependencies = [
  "cgmath",
- "derive-new",
+ "fast-srgb8",
  "hashbrown 0.15.0",
  "image",
  "korangar_interface",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ chrono = "0.4"
 cpal = "0.15"
 derive-new = "0.7"
 etherparse = "0.16"
+fast-srgb8 = "1"
 hashbrown = "0.15"
 image = { version = "0.25", default-features = false }
 kira = { version = "0.9", default-features = false }

--- a/korangar/src/graphics/color.rs
+++ b/korangar/src/graphics/color.rs
@@ -119,6 +119,9 @@ impl Color {
         }
     }
 
+    /// Converts the sRGB color into a linear representation for the shader.
+    /// Since we use pre-multiplied alpha blending, we premultiply the alpha
+    /// here too.
     pub fn components_linear(self) -> [f32; 4] {
         let srgb = [self.red, self.green, self.blue];
         let linear = srgb.map(|channel| {
@@ -128,7 +131,7 @@ impl Color {
                 ((channel + 0.055) / 1.055).powf(2.4)
             }
         });
-        [linear[0], linear[1], linear[2], self.alpha]
+        [linear[0] * self.alpha, linear[1] * self.alpha, linear[2] * self.alpha, self.alpha]
     }
 }
 

--- a/korangar/src/graphics/passes/forward/circle.rs
+++ b/korangar/src/graphics/passes/forward/circle.rs
@@ -95,7 +95,7 @@ impl Drawer<{ BindGroupCount::Two }, { ColorAttachmentCount::One }, { DepthAttac
                 compilation_options: PipelineCompilationOptions::default(),
                 targets: &[Some(ColorTargetState {
                     format: render_pass_context.color_attachment_formats()[0],
-                    blend: Some(BlendState::ALPHA_BLENDING),
+                    blend: Some(BlendState::PREMULTIPLIED_ALPHA_BLENDING),
                     write_mask: ColorWrites::default(),
                 })],
             }),

--- a/korangar/src/graphics/passes/forward/entity.rs
+++ b/korangar/src/graphics/passes/forward/entity.rs
@@ -163,7 +163,7 @@ impl Drawer<{ BindGroupCount::Two }, { ColorAttachmentCount::One }, { DepthAttac
                 compilation_options: PipelineCompilationOptions::default(),
                 targets: &[Some(ColorTargetState {
                     format: color_attachment_formats[0],
-                    blend: Some(BlendState::ALPHA_BLENDING),
+                    blend: Some(BlendState::PREMULTIPLIED_ALPHA_BLENDING),
                     write_mask: ColorWrites::default(),
                 })],
             }),

--- a/korangar/src/graphics/passes/forward/model.rs
+++ b/korangar/src/graphics/passes/forward/model.rs
@@ -305,7 +305,7 @@ impl ForwardModelDrawer {
                 compilation_options: PipelineCompilationOptions::default(),
                 targets: &[Some(ColorTargetState {
                     format: render_pass_context.color_attachment_formats()[0],
-                    blend: Some(BlendState::ALPHA_BLENDING),
+                    blend: Some(BlendState::PREMULTIPLIED_ALPHA_BLENDING),
                     write_mask: ColorWrites::default(),
                 })],
             }),

--- a/korangar/src/graphics/passes/forward/shader/circle.wgsl
+++ b/korangar/src/graphics/passes/forward/shader/circle.wgsl
@@ -39,7 +39,7 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     let scaling_factor = instance.screen_size.y / 2.0;
     let intensity = clamp(gaussian_peak(distance_from_center, scaling_factor), 0.0, 1.0);
 
-    return vec4<f32>(instance.color.rgb, intensity);
+    return instance.color * intensity;
 }
 
 fn gaussian_peak(x: f32, scaling_factor: f32) -> f32 {

--- a/korangar/src/graphics/passes/interface/rectangle.rs
+++ b/korangar/src/graphics/passes/interface/rectangle.rs
@@ -184,7 +184,7 @@ impl Drawer<{ BindGroupCount::One }, { ColorAttachmentCount::One }, { DepthAttac
                 compilation_options: PipelineCompilationOptions::default(),
                 targets: &[Some(ColorTargetState {
                     format: render_pass_context.color_attachment_formats()[0],
-                    blend: Some(BlendState::ALPHA_BLENDING),
+                    blend: Some(BlendState::PREMULTIPLIED_ALPHA_BLENDING),
                     write_mask: ColorWrites::default(),
                 })],
             }),

--- a/korangar/src/graphics/passes/interface/shader/rectangle.wgsl
+++ b/korangar/src/graphics/passes/interface/shader/rectangle.wgsl
@@ -94,7 +94,7 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
         }
         case 3u: {
             // Text (coverage)
-            color.a *= textureSample(font_atlas, linear_sampler, input.texture_coordinates).r;
+            color *= textureSample(font_atlas, linear_sampler, input.texture_coordinates).r;
         }
         default: {}
     }
@@ -155,7 +155,7 @@ fn rectangle_with_rounded_edges(
         alpha = total * (1.0/9.0);
     }
 
-    return vec4<f32>(color.rgb, color.a * alpha);
+    return color * alpha;
 }
 
 // 8-point Poisson Disk pattern

--- a/korangar/src/graphics/passes/interface/shader/rectangle_bindless.wgsl
+++ b/korangar/src/graphics/passes/interface/shader/rectangle_bindless.wgsl
@@ -94,7 +94,7 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
         }
         case 3u: {
             // Text (coverage)
-            color.a *= textureSample(font_atlas, linear_sampler, input.texture_coordinates).r;
+            color *= textureSample(font_atlas, linear_sampler, input.texture_coordinates).r;
         }
         default: {}
     }
@@ -155,7 +155,7 @@ fn rectangle_with_rounded_edges(
         alpha = total * (1.0 / 9.0);
     }
 
-    return vec4<f32>(color.rgb, color.a * alpha);
+    return color * alpha;
 }
 
 // 8-point Poisson Disk pattern that showed the best performance / quality characteristic.

--- a/korangar/src/graphics/passes/postprocessing/blitter.rs
+++ b/korangar/src/graphics/passes/postprocessing/blitter.rs
@@ -165,7 +165,11 @@ impl PostProcessingBlitterDrawer {
                 },
                 targets: &[Some(ColorTargetState {
                     format: color_texture_format,
-                    blend: if alpha_blending { Some(BlendState::ALPHA_BLENDING) } else { None },
+                    blend: if alpha_blending {
+                        Some(BlendState::PREMULTIPLIED_ALPHA_BLENDING)
+                    } else {
+                        None
+                    },
                     write_mask: ColorWrites::default(),
                 })],
             }),

--- a/korangar/src/graphics/passes/postprocessing/buffer.rs
+++ b/korangar/src/graphics/passes/postprocessing/buffer.rs
@@ -81,7 +81,7 @@ impl Drawer<{ BindGroupCount::One }, { ColorAttachmentCount::One }, { DepthAttac
                 compilation_options: PipelineCompilationOptions::default(),
                 targets: &[Some(ColorTargetState {
                     format: render_pass_context.color_attachment_formats()[0],
-                    blend: Some(BlendState::ALPHA_BLENDING),
+                    blend: Some(BlendState::PREMULTIPLIED_ALPHA_BLENDING),
                     write_mask: ColorWrites::default(),
                 })],
             }),

--- a/korangar/src/graphics/passes/postprocessing/rectangle.rs
+++ b/korangar/src/graphics/passes/postprocessing/rectangle.rs
@@ -170,7 +170,7 @@ impl Drawer<{ BindGroupCount::One }, { ColorAttachmentCount::One }, { DepthAttac
                 compilation_options: PipelineCompilationOptions::default(),
                 targets: &[Some(ColorTargetState {
                     format: render_pass_context.color_attachment_formats()[0],
-                    blend: Some(BlendState::ALPHA_BLENDING),
+                    blend: Some(BlendState::PREMULTIPLIED_ALPHA_BLENDING),
                     write_mask: ColorWrites::default(),
                 })],
             }),

--- a/korangar/src/graphics/passes/postprocessing/shader/buffer.wgsl
+++ b/korangar/src/graphics/passes/postprocessing/shader/buffer.wgsl
@@ -99,15 +99,15 @@ fn fs_main(
         if count != 0 {
             if (count <= 7) {
                 let incidence = f32(count) / 7.0;
-                color = vec4<f32>(0.0, incidence, 1.0 - incidence, 0.25);
+                color = vec4<f32>(0.0, incidence, 1.0 - incidence, 1.0) * 0.25;
             } else if (count <= 13) {
                 let incidence = (f32(count) - 7.0) / 6.0;
-                color = vec4<f32>(incidence, 1.0, 0.0, 0.25);
+                color = vec4<f32>(incidence, 1.0, 0.0, 1.0) * 0.25;
             } else if (count <= 20) {
                 let incidence = (f32(count) - 13.0) / 7.0;
-                color = vec4<f32>(1.0, 1.0 - incidence, 0.0, 0.25);
+                color = vec4<f32>(1.0, 1.0 - incidence, 0.0, 1.0) * 0.25;
             } else {
-                color = vec4<f32>(1.0, 0.0, 0.0, 0.25);
+                color = vec4<f32>(1.0, 0.0, 0.0, 1.0) * 0.25;
             }
         }
 

--- a/korangar/src/loaders/sprite/mod.rs
+++ b/korangar/src/loaders/sprite/mod.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 #[cfg(feature = "debug")]
 use korangar_debug::logging::{print_debug, Colorize, Timer};
 use korangar_interface::elements::PrototypeElement;
+use korangar_util::color::premultiply_alpha;
 use korangar_util::container::{Cacheable, SimpleCache};
 use korangar_util::FileLoader;
 use ragnarok_bytes::{ByteStream, FromBytes};
@@ -146,7 +147,9 @@ impl SpriteLoader {
 
         let textures = palette_images
             .chain(rgba_images)
-            .map(|image_data| {
+            .map(|mut image_data| {
+                premultiply_alpha(&mut image_data.data);
+
                 let texture = Texture::new_with_data(
                     &self.device,
                     &self.queue,

--- a/korangar_util/Cargo.toml
+++ b/korangar_util/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 cgmath = { workspace = true }
-derive-new = { workspace = true }
+fast-srgb8 = { workspace = true }
 hashbrown = { workspace = true }
 image = { workspace = true }
 korangar_interface = { workspace = true, optional = true }

--- a/korangar_util/src/color.rs
+++ b/korangar_util/src/color.rs
@@ -1,0 +1,21 @@
+//! Commonly used color functionality.
+
+use fast_srgb8::{f32_to_srgb8, srgb8_to_f32};
+
+/// Pre-multiplies the alpha of a sRGB gamma encoded pixel.
+pub fn premultiply_alpha(srgba_bytes: &mut [u8]) {
+    srgba_bytes.chunks_exact_mut(4).for_each(|chunk| {
+        let mut red = srgb8_to_f32(chunk[0]);
+        let mut green = srgb8_to_f32(chunk[1]);
+        let mut blue = srgb8_to_f32(chunk[2]);
+        let alpha = chunk[3] as f32 / 255.0;
+
+        red *= alpha;
+        blue *= alpha;
+        green *= alpha;
+
+        chunk[0] = f32_to_srgb8(red);
+        chunk[1] = f32_to_srgb8(green);
+        chunk[2] = f32_to_srgb8(blue);
+    });
+}

--- a/korangar_util/src/lib.rs
+++ b/korangar_util/src/lib.rs
@@ -3,6 +3,7 @@
 #![feature(let_chains)]
 
 pub mod collision;
+pub mod color;
 pub mod container;
 mod loader;
 pub mod math;


### PR DESCRIPTION
Since this fixes one of the issues with the white border around the entities, we should switch to pre-multiplied alpha throughout the render pipeline.

I did my best to catch all places where we had to change the logic when handling alpha values.

I moved the premultiply_alpha() function into the util crate, so that it gets properly optimized when compiling debug builds.

![grafik](https://github.com/user-attachments/assets/473f894e-d812-415d-a68d-11ba06d60abd)
