### PR TITLE
Properly bound the water of a map

### DIFF
--- a/korangar/src/graphics/instruction.rs
+++ b/korangar/src/graphics/instruction.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use cgmath::{Matrix4, Point3, Vector2, Vector3, Vector4};
+use korangar_util::Rectangle;
 use ragnarok_packets::EntityId;
 use wgpu::BlendFactor;
 
@@ -68,6 +69,7 @@ pub struct Uniforms {
 #[derive(Clone, Debug)]
 pub struct WaterInstruction<'a> {
     pub water_texture: &'a Texture,
+    pub water_bounds: Rectangle<f32>,
     pub texture_repeat: f32,
     pub water_level: f32,
     pub wave_amplitude: f32,

--- a/korangar/src/graphics/passes/water/shader/wave_msaa.wgsl
+++ b/korangar/src/graphics/passes/water/shader/wave_msaa.wgsl
@@ -25,6 +25,7 @@ struct DirectionalLightUniforms {
 }
 
 struct WaterWaveUniforms {
+    water_bounds: vec4<f32>,
     texture_repeat: f32,
     water_level: f32,
     wave_amplitude: f32,
@@ -105,11 +106,17 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
         wave_phase_speed = sqrt(GRAVITY / wave_frequency);
 
         let distance = find_wave_intersection(ray_origin, ray_direction, max_distance, max_wave_height);
+        let hit_position = ray_origin + ray_direction * distance;
 
-        if (distance < 0.0 || distance > max_distance) {
+        if (distance < 0.0 ||
+            distance > max_distance ||
+            hit_position.x < water_wave_uniforms.water_bounds.x ||
+            hit_position.z < water_wave_uniforms.water_bounds.y ||
+            hit_position.x > water_wave_uniforms.water_bounds.z ||
+            hit_position.z > water_wave_uniforms.water_bounds.w
+        ) {
             discard;
         } else {
-            let hit_position = ray_origin + ray_direction * distance;
             color = calculate_wave_color(hit_position);
         }
     }
@@ -128,11 +135,6 @@ fn find_wave_intersection(ray_origin: vec3<f32>, ray_direction: vec3<f32>, max_d
     if (water_wave_uniforms.wave_amplitude == 0.0) {
         // We found a flat water plane.
         return ray_plane_intersection(ray_origin, ray_direction, -water_wave_uniforms.water_level);
-    }
-
-    if (max_distance >= 1e30) {
-        // We look outside of the scene.
-        return -1.0;
     }
 
     let initial_guess = ray_plane_intersection(ray_origin, ray_direction, max_wave_height);

--- a/korangar/src/graphics/passes/water/wave.rs
+++ b/korangar/src/graphics/passes/water/wave.rs
@@ -20,12 +20,14 @@ const DRAWER_NAME: &str = "water wave";
 #[derive(Copy, Clone, Default, Pod, Zeroable)]
 #[repr(C)]
 struct WaterWaveUniforms {
+    water_bounds: [f32; 4],
     texture_repeat: f32,
     water_level: f32,
     wave_amplitude: f32,
     wave_speed: f32,
     wave_length: f32,
     water_opacity: f32,
+    padding: [u32; 2],
 }
 
 pub(crate) struct WaterWaveDrawer {
@@ -157,12 +159,14 @@ impl Prepare for WaterWaveDrawer {
     fn prepare(&mut self, device: &Device, instructions: &RenderInstruction) {
         if let Some(instruction) = instructions.water.as_ref() {
             self.uniforms = WaterWaveUniforms {
+                water_bounds: instruction.water_bounds.into(),
                 texture_repeat: instruction.texture_repeat,
                 water_level: instruction.water_level,
                 wave_amplitude: instruction.wave_amplitude,
                 wave_speed: instruction.wave_speed,
                 wave_length: instruction.wave_length,
                 water_opacity: instruction.water_opacity,
+                padding: Default::default(),
             };
             self.bind_group = Self::create_bind_group(
                 device,

--- a/korangar/src/world/map/mod.rs
+++ b/korangar/src/world/map/mod.rs
@@ -9,7 +9,7 @@ use korangar_audio::AudioEngine;
 use korangar_interface::windows::PrototypeWindow;
 use korangar_util::collision::{Frustum, KDTree, Sphere, AABB};
 use korangar_util::container::{SimpleKey, SimpleSlab};
-use korangar_util::create_simple_key;
+use korangar_util::{create_simple_key, Rectangle};
 #[cfg(feature = "debug")]
 use option_ext::OptionExt;
 #[cfg(feature = "debug")]
@@ -118,6 +118,7 @@ pub struct Map {
     width: usize,
     height: usize,
     water_settings: Option<WaterSettings>,
+    water_bounds: Rectangle<f32>,
     light_settings: LightSettings,
     tiles: Vec<Tile>,
     ground_vertex_offset: usize,
@@ -141,6 +142,10 @@ pub struct Map {
 }
 
 impl Map {
+    pub fn water_bounds(&self) -> Rectangle<f32> {
+        self.water_bounds
+    }
+
     pub fn x_in_bounds(&self, x: usize) -> bool {
         x <= self.width
     }
@@ -295,6 +300,7 @@ impl Map {
 
             *water_instruction = Some(WaterInstruction {
                 water_texture: &water_textures[water_texture_index as usize],
+                water_bounds: self.water_bounds(),
                 texture_repeat,
                 water_level,
                 wave_amplitude,

--- a/korangar_util/src/rectangle.rs
+++ b/korangar_util/src/rectangle.rs
@@ -46,3 +46,9 @@ impl<N: BaseNum> PartialEq for Rectangle<N> {
         self.min == other.min && self.max == other.max
     }
 }
+
+impl<N> From<Rectangle<N>> for [N; 4] {
+    fn from(value: Rectangle<N>) -> Self {
+        [value.min.x, value.min.y, value.max.x, value.max.y]
+    }
+}


### PR DESCRIPTION
This removes the depth hack of the water SDF function and instead reads the water bound from the tiles that would be turned into a water mesh in a traditional renderer.