### PR TITLE
Remove unused Writable::create() function

### DIFF
--- a/korangar/src/loaders/archive/folder/mod.rs
+++ b/korangar/src/loaders/archive/folder/mod.rs
@@ -70,11 +70,6 @@ impl Archive for FolderArchive {
 }
 
 impl Writable for FolderArchive {
-    fn create(&mut self) {
-        fs::create_dir_all(&self.folder_path)
-            .unwrap_or_else(|_| panic!("error creating folder {} for FolderArchive", self.folder_path.display()));
-    }
-
     fn add_file(&mut self, file_path: &str, file_data: Vec<u8>) {
         let normalized_asset_path = Self::os_specific_path(file_path);
         let full_path = self.folder_path.join(normalized_asset_path);

--- a/korangar/src/loaders/archive/mod.rs
+++ b/korangar/src/loaders/archive/mod.rs
@@ -22,8 +22,6 @@ pub enum ArchiveType {
 
 /// A common trait to all writable archives.
 pub trait Writable {
-    fn create(&mut self) {}
-
     fn add_file(&mut self, path: &str, asset: Vec<u8>);
 
     fn save(&self) {}


### PR DESCRIPTION
The functionality isn't used anymore, since the add_file() function will call create_dir_all() if not all folders are found.