### PR TITLE
Fix bug in frustum creation code

### DIFF
--- a/korangar/src/world/effect/mod.rs
+++ b/korangar/src/world/effect/mod.rs
@@ -329,7 +329,7 @@ impl EffectBase for EffectWithLight {
 
     fn register_point_lights(&self, point_light_manager: &mut PointLightManager, camera: &dyn Camera) {
         let (view_matrix, projection_matrix) = camera.view_projection_matrices();
-        let frustum = Frustum::new(projection_matrix * view_matrix);
+        let frustum = Frustum::new(projection_matrix * view_matrix, true);
 
         let light_position = self.center.to_position() + self.light_offset;
 

--- a/korangar/src/world/map/mod.rs
+++ b/korangar/src/world/map/mod.rs
@@ -215,7 +215,7 @@ impl Map {
         }
 
         let (view_matrix, projection_matrix) = camera.view_projection_matrices();
-        let frustum = Frustum::new(projection_matrix * view_matrix);
+        let frustum = Frustum::new(projection_matrix * view_matrix, true);
 
         object_set.create_set(|visible_objects| {
             self.object_kdtree.query(&frustum, visible_objects);
@@ -447,7 +447,7 @@ impl Map {
         camera: &dyn Camera,
     ) {
         let (view_matrix, projection_matrix) = camera.view_projection_matrices();
-        let frustum = Frustum::new(projection_matrix * view_matrix);
+        let frustum = Frustum::new(projection_matrix * view_matrix, true);
 
         let set = light_source_set_buffer.create_set(|buffer| {
             self.light_source_kdtree.query(&frustum, buffer);


### PR DESCRIPTION
The near and far planes where "switched" when we used reverse Z projection. It didn't matter for actual frustum culling (since the order is not important), but we should have always the correct order anyhow. We also detect now, when we use an infinite projection and properly set the normal vector (it would be NaN otherwise).