### PR TITLE
On double right click, reset the camera rotation

### DIFF
--- a/korangar/src/input/event.rs
+++ b/korangar/src/input/event.rs
@@ -26,6 +26,7 @@ pub enum UserEvent {
     Exit,
     CameraZoom(f32),
     CameraRotate(f32),
+    CameraResetRotation,
     OpenMenuWindow,
     OpenInventoryWindow,
     OpenEquipmentWindow,

--- a/korangar/src/main.rs
+++ b/korangar/src/main.rs
@@ -1445,6 +1445,7 @@ impl Client {
                 UserEvent::Exit => event_loop.exit(),
                 UserEvent::CameraZoom(factor) => self.player_camera.soft_zoom(factor),
                 UserEvent::CameraRotate(factor) => self.player_camera.soft_rotate(factor),
+                UserEvent::CameraResetRotation => self.player_camera.reset_rotation(),
                 UserEvent::OpenMenuWindow => {
                     if !self.entities.is_empty() {
                         self.interface.open_window(&self.application, &mut self.focus_state, &MenuWindow)

--- a/korangar/src/world/cameras/player.rs
+++ b/korangar/src/world/cameras/player.rs
@@ -10,6 +10,7 @@ const ROTATION_SPEED: f32 = 0.01;
 const MINIMUM_ZOOM: f32 = 150.0;
 const MAXIMUM_ZOOM: f32 = 600.0;
 const DEFAULT_ZOOM: f32 = 400.0;
+const DEFAULT_ANGLE: f32 = FRAC_PI_2;
 const THRESHHOLD: f32 = 0.01;
 
 pub struct PlayerCamera {
@@ -31,7 +32,7 @@ impl PlayerCamera {
             view_matrix: Matrix4::from_value(0.0),
             projection_matrix: Matrix4::from_value(0.0),
             world_to_screen_matrix: Matrix4::from_value(0.0),
-            view_angle: SmoothedValue::new(FRAC_PI_2, THRESHHOLD, 15.0),
+            view_angle: SmoothedValue::new(DEFAULT_ANGLE, THRESHHOLD, 15.0),
             zoom: SmoothedValue::new(DEFAULT_ZOOM, THRESHHOLD, 5.0),
             aspect_ratio: 0.0,
         }
@@ -55,6 +56,10 @@ impl PlayerCamera {
 
     pub fn soft_rotate(&mut self, rotation: f32) {
         self.view_angle.move_desired(rotation * ROTATION_SPEED);
+    }
+
+    pub fn reset_rotation(&mut self) {
+        self.view_angle.set_desired(DEFAULT_ANGLE);
     }
 
     pub fn update(&mut self, delta_time: f64) {


### PR DESCRIPTION
The worse way to implement a double-click handler. 