### PR TITLE
Set the encoding to UTF-8 when reading string with FromBytes

### DIFF
--- a/ragnarok_bytes/src/from_bytes/implement.rs
+++ b/ragnarok_bytes/src/from_bytes/implement.rs
@@ -65,16 +65,19 @@ impl<T: FromBytes, const SIZE: usize> FromBytes for [T; SIZE] {
 
 impl FromBytes for String {
     fn from_bytes<Meta>(byte_reader: &mut ByteReader<Meta>) -> ConversionResult<Self> {
-        let mut value = String::new();
+        let mut value = Vec::<u8>::new();
 
         while let Ok(byte) = byte_reader.byte::<Self>() {
             match byte {
                 0 => break,
-                byte => value.push(byte as char),
+                byte => value.push(byte),
             }
         }
+        let result = String::from_utf8(value)
+            .map_err(|error| error.into_bytes())
+            .unwrap_or_else(|error| error.iter().map(|byte| *byte as char).collect());
 
-        Ok(value)
+        Ok(result)
     }
 }
 


### PR DESCRIPTION
Change the encoding to UTF-8 when reading string, and also fall back to single-byte character encoding for unsupported string encodings.
The issue discovered is that the string is being processed one byte at a time. However, in UTF-8 encoding, characters can be represented by two or more bytes, which might cause encoding issues.
For example the character á is encoded incorrectly.