### PR TITLE
Size shadow map based on camera view direction

### DIFF
--- a/korangar/src/world/cameras/directional_shadow.rs
+++ b/korangar/src/world/cameras/directional_shadow.rs
@@ -1,19 +1,22 @@
 use cgmath::{InnerSpace, Matrix4, Point3, Vector2, Vector3, Zero};
+use korangar_util::math::lerp;
 
 use super::Camera;
 use crate::graphics::orthographic_reverse_lh;
 
 const FAR_PLANE: f32 = 500.0;
 const NEAR_PLANE: f32 = -500.0;
-const MIN_SCALE: f32 = 0.4;
 const MAX_BOUNDS: f32 = 300.0;
+const FRONT_SCALE: f32 = 1.5;
+const SIDE_SCALE: f32 = 1.0;
+const BACK_SCALE: f32 = 0.5;
 const LOOK_UP: Vector3<f32> = Vector3::new(0.0, 1.0, 0.0);
 
 pub struct DirectionalShadowCamera {
     focus_point: Point3<f32>,
     camera_position: Point3<f32>,
     view_direction: Vector3<f32>,
-    zoom_scale: f32,
+    main_camera_view_direction: Vector3<f32>,
     view_matrix: Matrix4<f32>,
     projection_matrix: Matrix4<f32>,
     view_projection_matrix: Matrix4<f32>,
@@ -25,7 +28,7 @@ impl DirectionalShadowCamera {
             focus_point: Point3::new(0.0, 0.0, 0.0),
             camera_position: Point3::new(0.0, 0.0, 0.0),
             view_direction: Vector3::zero(),
-            zoom_scale: 0.0,
+            main_camera_view_direction: Vector3::zero(),
             view_matrix: Matrix4::zero(),
             projection_matrix: Matrix4::zero(),
             view_projection_matrix: Matrix4::zero(),
@@ -34,7 +37,7 @@ impl DirectionalShadowCamera {
 
     pub fn set_focus_point(&mut self, focus_point: Point3<f32>) {
         // We need to snap the camera to a grid, or else shadows get too noisy.
-        let grid_size = 25.0;
+        let grid_size = 10.0;
         self.focus_point = Point3::new(
             (focus_point.x / grid_size).floor() * grid_size,
             (focus_point.y / grid_size).floor() * grid_size,
@@ -42,21 +45,29 @@ impl DirectionalShadowCamera {
         );
     }
 
-    // The zoom_scale is used to scale the shadow map and give the best possible
-    // resolution for objects shadows.
-    pub fn update(&mut self, direction_to_light: Vector3<f32>, zoom_scale: f32) {
+    pub fn update(&mut self, direction_to_light: Vector3<f32>, main_camera_view_direction: Vector3<f32>) {
         // TODO: NHA Currently the directional light is the direction TO the light.
         //       We should change that to make it the direction the light shines.
         let direction_to_light = direction_to_light.normalize();
         let scaled_direction = direction_to_light * 100.0;
         self.camera_position = self.focus_point + scaled_direction;
         self.view_direction = -direction_to_light;
-        self.zoom_scale = zoom_scale;
+        self.main_camera_view_direction = main_camera_view_direction;
     }
 
-    fn calculate_bounds(&self) -> f32 {
-        let adjusted_scale = MIN_SCALE + (1.0 - MIN_SCALE) * self.zoom_scale;
-        MAX_BOUNDS * adjusted_scale
+    fn calculate_bounds(&self) -> (f32, f32, f32, f32) {
+        let flat_main_view = Vector3::new(self.main_camera_view_direction.x, 0.0, self.main_camera_view_direction.z).normalize();
+        let flat_light_direction = Vector3::new(self.view_direction.x, 0.0, self.view_direction.z).normalize();
+
+        let angle = flat_main_view.dot(flat_light_direction);
+        let lerp_factor = (-angle + 1.0) * 0.5;
+
+        let front = lerp(MAX_BOUNDS * FRONT_SCALE, MAX_BOUNDS * SIDE_SCALE, lerp_factor).round();
+        let back = lerp(-MAX_BOUNDS * BACK_SCALE, -MAX_BOUNDS * SIDE_SCALE, lerp_factor).round();
+        let left = lerp(-MAX_BOUNDS * SIDE_SCALE, -MAX_BOUNDS * BACK_SCALE, lerp_factor).round();
+        let right = lerp(MAX_BOUNDS * SIDE_SCALE, MAX_BOUNDS * FRONT_SCALE, lerp_factor).round();
+
+        (front, back, left, right)
     }
 }
 
@@ -70,9 +81,9 @@ impl Camera for DirectionalShadowCamera {
     }
 
     fn generate_view_projection(&mut self, _window_size: Vector2<usize>) {
-        let bound_size = self.calculate_bounds();
+        let (front, back, left, right) = self.calculate_bounds();
         self.view_matrix = Matrix4::look_to_lh(self.camera_position(), self.view_direction, LOOK_UP);
-        self.projection_matrix = orthographic_reverse_lh(-bound_size, bound_size, -bound_size, bound_size, NEAR_PLANE, FAR_PLANE);
+        self.projection_matrix = orthographic_reverse_lh(left, right, back, front, NEAR_PLANE, FAR_PLANE);
         self.view_projection_matrix = self.projection_matrix * self.view_matrix;
     }
 

--- a/korangar/src/world/cameras/mod.rs
+++ b/korangar/src/world/cameras/mod.rs
@@ -20,7 +20,7 @@ pub use self::start::StartCamera;
 #[cfg(feature = "debug")]
 use crate::interface::layout::{ScreenPosition, ScreenSize};
 
-const MAXIMUM_CAMERA_DISTANCE: f32 = 600.0;
+const MAXIMUM_CAMERA_DISTANCE: f32 = 500.0;
 const MINIMUM_CAMERA_DISTANCE: f32 = 150.0;
 
 /// The world space has a left-handed coordinate system where the Y axis is up.

--- a/korangar/src/world/cameras/player.rs
+++ b/korangar/src/world/cameras/player.rs
@@ -7,8 +7,8 @@ const ZOOM_SPEED: f32 = 2.0;
 const ROTATION_SPEED: f32 = 0.01;
 const DEFAULT_DISTANCE: f32 = 400.0;
 const DEFAULT_ANGLE: f32 = 180_f32.to_radians();
-const CAMERA_PITCH: Deg<f32> = Deg(-50.0);
-const VERTICAL_FOV: Deg<f32> = Deg(15.0);
+const CAMERA_PITCH: Deg<f32> = Deg(-55.0);
+const VERTICAL_FOV: Deg<f32> = Deg(15.5);
 const THRESHOLD: f32 = 0.01;
 const LOOK_UP: Vector3<f32> = Vector3::new(0.0, 1.0, 0.0);
 
@@ -47,10 +47,6 @@ impl PlayerCamera {
         self.focus_point.x.set_desired(position.x);
         self.focus_point.y.set_desired(position.y);
         self.focus_point.z.set_desired(position.z);
-    }
-
-    pub fn get_zoom_scale(&self) -> f32 {
-        (self.camera_distance.get_current() - MINIMUM_CAMERA_DISTANCE) / (MAXIMUM_CAMERA_DISTANCE - MINIMUM_CAMERA_DISTANCE)
     }
 
     pub fn soft_zoom(&mut self, zoom_factor: f32) {

--- a/korangar/src/world/cameras/start.rs
+++ b/korangar/src/world/cameras/start.rs
@@ -48,11 +48,6 @@ impl StartCamera {
         self.camera_position = self.focus_point + rotated_offset;
         self.view_direction = -rotated_offset.normalize();
     }
-
-    pub fn get_zoom_scale(&self) -> f32 {
-        // The start camera has a fixed zoom.
-        1.0
-    }
 }
 
 impl Camera for StartCamera {

--- a/korangar_util/src/math.rs
+++ b/korangar_util/src/math.rs
@@ -9,6 +9,11 @@ pub fn multiply_matrix4_and_point3(matrix: &Matrix4<f32>, vector: Point3<f32>) -
     Point3::from_vec((adjusted_vector / adjusted_vector.w).truncate())
 }
 
+/// Simple linear interpolation.
+pub fn lerp(a: f32, b: f32, t: f32) -> f32 {
+    a + (b - a) * t
+}
+
 #[cfg(test)]
 mod tests {
     use cgmath::{assert_relative_eq, EuclideanSpace, Matrix4, Point3};


### PR DESCRIPTION
This tries to compensate for the top to bottom degree at 55°, where the front facing part needs the most space inside the shadow map. We lerp now the shadow map bounds, so that we can properly draw shadows in the distance. This works for standard sun directions very well. We should re-work the enhanced sun direction, so that extreme low angles when the sun is sinking aren't possible. In reality this is also not the case, since the scattered light that come from the sun behind the horizon isn't throwing extremely large shadows either. We should also aim to also do that, or apply a dynamic scaling based on the sun's height angle in the sky. I also adjusted the FOV/default zoom to be closer to the original client. The maximum zoom also was shrunk a bit, so that we don't need to waste precious shadow map resources.

We also now set a default windows size of logical 720p.