### PR TITLE
Fix transparent rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,6 +1038,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glidesort"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2e102e6eb644d3e0b186fc161e4460417880a0a0b87d235f2e5b8fb30f2e9e0"
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1636,6 +1642,7 @@ dependencies = [
  "chrono",
  "cosmic-text",
  "derive-new",
+ "glidesort",
  "hashbrown 0.15.2",
  "image",
  "korangar_audio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ cpal = "0.15"
 derive-new = "0.7"
 etherparse = "0.16"
 fast-srgb8 = "1"
+glidesort = "0.1"
 hashbrown = "0.15"
 image = { version = "0.25", default-features = false }
 kira = { version = "0.9", default-features = false }

--- a/korangar/Cargo.toml
+++ b/korangar/Cargo.toml
@@ -11,6 +11,7 @@ chrono = { workspace = true }
 cosmic-text = { workspace = true }
 derive-new = { workspace = true }
 hashbrown = { workspace = true }
+glidesort = { workspace = true }
 image = { workspace = true, features = ["bmp", "jpeg", "png", "tga", "rayon"] }
 korangar_audio = { workspace = true }
 korangar_debug = { workspace = true, optional = true }

--- a/korangar/src/loaders/model/mod.rs
+++ b/korangar/src/loaders/model/mod.rs
@@ -443,7 +443,9 @@ impl ModelLoader {
             reverse_order,
         );
 
-        Self::calculate_transformation_matrix(&mut root_nodes[0], true, bounding_box, Matrix4::identity());
+        for root_node in root_nodes.iter_mut() {
+            Self::calculate_transformation_matrix(root_node, true, bounding_box, Matrix4::identity());
+        }
 
         let model = Model::new(
             root_nodes,

--- a/korangar_util/src/collision/aabb.rs
+++ b/korangar_util/src/collision/aabb.rs
@@ -113,6 +113,14 @@ impl AABB {
             && self.max.z >= other.min.z
     }
 
+    /// Creates a new AABB that is expanded by a given margin in all directions.
+    pub fn expanded(&self, margin: f32) -> Self {
+        AABB {
+            min: Point3::new(self.min.x - margin, self.min.y - margin, self.min.z - margin),
+            max: Point3::new(self.max.x + margin, self.max.y + margin, self.max.z + margin),
+        }
+    }
+
     /// Expand the AABB to include a point.
     pub fn expand(&mut self, point: Point3<f32>) {
         self.min = self.min.zip(point, f32::min);
@@ -315,6 +323,15 @@ mod tests {
 
         assert_eq!(aabb.min(), Point3::new(f32::MAX, f32::MAX, f32::MAX));
         assert_eq!(aabb.max(), Point3::new(-f32::MAX, -f32::MAX, -f32::MAX));
+    }
+
+    #[test]
+    fn test_expanded() {
+        let aabb = AABB::new(Point3::new(0.0, 0.0, 0.0), Point3::new(1.0, 1.0, 1.0));
+        let expanded = aabb.expanded(0.5);
+
+        assert_eq!(expanded.min(), Point3::new(-0.5, -0.5, -0.5));
+        assert_eq!(expanded.max(), Point3::new(1.5, 1.5, 1.5));
     }
 
     #[test]


### PR DESCRIPTION
Fixes two issues:

 1. Transparent meshes where spliced sometimes into deformed meshes. I updated the splicing algorithm to a DSU approach, that also uses a KD-tree to reduce the time complexity. We also have to use a stable sort now, since I saw z-fighting because of the new, better splicing (we have some intersecting transparent meshes, which share no vertices). Since we don't want to allocate, we use an external crate, called glidesort which allows us to re-use the sort buffers.
 2. Some transparent objects in dicastes were broken, because we didn't properly calculate the transformation matrix for all root nodes.