### PR TITLE
Optionally use clamp to border for the shadow sampler

### DIFF
--- a/korangar/src/graphics/capabilities.rs
+++ b/korangar/src/graphics/capabilities.rs
@@ -16,6 +16,7 @@ pub struct Capabilities {
     supported_msaa: Vec<Msaa>,
     bindless: bool,
     multidraw_indirect: bool,
+    clamp_to_border: bool,
     #[cfg(feature = "debug")]
     polygon_mode_line: bool,
     required_features: Features,
@@ -35,6 +36,7 @@ impl Capabilities {
             supported_msaa,
             bindless: false,
             multidraw_indirect: false,
+            clamp_to_border: false,
             #[cfg(feature = "debug")]
             polygon_mode_line: false,
             required_features: Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES,
@@ -47,6 +49,8 @@ impl Capabilities {
 
         #[cfg(feature = "debug")]
         {
+            Self::check_feature(adapter_features, Features::ADDRESS_MODE_CLAMP_TO_BORDER);
+            Self::check_feature(adapter_features, Features::ADDRESS_MODE_CLAMP_TO_ZERO);
             Self::check_feature(adapter_features, Features::INDIRECT_FIRST_INSTANCE);
             Self::check_feature(adapter_features, Features::MULTI_DRAW_INDIRECT);
             Self::check_feature(adapter_features, Features::PARTIALLY_BOUND_BINDING_ARRAY);
@@ -74,6 +78,11 @@ impl Capabilities {
         if adapter_features.contains(Features::INDIRECT_FIRST_INSTANCE | Features::MULTI_DRAW_INDIRECT) {
             capabilities.multidraw_indirect = true;
             capabilities.required_features |= Features::INDIRECT_FIRST_INSTANCE | Features::MULTI_DRAW_INDIRECT;
+        }
+
+        if adapter_features.contains(Features::ADDRESS_MODE_CLAMP_TO_BORDER | Features::ADDRESS_MODE_CLAMP_TO_ZERO) {
+            capabilities.clamp_to_border = true;
+            capabilities.required_features |= Features::ADDRESS_MODE_CLAMP_TO_BORDER | Features::ADDRESS_MODE_CLAMP_TO_ZERO;
         }
 
         #[cfg(feature = "debug")]
@@ -118,6 +127,12 @@ impl Capabilities {
     /// support bindless fully.
     pub fn supports_bindless(&self) -> bool {
         self.bindless
+    }
+
+    /// Returns `true` if the backend allows clamping the border of a texture to
+    /// a specific value.
+    pub fn supports_clamp_to_border(&self) -> bool {
+        self.clamp_to_border
     }
 
     /// Returns `true` if the backend allows drawing triangles as lines

--- a/korangar/src/graphics/engine.rs
+++ b/korangar/src/graphics/engine.rs
@@ -184,6 +184,7 @@ impl GraphicsEngine {
                         let global_context = GlobalContext::new(
                             &self.device,
                             &self.queue,
+                            &self.capabilities,
                             &self.texture_loader,
                             surface_texture_format,
                             msaa,
@@ -486,7 +487,7 @@ impl GraphicsEngine {
         if let Some(engine_context) = self.engine_context.as_mut() {
             engine_context
                 .global_context
-                .update_texture_sampler(&self.device, texture_sampler_type);
+                .update_texture_sampler(&self.device, &self.capabilities, texture_sampler_type);
         }
     }
 

--- a/korangar/src/graphics/mod.rs
+++ b/korangar/src/graphics/mod.rs
@@ -354,6 +354,7 @@ impl GlobalContext {
     fn new(
         device: &Device,
         queue: &Queue,
+        capabilities: &Capabilities,
         texture_loader: &TextureLoader,
         surface_texture_format: TextureFormat,
         msaa: Msaa,
@@ -432,10 +433,10 @@ impl GlobalContext {
 
         let tile_light_indices_buffer = Self::create_tile_light_indices_buffer(device, forward_size);
 
-        let nearest_sampler = create_new_sampler(device, "nearest", SamplerType::TextureNearest);
-        let linear_sampler = create_new_sampler(device, "linear", SamplerType::TextureLinear);
-        let texture_sampler = create_new_sampler(device, "texture", texture_sampler);
-        let shadow_map_sampler = create_new_sampler(device, "shadow map", SamplerType::DepthCompare);
+        let nearest_sampler = create_new_sampler(device, capabilities, "nearest", SamplerType::TextureNearest);
+        let linear_sampler = create_new_sampler(device, capabilities, "linear", SamplerType::TextureLinear);
+        let texture_sampler = create_new_sampler(device, capabilities, "texture", texture_sampler);
+        let shadow_map_sampler = create_new_sampler(device, capabilities, "shadow map", SamplerType::DepthCompare);
 
         let anti_aliasing_resources = Self::create_anti_aliasing_resources(device, screen_space_anti_aliasing, screen_size);
 
@@ -862,8 +863,8 @@ impl GlobalContext {
         }
     }
 
-    fn update_texture_sampler(&mut self, device: &Device, texture_sampler_type: TextureSamplerType) {
-        self.texture_sampler = create_new_sampler(device, "texture", texture_sampler_type);
+    fn update_texture_sampler(&mut self, device: &Device, capabilities: &Capabilities, texture_sampler_type: TextureSamplerType) {
+        self.texture_sampler = create_new_sampler(device, capabilities, "texture", texture_sampler_type);
         self.global_bind_group = Self::create_global_bind_group(
             device,
             &self.global_uniforms_buffer,


### PR DESCRIPTION
This makes the "pop in" a little bit less distracting, since the areas outside the shadow map are now clamped to 0.0, so we don't get the "black borders" anymore.

Optional feature using our capability system.