### PR TITLE
Refactor the camera code

### DIFF
--- a/korangar/src/graphics/projection.rs
+++ b/korangar/src/graphics/projection.rs
@@ -33,8 +33,8 @@ pub fn orthographic_reverse_lh(left: f32, right: f32, bottom: f32, top: f32, nea
 /// This function generates a matrix that transforms from left-handed, y-up
 /// world space to left-handed, y-up clip space with a depth range of 1.0 (near)
 /// to 0.0 (far).
-pub fn perspective_reverse_lh(vertical_fov: Rad<f32>, aspect_ratio: f32) -> Matrix4<f32> {
-    let tangent = (vertical_fov / 2.0).tan();
+pub fn perspective_reverse_lh(vertical_fov: impl Into<Rad<f32>>, aspect_ratio: f32) -> Matrix4<f32> {
+    let tangent = (vertical_fov.into() / 2.0).tan();
     let height = 1.0 / tangent;
     let width = height / aspect_ratio;
 

--- a/korangar/src/renderer/effect.rs
+++ b/korangar/src/renderer/effect.rs
@@ -48,8 +48,7 @@ impl EffectRenderer {
     ) {
         const EFFECT_ORIGIN: Vector2<f32> = Vector2::new(319.0, 291.0);
 
-        let (view_matrix, projection_matrix) = camera.view_projection_matrices();
-        let clip_space_position = projection_matrix * view_matrix * position.to_homogeneous();
+        let clip_space_position = camera.view_projection_matrix() * position.to_homogeneous();
         let screen_space_position = camera.clip_to_screen_space(clip_space_position);
 
         let half_screen = Vector2::new(self.window_size.width / 2.0, self.window_size.height / 2.0);

--- a/korangar/src/world/cameras/debug.rs
+++ b/korangar/src/world/cameras/debug.rs
@@ -1,6 +1,4 @@
-use std::f32::consts::FRAC_PI_4;
-
-use cgmath::{Matrix4, Point3, Rad, SquareMatrix, Vector2, Vector3};
+use cgmath::{Deg, InnerSpace, Matrix4, Point3, Quaternion, Rad, Rotation, Rotation3, Vector2, Vector3, Zero};
 
 use super::Camera;
 use crate::graphics::perspective_reverse_lh;
@@ -8,59 +6,56 @@ use crate::graphics::perspective_reverse_lh;
 const LOOK_AROUND_SPEED: f32 = 0.005;
 const FLY_SPEED_FAST: f32 = 1000.0;
 const FLY_SPEED_SLOW: f32 = 100.0;
+const VERTICAL_FOV: Deg<f32> = Deg(45.0);
+const LOOK_UP_VECTOR: Vector3<f32> = Vector3::new(0.0, 1.0, 0.0);
 
 pub struct DebugCamera {
     camera_position: Point3<f32>,
-    look_up_vector: Vector3<f32>,
+    orientation: Quaternion<f32>,
+    fly_speed: f32,
     view_matrix: Matrix4<f32>,
     projection_matrix: Matrix4<f32>,
-    world_to_screen_matrix: Matrix4<f32>,
-    pitch: Rad<f32>,
-    yaw: Rad<f32>,
-    fly_speed: f32,
+    view_projection_matrix: Matrix4<f32>,
 }
 
 impl DebugCamera {
     pub fn new() -> Self {
         Self {
-            camera_position: Point3::new(0.0, 10.0, 0.0),
-            look_up_vector: Vector3::new(0.0, 1.0, 0.0),
-            view_matrix: Matrix4::from_value(0.0),
-            projection_matrix: Matrix4::from_value(0.0),
-            world_to_screen_matrix: Matrix4::from_value(0.0),
-            pitch: Rad(0.0),
-            yaw: Rad(0.0),
+            camera_position: Point3::new(0.0, 50.0, 0.0),
+            orientation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
             fly_speed: 100.0,
+            view_matrix: Matrix4::zero(),
+            projection_matrix: Matrix4::zero(),
+            view_projection_matrix: Matrix4::zero(),
         }
     }
 
     pub fn look_around(&mut self, mouse_delta: Vector2<f32>) {
-        self.pitch += Rad(mouse_delta.y * LOOK_AROUND_SPEED);
-        self.yaw += Rad(mouse_delta.x * LOOK_AROUND_SPEED);
+        let pitch = Quaternion::from_axis_angle(Vector3::unit_x(), Rad(-mouse_delta.y * LOOK_AROUND_SPEED));
+        let yaw = Quaternion::from_axis_angle(Vector3::unit_y(), Rad(-mouse_delta.x * LOOK_AROUND_SPEED));
+        self.orientation = (yaw * self.orientation * pitch).normalize();
     }
 
     pub fn move_forward(&mut self, delta_time: f32) {
-        let forward_vector = self.focus_point() - self.camera_position;
-        self.camera_position += forward_vector * self.fly_speed * delta_time;
+        self.camera_position += self.view_direction() * self.fly_speed * delta_time;
     }
 
     pub fn move_backward(&mut self, delta_time: f32) {
-        let forward_vector = self.focus_point() - self.camera_position;
-        self.camera_position -= forward_vector * self.fly_speed * delta_time;
+        self.camera_position -= self.view_direction() * self.fly_speed * delta_time;
     }
 
     pub fn move_left(&mut self, delta_time: f32) {
-        let forward_vector = self.focus_point() - self.camera_position;
-        self.camera_position += forward_vector.cross(self.look_up_vector) * self.fly_speed * delta_time;
+        let left = self.view_direction().cross(LOOK_UP_VECTOR).normalize();
+        self.camera_position += left * self.fly_speed * delta_time;
     }
 
     pub fn move_right(&mut self, delta_time: f32) {
-        let forward_vector = self.focus_point() - self.camera_position;
-        self.camera_position -= forward_vector.cross(self.look_up_vector) * self.fly_speed * delta_time;
+        let right = LOOK_UP_VECTOR.cross(self.view_direction()).normalize();
+        self.camera_position += right * self.fly_speed * delta_time;
     }
 
     pub fn move_up(&mut self, delta_time: f32) {
-        self.camera_position += Vector3::new(0.0, 1.0, 0.0) * self.fly_speed * delta_time;
+        self.camera_position += Vector3::unit_y() * self.fly_speed * delta_time;
     }
 
     pub fn accelerate(&mut self) {
@@ -78,34 +73,29 @@ impl Camera for DebugCamera {
     }
 
     fn focus_point(&self) -> Point3<f32> {
-        let x = self.yaw.0.cos() * self.pitch.0.cos();
-        let y = self.pitch.0.sin();
-        let z = self.yaw.0.sin() * self.pitch.0.cos();
-
-        Point3::new(
-            self.camera_position.x + x,
-            self.camera_position.y + y,
-            self.camera_position.z + z,
-        )
+        self.camera_position + self.view_direction()
     }
 
     fn generate_view_projection(&mut self, window_size: Vector2<usize>) {
         let aspect_ratio = window_size.x as f32 / window_size.y as f32;
-        self.projection_matrix = perspective_reverse_lh(Rad(FRAC_PI_4), aspect_ratio);
-        self.view_matrix = Matrix4::look_at_lh(self.camera_position, self.focus_point(), self.look_up_vector);
-
-        self.world_to_screen_matrix = self.projection_matrix * self.view_matrix;
+        self.view_matrix = Matrix4::look_to_lh(self.camera_position, self.view_direction(), LOOK_UP_VECTOR);
+        self.projection_matrix = perspective_reverse_lh(VERTICAL_FOV, aspect_ratio);
+        self.view_projection_matrix = self.projection_matrix * self.view_matrix;
     }
 
     fn look_up_vector(&self) -> Vector3<f32> {
-        self.look_up_vector
+        LOOK_UP_VECTOR
     }
 
     fn view_projection_matrices(&self) -> (Matrix4<f32>, Matrix4<f32>) {
         (self.view_matrix, self.projection_matrix)
     }
 
-    fn world_to_screen_matrix(&self) -> Matrix4<f32> {
-        self.world_to_screen_matrix
+    fn view_projection_matrix(&self) -> Matrix4<f32> {
+        self.view_projection_matrix
+    }
+
+    fn view_direction(&self) -> Vector3<f32> {
+        self.orientation.rotate_vector(Vector3::unit_z())
     }
 }

--- a/korangar/src/world/cameras/start.rs
+++ b/korangar/src/world/cameras/start.rs
@@ -1,35 +1,36 @@
-use std::f32::consts::{FRAC_PI_2, FRAC_PI_4};
-
-use cgmath::{Matrix4, Point3, Rad, SquareMatrix, Vector2, Vector3};
+use cgmath::{Array, Deg, InnerSpace, Matrix4, Point3, Quaternion, Rad, Rotation, Rotation3, Vector2, Vector3, Zero};
 
 use super::Camera;
 use crate::graphics::perspective_reverse_lh;
 
-const DEFAULT_ZOOM: f32 = 150.0;
+const DEFAULT_VIEW_ANGLE: f32 = 180_f32.to_radians();
+const DEFAULT_VIEW_DISTANCE: f32 = 150.0;
 const ROTATION_SPEED: f32 = 0.03;
+const VERTICAL_FOV: Deg<f32> = Deg(45.0);
+const LOOK_UP: Vector3<f32> = Vector3::new(0.0, 1.0, 0.0);
 
 pub struct StartCamera {
     focus_point: Point3<f32>,
-    look_up_vector: Vector3<f32>,
+    camera_position: Point3<f32>,
+    view_direction: Vector3<f32>,
+    view_angle: f32,
+    view_distance: f32,
     view_matrix: Matrix4<f32>,
     projection_matrix: Matrix4<f32>,
-    world_to_screen_matrix: Matrix4<f32>,
-    view_angle: f32,
-    zoom: f32,
-    aspect_ratio: f32,
+    view_projection_matrix: Matrix4<f32>,
 }
 
 impl StartCamera {
     pub fn new() -> Self {
         Self {
-            focus_point: Point3::new(0.0, 0.0, 0.0),
-            look_up_vector: Vector3::new(0.0, 1.0, 0.0),
-            view_matrix: Matrix4::from_value(0.0),
-            projection_matrix: Matrix4::from_value(0.0),
-            world_to_screen_matrix: Matrix4::from_value(0.0),
-            view_angle: FRAC_PI_2,
-            zoom: DEFAULT_ZOOM,
-            aspect_ratio: 0.0,
+            focus_point: Point3::from_value(0.0),
+            camera_position: Point3::from_value(0.0),
+            view_direction: Vector3::zero(),
+            view_angle: DEFAULT_VIEW_ANGLE,
+            view_distance: DEFAULT_VIEW_DISTANCE,
+            view_matrix: Matrix4::zero(),
+            projection_matrix: Matrix4::zero(),
+            view_projection_matrix: Matrix4::zero(),
         }
     }
 
@@ -39,21 +40,24 @@ impl StartCamera {
 
     pub fn update(&mut self, delta_time: f64) {
         self.view_angle += delta_time as f32 * ROTATION_SPEED;
+
+        let yaw_rotation = Quaternion::from_angle_y(Rad(self.view_angle));
+        let base_offset = Vector3::new(0.0, self.view_distance, self.view_distance);
+        let rotated_offset = yaw_rotation.rotate_vector(base_offset);
+
+        self.camera_position = self.focus_point + rotated_offset;
+        self.view_direction = -rotated_offset.normalize();
     }
 
     pub fn get_zoom_scale(&self) -> f32 {
-        // We don't have a zoom range for the start camera.
+        // The start camera has a fixed zoom.
         1.0
     }
 }
 
 impl Camera for StartCamera {
     fn camera_position(&self) -> Point3<f32> {
-        Point3::new(
-            self.focus_point.x + self.zoom * self.view_angle.cos(),
-            self.focus_point.y + self.zoom,
-            self.focus_point.z - self.zoom * self.view_angle.sin(),
-        )
+        self.camera_position
     }
 
     fn focus_point(&self) -> Point3<f32> {
@@ -61,25 +65,26 @@ impl Camera for StartCamera {
     }
 
     fn generate_view_projection(&mut self, window_size: Vector2<usize>) {
-        self.aspect_ratio = window_size.x as f32 / window_size.y as f32;
-        self.projection_matrix = perspective_reverse_lh(Rad(FRAC_PI_4), self.aspect_ratio);
-
+        let aspect_ratio = window_size.x as f32 / window_size.y as f32;
         let camera_position = self.camera_position();
-        self.view_matrix = Matrix4::look_at_lh(camera_position, self.focus_point, self.look_up_vector);
-
-        self.world_to_screen_matrix = self.projection_matrix * self.view_matrix;
+        self.view_matrix = Matrix4::look_to_lh(camera_position, self.view_direction, LOOK_UP);
+        self.projection_matrix = perspective_reverse_lh(VERTICAL_FOV, aspect_ratio);
+        self.view_projection_matrix = self.projection_matrix * self.view_matrix;
     }
 
     fn look_up_vector(&self) -> Vector3<f32> {
-        self.look_up_vector
+        LOOK_UP
     }
 
     fn view_projection_matrices(&self) -> (Matrix4<f32>, Matrix4<f32>) {
         (self.view_matrix, self.projection_matrix)
     }
 
-    #[cfg(feature = "debug")]
-    fn world_to_screen_matrix(&self) -> Matrix4<f32> {
-        self.world_to_screen_matrix
+    fn view_projection_matrix(&self) -> Matrix4<f32> {
+        self.view_projection_matrix
+    }
+
+    fn view_direction(&self) -> Vector3<f32> {
+        self.view_direction
     }
 }

--- a/korangar/src/world/effect/mod.rs
+++ b/korangar/src/world/effect/mod.rs
@@ -328,8 +328,7 @@ impl EffectBase for EffectWithLight {
     }
 
     fn register_point_lights(&self, point_light_manager: &mut PointLightManager, camera: &dyn Camera) {
-        let (view_matrix, projection_matrix) = camera.view_projection_matrices();
-        let frustum = Frustum::new(projection_matrix * view_matrix, true);
+        let frustum = Frustum::new(camera.view_projection_matrix(), true);
 
         let light_position = self.center.to_position() + self.light_offset;
 

--- a/korangar/src/world/entity/mod.rs
+++ b/korangar/src/world/entity/mod.rs
@@ -854,8 +854,7 @@ impl Player {
     }
 
     pub fn render_status(&self, renderer: &GameInterfaceRenderer, camera: &dyn Camera, theme: &GameTheme, window_size: ScreenSize) {
-        let (view_matrix, projection_matrix) = camera.view_projection_matrices();
-        let clip_space_position = (projection_matrix * view_matrix) * self.common.position.to_homogeneous();
+        let clip_space_position = camera.view_projection_matrix() * self.common.position.to_homogeneous();
         let screen_position = camera.clip_to_screen_space(clip_space_position);
         let final_position = ScreenPosition {
             left: screen_position.x * window_size.width,
@@ -984,8 +983,7 @@ impl Npc {
             return;
         }
 
-        let (view_matrix, projection_matrix) = camera.view_projection_matrices();
-        let clip_space_position = (projection_matrix * view_matrix) * self.common.position.to_homogeneous();
+        let clip_space_position = camera.view_projection_matrix() * self.common.position.to_homogeneous();
         let screen_position = camera.clip_to_screen_space(clip_space_position);
         let final_position = ScreenPosition {
             left: screen_position.x * window_size.width,

--- a/korangar/src/world/light/mod.rs
+++ b/korangar/src/world/light/mod.rs
@@ -245,8 +245,7 @@ impl PointLightSet<'_> {
                 point_shadow_camera.change_direction(face_index);
                 point_shadow_camera.generate_view_projection(Vector2::zero());
 
-                let (view_matrix, projection_matrix) = point_shadow_camera.view_projection_matrices();
-                view_projection_matrices[face_index as usize] = projection_matrix * view_matrix;
+                view_projection_matrices[face_index as usize] = point_shadow_camera.view_projection_matrix();
 
                 let model_offset = point_shadow_model_instructions.len();
 

--- a/korangar/src/world/map/mod.rs
+++ b/korangar/src/world/map/mod.rs
@@ -214,8 +214,7 @@ impl Map {
             });
         }
 
-        let (view_matrix, projection_matrix) = camera.view_projection_matrices();
-        let frustum = Frustum::new(projection_matrix * view_matrix, true);
+        let frustum = Frustum::new(camera.view_projection_matrix(), true);
 
         object_set.create_set(|visible_objects| {
             self.object_kdtree.query(&frustum, visible_objects);
@@ -446,8 +445,7 @@ impl Map {
         light_source_set_buffer: &mut ResourceSetBuffer<LightSourceKey>,
         camera: &dyn Camera,
     ) {
-        let (view_matrix, projection_matrix) = camera.view_projection_matrices();
-        let frustum = Frustum::new(projection_matrix * view_matrix, true);
+        let frustum = Frustum::new(camera.view_projection_matrix(), true);
 
         let set = light_source_set_buffer.create_set(|buffer| {
             self.light_source_kdtree.query(&frustum, buffer);

--- a/korangar/src/world/particles/mod.rs
+++ b/korangar/src/world/particles/mod.rs
@@ -47,8 +47,7 @@ impl Particle for DamageNumber {
     }
 
     fn render(&self, renderer: &GameInterfaceRenderer, camera: &dyn Camera, window_size: ScreenSize) {
-        let (view_matrix, projection_matrix) = camera.view_projection_matrices();
-        let clip_space_position = (projection_matrix * view_matrix) * self.position.to_homogeneous();
+        let clip_space_position = camera.view_projection_matrix() * self.position.to_homogeneous();
         let screen_position = camera.clip_to_screen_space(clip_space_position);
         let final_position = ScreenPosition {
             left: screen_position.x * window_size.width,
@@ -80,8 +79,7 @@ impl Particle for HealNumber {
     }
 
     fn render(&self, renderer: &GameInterfaceRenderer, camera: &dyn Camera, window_size: ScreenSize) {
-        let (view_matrix, projection_matrix) = camera.view_projection_matrices();
-        let clip_space_position = (projection_matrix * view_matrix) * self.position.to_homogeneous();
+        let clip_space_position = camera.view_projection_matrix() * self.position.to_homogeneous();
         let screen_position = camera.clip_to_screen_space(clip_space_position);
         let final_position = ScreenPosition {
             left: screen_position.x * window_size.width,
@@ -120,8 +118,7 @@ impl QuestIcon {
     }
 
     fn render(&self, renderer: &GameInterfaceRenderer, camera: &dyn Camera, window_size: ScreenSize, scaling_factor: f32) {
-        let (view_matrix, projection_matrix) = camera.view_projection_matrices();
-        let clip_space_position = (projection_matrix * view_matrix) * self.position.to_homogeneous();
+        let clip_space_position = camera.view_projection_matrix() * self.position.to_homogeneous();
         let screen_position = camera.clip_to_screen_space(clip_space_position);
         let final_position = ScreenPosition {
             left: screen_position.x * window_size.width,


### PR DESCRIPTION
This commits aims to clean up the camera code and make it easier to understand. We use now quaternions instead of using Euler angles. I tried to pre-calculate often used variables and tried to keep field order the same between all cameras. I also tried to use more constants where ever possible (for example the default horizontal view angle of the camera).