### PR TITLE
Split transparent nodes into sub nodes

### DIFF
--- a/korangar/src/graphics/passes/forward/model.rs
+++ b/korangar/src/graphics/passes/forward/model.rs
@@ -436,7 +436,7 @@ impl ForwardModelDrawer {
             },
             depth_stencil: Some(DepthStencilState {
                 format: render_pass_context.depth_attachment_output_format()[0],
-                depth_write_enabled: true,
+                depth_write_enabled: !transparent,
                 depth_compare: CompareFunction::Greater,
                 stencil: StencilState::default(),
                 bias: DepthBiasState::default(),

--- a/korangar/src/graphics/vertices/native.rs
+++ b/korangar/src/graphics/vertices/native.rs
@@ -4,7 +4,7 @@ use korangar_util::texture_atlas::AtlasAllocation;
 
 use crate::graphics::{Color, ModelVertex};
 
-#[derive(new)]
+#[derive(Copy, Clone, new)]
 pub struct NativeModelVertex {
     pub position: Point3<f32>,
     pub normal: Vector3<f32>,

--- a/korangar/src/world/model/mod.rs
+++ b/korangar/src/world/model/mod.rs
@@ -21,7 +21,7 @@ use crate::world::Camera;
 
 #[derive(PrototypeElement, new)]
 pub struct Model {
-    pub root_node: Node,
+    pub root_nodes: Vec<Node>,
     pub bounding_box: AABB,
     #[cfg(feature = "debug")]
     pub model_data: ModelData,
@@ -35,7 +35,9 @@ impl Model {
         client_tick: ClientTick,
         camera: &dyn Camera,
     ) {
-        self.root_node.render_geometry(instructions, transform, client_tick, camera);
+        self.root_nodes
+            .iter()
+            .for_each(|node| node.render_geometry(instructions, transform, client_tick, camera));
     }
 
     #[cfg(feature = "debug")]

--- a/korangar/src/world/model/node.rs
+++ b/korangar/src/world/model/node.rs
@@ -1,4 +1,4 @@
-use cgmath::{Array, EuclideanSpace, Matrix4, Point3, SquareMatrix, Transform as PointTransform};
+use cgmath::{EuclideanSpace, Matrix4, Point3, SquareMatrix, Transform as PointTransform};
 use derive_new::new;
 use korangar_interface::elements::PrototypeElement;
 use ragnarok_formats::model::RotationKeyframeData;
@@ -12,6 +12,8 @@ use crate::world::Camera;
 pub struct Node {
     #[hidden_element]
     pub transform_matrix: Matrix4<f32>,
+    #[hidden_element]
+    pub centroid: Point3<f32>,
     pub transparent: bool,
     pub vertex_offset: usize,
     pub vertex_count: usize,
@@ -66,7 +68,7 @@ impl Node {
         camera: &dyn Camera,
     ) {
         let model_matrix = self.world_matrix(transform, client_tick);
-        let position = model_matrix.transform_point(Point3::from_value(0.0));
+        let position = model_matrix.transform_point(self.centroid);
         let distance = camera.distance_to(position);
 
         instructions.push(ModelInstruction {


### PR DESCRIPTION
This enables us to properly order and render all parts of transparent node correctly.

![grafik](https://github.com/user-attachments/assets/422b7239-fab5-4c6e-949e-1977993e49e8)
