### PR TITLE
Change render order of entities and models

### DIFF
--- a/korangar/src/graphics/engine.rs
+++ b/korangar/src/graphics/engine.rs
@@ -991,12 +991,17 @@ impl GraphicsEngine {
                         .forward_pass_context
                         .create_pass(&mut forward_encoder, &engine_context.global_context, None);
 
-                let draw_data = ModelBatchDrawData {
+                let batch_data = &ModelBatchDrawData {
                     batches: instruction.model_batches,
                     instructions: instruction.models,
                     #[cfg(feature = "debug")]
                     show_wireframe: instruction.render_settings.show_wireframe,
                 };
+
+                engine_context.forward_model_drawer.draw(&mut render_pass, ForwardModelDrawData {
+                    batch_data,
+                    draw_transparent: false,
+                });
 
                 engine_context.forward_entity_drawer.draw(&mut render_pass, instruction.entities);
 
@@ -1004,7 +1009,10 @@ impl GraphicsEngine {
                     .forward_indicator_drawer
                     .draw(&mut render_pass, instruction.indicator.as_ref());
 
-                engine_context.forward_model_drawer.draw(&mut render_pass, draw_data);
+                engine_context.forward_model_drawer.draw(&mut render_pass, ForwardModelDrawData {
+                    batch_data,
+                    draw_transparent: true,
+                });
 
                 #[cfg(feature = "debug")]
                 {

--- a/korangar/src/graphics/passes/forward/mod.rs
+++ b/korangar/src/graphics/passes/forward/mod.rs
@@ -14,7 +14,7 @@ pub(crate) use aabb::ForwardAabbDrawer;
 pub(crate) use circle::ForwardCircleDrawer;
 pub(crate) use entity::ForwardEntityDrawer;
 pub(crate) use indicator::ForwardIndicatorDrawer;
-pub(crate) use model::ForwardModelDrawer;
+pub(crate) use model::{ForwardModelDrawData, ForwardModelDrawer};
 #[cfg(feature = "debug")]
 pub(crate) use rectangle::ForwardRectangleDrawer;
 use wgpu::{


### PR DESCRIPTION
This lets entities properly draw their transparent parts. Our draw order now is:

Model Opaque -> Entities -> Model Transparent