### PR TITLE
Render entities from back to front

### DIFF
--- a/korangar/src/graphics/instruction.rs
+++ b/korangar/src/graphics/instruction.rs
@@ -31,7 +31,7 @@ pub struct RenderInstruction<'a> {
     pub point_light: &'a [PointLightInstruction],
     pub model_batches: &'a [ModelBatch],
     pub models: &'a [ModelInstruction],
-    pub entities: &'a [EntityInstruction],
+    pub entities: &'a mut [EntityInstruction],
     pub directional_model_batches: &'a [ModelBatch],
     pub directional_shadow_models: &'a [ModelInstruction],
     pub directional_shadow_entities: &'a [EntityInstruction],
@@ -186,6 +186,7 @@ pub struct EntityInstruction {
     pub mirror: bool,
     pub entity_id: EntityId,
     pub texture: Arc<Texture>,
+    pub distance: f32,
 }
 
 #[derive(Clone, Debug)]

--- a/korangar/src/main.rs
+++ b/korangar/src/main.rs
@@ -2205,7 +2205,7 @@ impl Client {
             point_light: &self.point_light_instructions,
             model_batches: &self.model_batches,
             models: &self.model_instructions,
-            entities: &self.entity_instructions,
+            entities: &mut self.entity_instructions,
             directional_model_batches: &self.directional_shadow_model_batches,
             directional_shadow_models: &self.directional_shadow_model_instructions,
             directional_shadow_entities: &self.directional_shadow_entity_instructions,
@@ -2225,7 +2225,7 @@ impl Client {
             marker: self.debug_marker_renderer.get_instructions(),
         };
 
-        self.graphics_engine.render_next_frame(frame, &render_instruction);
+        self.graphics_engine.render_next_frame(frame, render_instruction);
 
         #[cfg(feature = "debug")]
         render_frame_measurement.stop();

--- a/korangar/src/world/animation/mod.rs
+++ b/korangar/src/world/animation/mod.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use cgmath::{Array, Matrix4, Point3, Vector2, Zero};
+use cgmath::{Array, Matrix4, Point3, Transform, Vector2, Zero};
 use korangar_interface::elements::PrototypeElement;
 use korangar_util::container::Cacheable;
 use ragnarok_packets::EntityId;
@@ -134,6 +134,9 @@ impl AnimationData {
             let texture_position = Vector2::new(texture_size.x * cell_position.x as f32, texture_size.y * cell_position.y as f32);
             let (depth_offset, curvature) = camera.calculate_depth_offset_and_curvature(&world_matrix, scale.x, scale.y);
 
+            let position = world_matrix.transform_point(Point3::from_value(0.0));
+            let distance = camera.distance_to(position);
+
             instructions.push(EntityInstruction {
                 world: world_matrix,
                 frame_part_transform: affine_matrix,
@@ -147,6 +150,7 @@ impl AnimationData {
                 mirror: frame_part.mirror,
                 entity_id,
                 texture: texture.clone(),
+                distance,
             });
         }
     }

--- a/korangar/src/world/cameras/mod.rs
+++ b/korangar/src/world/cameras/mod.rs
@@ -8,9 +8,7 @@ mod start;
 
 use std::f32::consts::FRAC_PI_2;
 
-#[cfg(feature = "debug")]
-use cgmath::MetricSpace;
-use cgmath::{Array, EuclideanSpace, InnerSpace, Matrix4, Point3, Vector2, Vector3, Vector4};
+use cgmath::{Array, EuclideanSpace, InnerSpace, Matrix4, MetricSpace, Point3, Vector2, Vector3, Vector4};
 
 #[cfg(feature = "debug")]
 pub use self::debug::DebugCamera;
@@ -132,7 +130,6 @@ pub trait Camera {
         Vector4::new(x, y, 0.0, 1.0)
     }
 
-    #[cfg(feature = "debug")]
     fn distance_to(&self, position: Point3<f32>) -> f32 {
         self.camera_position().distance(position)
     }


### PR DESCRIPTION
This is the second part needed to render entities properly without the white borders. I think this solution is quite elegant, since we don't need to introduce sort buffers of any sort.