### PR TITLE
Explicitly encode if an entity should be included in the picker buffer

### DIFF
--- a/korangar/src/graphics/instruction.rs
+++ b/korangar/src/graphics/instruction.rs
@@ -185,6 +185,7 @@ pub struct EntityInstruction {
     pub color: Color,
     pub mirror: bool,
     pub entity_id: EntityId,
+    pub add_to_picker: bool,
     pub texture: Arc<Texture>,
     pub distance: f32,
 }

--- a/korangar/src/main.rs
+++ b/korangar/src/main.rs
@@ -1979,7 +1979,6 @@ impl Client {
                 &mut self.directional_shadow_entity_instructions,
                 entities,
                 &self.directional_shadow_camera,
-                true,
             );
         }
 
@@ -2042,8 +2041,7 @@ impl Client {
             );
 
             #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_entities))]
-            self.map
-                .render_entities(&mut self.entity_instructions, entities, current_camera, true);
+            self.map.render_entities(&mut self.entity_instructions, entities, current_camera);
 
             #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_water))]
             self.map.render_water(&mut map_water_vertex_buffer);

--- a/korangar/src/world/animation/mod.rs
+++ b/korangar/src/world/animation/mod.rs
@@ -82,6 +82,7 @@ impl AnimationData {
         entity_position: Point3<f32>,
         animation_state: &AnimationState,
         head_direction: usize,
+        add_to_picker: bool,
     ) {
         let camera_direction = camera.camera_direction();
         let direction = (camera_direction + head_direction) % 8;
@@ -149,6 +150,7 @@ impl AnimationData {
                 color: frame_part.color,
                 mirror: frame_part.mirror,
                 entity_id,
+                add_to_picker,
                 texture: texture.clone(),
                 distance,
             });

--- a/korangar/src/world/entity/mod.rs
+++ b/korangar/src/world/entity/mod.rs
@@ -762,7 +762,7 @@ impl Common {
         }
     }
 
-    pub fn render(&self, instructions: &mut Vec<EntityInstruction>, camera: &dyn Camera) {
+    pub fn render(&self, instructions: &mut Vec<EntityInstruction>, camera: &dyn Camera, add_to_picker: bool) {
         self.animation_data.render(
             instructions,
             camera,
@@ -770,6 +770,7 @@ impl Common {
             self.position,
             &self.animation_state,
             self.head_direction,
+            add_to_picker,
         );
     }
 
@@ -1130,8 +1131,8 @@ impl Entity {
             .generate_pathing_mesh(device, queue, map, pathing_texture_mapping);
     }
 
-    pub fn render(&self, instructions: &mut Vec<EntityInstruction>, camera: &dyn Camera) {
-        self.get_common().render(instructions, camera);
+    pub fn render(&self, instructions: &mut Vec<EntityInstruction>, camera: &dyn Camera, add_to_picker: bool) {
+        self.get_common().render(instructions, camera, add_to_picker);
     }
 
     #[cfg(feature = "debug")]

--- a/korangar/src/world/map/mod.rs
+++ b/korangar/src/world/map/mod.rs
@@ -264,11 +264,10 @@ impl Map {
     }
 
     #[cfg_attr(feature = "debug", korangar_debug::profile)]
-    pub fn render_entities(&self, instructions: &mut Vec<EntityInstruction>, entities: &[Entity], camera: &dyn Camera, include_self: bool) {
-        entities
-            .iter()
-            .skip(!include_self as usize)
-            .for_each(|entity| entity.render(instructions, camera));
+    pub fn render_entities(&self, instructions: &mut Vec<EntityInstruction>, entities: &[Entity], camera: &dyn Camera) {
+        entities.iter().enumerate().for_each(|(index, entity)| {
+            entity.render(instructions, camera, index != 0);
+        });
     }
 
     #[cfg(feature = "debug")]


### PR DESCRIPTION
After sorting the entities from back to front, the logic from picker ignoring first two elements need to be changed.