### PR TITLE
Implement custom path finding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,18 +688,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deprecate-until"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a3767f826efbbe5a5ae093920b58b43b01734202be697e1354914e862e8e704"
-dependencies = [
- "proc-macro2",
- "quote",
- "semver",
- "syn",
-]
-
-[[package]]
 name = "derive-new"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1491,15 +1479,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "integer-sqrt"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "interface_procedural"
 version = "0.1.0"
 dependencies = [
@@ -1626,6 +1605,7 @@ dependencies = [
 name = "korangar"
 version = "0.1.0"
 dependencies = [
+ "arrayvec",
  "bumpalo",
  "bytemuck",
  "cgmath",
@@ -1645,7 +1625,6 @@ dependencies = [
  "mlua",
  "num",
  "option-ext",
- "pathfinding",
  "pollster",
  "ragnarok_bytes",
  "ragnarok_formats",
@@ -2529,20 +2508,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
-name = "pathfinding"
-version = "4.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cff69f3ba9d0346c1dbe1248fc2ed4523567b683d1b6ff4144a6b3583369082"
-dependencies = [
- "deprecate-until",
- "indexmap",
- "integer-sqrt",
- "num-traits",
- "rustc-hash 2.0.0",
- "thiserror",
-]
-
-[[package]]
 name = "pcap"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3186,12 +3151,6 @@ name = "self_cell"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d369a96f978623eb3dc28807c4852d6cc617fed53da5d3c400feff1ef34a714a"
-
-[[package]]
-name = "semver"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "send_wrapper"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = ["korangar", "ragnarok_*", "korangar_*"]
 
 [workspace.dependencies]
+arrayvec = "0.7"
 bitflags = "2.6"
 bumpalo = "3.16"
 bytemuck = "1.20"
@@ -27,7 +28,6 @@ lunify = "1.1"
 mlua = "0.10"
 num = "0.4"
 option-ext = "0.2"
-pathfinding = "4.11"
 pcap = "2.2"
 pollster = "0.4"
 proc-macro2 = "1.0"

--- a/korangar/Cargo.toml
+++ b/korangar/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+arrayvec = { workspace = true }
 bumpalo = { workspace = true, features = ["allocator_api"] }
 bytemuck = { workspace = true, features = ["derive", "extern_crate_std", "min_const_generics"] }
 cgmath = { workspace = true, features = ["mint", "serde"] }
@@ -23,7 +24,6 @@ lunify = { workspace = true }
 mlua = { workspace = true, features = ["lua51", "vendored"] }
 num = { workspace = true }
 option-ext = { workspace = true }
-pathfinding = { workspace = true }
 pollster = { workspace = true }
 ragnarok_bytes = { workspace = true, features = ["derive", "cgmath"] }
 ragnarok_formats = { workspace = true, features = ["interface"] }

--- a/korangar/src/world/map/mod.rs
+++ b/korangar/src/world/map/mod.rs
@@ -9,6 +9,7 @@ use korangar_audio::AudioEngine;
 use korangar_interface::windows::PrototypeWindow;
 use korangar_util::collision::{Frustum, KDTree, Sphere, AABB};
 use korangar_util::container::{SimpleKey, SimpleSlab};
+use korangar_util::pathing::Traversable;
 use korangar_util::{create_simple_key, Rectangle};
 #[cfg(feature = "debug")]
 use option_ext::OptionExt;
@@ -144,14 +145,6 @@ pub struct Map {
 impl Map {
     pub fn water_bounds(&self) -> Rectangle<f32> {
         self.water_bounds
-    }
-
-    pub fn x_in_bounds(&self, x: usize) -> bool {
-        x <= self.width
-    }
-
-    pub fn y_in_bounds(&self, y: usize) -> bool {
-        y <= self.height
     }
 
     pub fn get_world_position(&self, position: Vector2<usize>) -> Point3<f32> {
@@ -738,5 +731,21 @@ impl Map {
 
         let (screen_position, screen_size) = camera.screen_position_size(top_left_position, bottom_right_position);
         Some((screen_position, screen_size))
+    }
+}
+
+impl Traversable for Map {
+    fn is_walkable(&self, position: Vector2<usize>) -> bool {
+        self.tiles
+            .get(position.x + position.y * self.width)
+            .map(|tile| tile.flags.contains(TileFlags::WALKABLE))
+            .unwrap_or(false)
+    }
+
+    fn is_snipeable(&self, position: Vector2<usize>) -> bool {
+        self.tiles
+            .get(position.x + position.y * self.width)
+            .map(|tile| tile.flags.contains(TileFlags::SNIPABLE))
+            .unwrap_or(false)
     }
 }

--- a/korangar_util/src/lib.rs
+++ b/korangar_util/src/lib.rs
@@ -7,6 +7,7 @@ pub mod color;
 pub mod container;
 mod loader;
 pub mod math;
+pub mod pathing;
 mod rectangle;
 pub mod texture_atlas;
 

--- a/korangar_util/src/pathing.rs
+++ b/korangar_util/src/pathing.rs
@@ -1,0 +1,393 @@
+//! Implements pathfinding algorithms.
+
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+
+use cgmath::Vector2;
+use hashbrown::{HashMap, HashSet};
+
+const MOVE_DIAGONAL_COST: usize = 14;
+const MOVE_ORTHOGONAL_COST: usize = 10;
+/// The maximum size a walkable path can have.
+pub const MAX_WALK_PATH_SIZE: usize = 32;
+
+/// Essential trait that is needed to be implements for pathfinding.
+pub trait Traversable {
+    /// Must return `true` if the position can be walked on.
+    fn is_walkable(&self, position: Vector2<usize>) -> bool;
+    /// Must return `true` if the position can be shot through.
+    fn is_snipeable(&self, position: Vector2<usize>) -> bool;
+}
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+struct PathNode {
+    position: Vector2<usize>,
+    f_score: usize,
+    g_score: usize,
+}
+
+impl Ord for PathNode {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other.f_score.cmp(&self.f_score)
+    }
+}
+
+impl PartialOrd for PathNode {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Pathfinding algorithm for entity map navigation.
+#[derive(Default)]
+pub struct PathFinder {
+    open_set: BinaryHeap<PathNode>,
+    closed_set: HashSet<Vector2<usize>>,
+    came_from: HashMap<Vector2<usize>, Vector2<usize>>,
+    g_scores: HashMap<Vector2<usize>, usize>,
+    path: Vec<Vector2<usize>>,
+    neighbors: Vec<Vector2<usize>>,
+}
+
+impl PathFinder {
+    /// Returns the shortest walkable path between start and goal. Uses a simple
+    /// A* search algorithm like the legacy client and alternative server
+    /// implementations. It must have the same behavior, or else we would
+    /// "desync" with our client movement prediction.
+    pub fn find_walkable_path(&mut self, map: &impl Traversable, start: Vector2<usize>, goal: Vector2<usize>) -> Option<&[Vector2<usize>]> {
+        self.open_set.clear();
+        self.closed_set.clear();
+        self.came_from.clear();
+        self.g_scores.clear();
+        self.path.clear();
+
+        self.open_set.push(PathNode {
+            position: start,
+            g_score: 0,
+            f_score: Self::heuristic(start, goal),
+        });
+        self.g_scores.insert(start, 0);
+
+        while let Some(current) = self.open_set.pop() {
+            if current.position == goal {
+                return match self.reconstruct_path(start, goal) {
+                    true => Some(&self.path),
+                    false => None,
+                };
+            }
+
+            if self.closed_set.contains(&current.position) {
+                continue;
+            }
+            self.closed_set.insert(current.position);
+
+            self.find_neighbors(map, current.position);
+
+            for neighbor in self.neighbors.drain(..) {
+                if self.closed_set.contains(&neighbor) {
+                    continue;
+                }
+
+                let movement_cost = if neighbor.x != current.position.x && neighbor.y != current.position.y {
+                    MOVE_DIAGONAL_COST
+                } else {
+                    MOVE_ORTHOGONAL_COST
+                };
+
+                let tentative_g_score = current.g_score + movement_cost;
+
+                if tentative_g_score < self.g_scores.get(&neighbor).copied().unwrap_or(usize::MAX) {
+                    self.came_from.insert(neighbor, current.position);
+                    self.g_scores.insert(neighbor, tentative_g_score);
+
+                    let h_score = Self::heuristic(neighbor, goal);
+                    let f_score = tentative_g_score + h_score;
+
+                    self.open_set.push(PathNode {
+                        position: neighbor,
+                        g_score: tentative_g_score,
+                        f_score,
+                    });
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Returns the shortest path between start and goal that can be shot
+    /// through.
+    pub fn find_snipable_path(&mut self, map: &impl Traversable, start: Vector2<usize>, goal: Vector2<usize>) -> Option<&[Vector2<usize>]> {
+        self.path.clear();
+
+        let mut current_x = start.x as isize;
+        let mut current_y = start.y as isize;
+        let mut target_x = goal.x as isize;
+        let mut target_y = goal.y as isize;
+
+        let mut delta_x = target_x - current_x;
+        if delta_x < 0 {
+            std::mem::swap(&mut current_x, &mut target_x);
+            std::mem::swap(&mut current_y, &mut target_y);
+            delta_x = -delta_x;
+        }
+        let delta_y = target_y - current_y;
+
+        self.path.push(Vector2::new(current_x as usize, current_y as usize));
+
+        let weight = if delta_x > delta_y.abs() { delta_x } else { delta_y.abs() };
+
+        let mut weight_x = 0;
+        let mut weight_y = 0;
+
+        while current_x != target_x || current_y != target_y {
+            weight_x += delta_x;
+            weight_y += delta_y;
+
+            if weight_x >= weight {
+                weight_x -= weight;
+                current_x += 1;
+            }
+            if weight_y >= weight {
+                weight_y -= weight;
+                current_y += 1;
+            } else if weight_y < 0 {
+                weight_y += weight;
+                current_y -= 1;
+            }
+
+            if self.path.len() < MAX_WALK_PATH_SIZE {
+                self.path.push(Vector2::new(current_x as usize, current_y as usize));
+            } else {
+                return None;
+            }
+
+            if (current_x != target_x || current_y != target_y) && !map.is_snipeable(Vector2::new(current_x as usize, current_y as usize)) {
+                return None;
+            }
+        }
+
+        Some(&self.path)
+    }
+
+    fn heuristic(start: Vector2<usize>, goal: Vector2<usize>) -> usize {
+        let dx = (start.x as isize - goal.x as isize).unsigned_abs();
+        let dy = (start.y as isize - goal.y as isize).unsigned_abs();
+        let manhattan_distance = dx + dy;
+        MOVE_ORTHOGONAL_COST * manhattan_distance
+    }
+
+    fn find_neighbors(&mut self, map: &impl Traversable, position: Vector2<usize>) {
+        let orthogonal_neighbors = [(1, 0), (-1, 0), (0, 1), (0, -1)];
+
+        for (dx, dy) in orthogonal_neighbors {
+            let new_x = position.x.wrapping_add_signed(dx);
+            let new_y = position.y.wrapping_add_signed(dy);
+            let new_position = Vector2::new(new_x, new_y);
+
+            if map.is_walkable(new_position) {
+                self.neighbors.push(new_position);
+            }
+        }
+
+        let diagonal_neighbors = [(1, 1), (1, -1), (-1, 1), (-1, -1)];
+
+        for (dx, dy) in diagonal_neighbors {
+            let new_x = position.x.wrapping_add_signed(dx);
+            let new_y = position.y.wrapping_add_signed(dy);
+            let new_position = Vector2::new(new_x, new_y);
+
+            // Only allow diagonal neighbors when both adjacent orthogonal neighbors are
+            // also walkable.
+            if map.is_walkable(new_position)
+                && map.is_walkable(Vector2::new(position.x, new_y))
+                && map.is_walkable(Vector2::new(new_x, position.y))
+            {
+                self.neighbors.push(new_position);
+            }
+        }
+    }
+
+    fn reconstruct_path(&mut self, start: Vector2<usize>, goal: Vector2<usize>) -> bool {
+        let mut current = goal;
+
+        while current != start {
+            self.path.push(current);
+            current = *self.came_from.get(&current).unwrap();
+
+            if self.path.len() >= MAX_WALK_PATH_SIZE {
+                return false;
+            }
+        }
+
+        self.path.push(start);
+        self.path.reverse();
+
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestMap {
+        width: usize,
+        height: usize,
+        not_walkable: HashSet<Vector2<usize>>,
+        not_snipable: HashSet<Vector2<usize>>,
+    }
+
+    impl TestMap {
+        fn new(width: usize, height: usize) -> Self {
+            Self {
+                width,
+                height,
+                not_walkable: HashSet::new(),
+                not_snipable: HashSet::new(),
+            }
+        }
+
+        fn set_unwalkable(&mut self, points: &[Vector2<usize>]) {
+            for point in points {
+                self.not_walkable.insert(*point);
+            }
+        }
+
+        fn set_unsnipable(&mut self, points: &[Vector2<usize>]) {
+            for point in points {
+                self.not_snipable.insert(*point);
+            }
+        }
+    }
+
+    impl Traversable for TestMap {
+        fn is_walkable(&self, position: Vector2<usize>) -> bool {
+            position.x < self.width && position.y < self.height && !self.not_walkable.contains(&position)
+        }
+
+        fn is_snipeable(&self, position: Vector2<usize>) -> bool {
+            position.x < self.width && position.y < self.height && !self.not_snipable.contains(&position)
+        }
+    }
+
+    #[test]
+    fn test_straight_path() {
+        let map = TestMap::new(10, 10);
+        let mut pathfinder = PathFinder::default();
+
+        let start = Vector2::new(0, 0);
+        let goal = Vector2::new(3, 0);
+
+        let path = pathfinder.find_walkable_path(&map, start, goal).unwrap();
+        assert_eq!(path, vec![
+            Vector2::new(0, 0),
+            Vector2::new(1, 0),
+            Vector2::new(2, 0),
+            Vector2::new(3, 0),
+        ]);
+    }
+
+    #[test]
+    fn test_diagonal_path() {
+        let map = TestMap::new(10, 10);
+        let mut pathfinder = PathFinder::default();
+
+        let start = Vector2::new(0, 0);
+        let goal = Vector2::new(3, 3);
+
+        let path = pathfinder.find_walkable_path(&map, start, goal).unwrap();
+        assert_eq!(path, vec![
+            Vector2::new(0, 0),
+            Vector2::new(1, 1),
+            Vector2::new(2, 2),
+            Vector2::new(3, 3),
+        ]);
+    }
+
+    #[test]
+    fn test_path_with_obstacle() {
+        let mut map = TestMap::new(5, 5);
+        map.set_unwalkable(&[Vector2::new(1, 1), Vector2::new(1, 2), Vector2::new(1, 3)]);
+
+        let mut pathfinder = PathFinder::default();
+        let start = Vector2::new(0, 0);
+        let goal = Vector2::new(2, 2);
+
+        let path = pathfinder.find_walkable_path(&map, start, goal).unwrap();
+
+        assert_eq!(path, vec![
+            Vector2::new(0, 0),
+            Vector2::new(1, 0),
+            Vector2::new(2, 0),
+            Vector2::new(2, 1),
+            Vector2::new(2, 2),
+        ]);
+    }
+
+    #[test]
+    fn test_no_path_possible() {
+        let mut map = TestMap::new(5, 5);
+
+        map.set_unwalkable(&[
+            Vector2::new(1, 0),
+            Vector2::new(1, 1),
+            Vector2::new(1, 2),
+            Vector2::new(1, 3),
+            Vector2::new(1, 4),
+        ]);
+
+        let mut pathfinder = PathFinder::default();
+
+        let start = Vector2::new(0, 2);
+        let goal = Vector2::new(2, 2);
+
+        assert!(pathfinder.find_walkable_path(&map, start, goal).is_none());
+    }
+
+    #[test]
+    fn test_shoot_path_straight() {
+        let map = TestMap::new(10, 10);
+        let mut pathfinder = PathFinder::default();
+
+        let start = Vector2::new(0, 0);
+        let goal = Vector2::new(3, 0);
+
+        let path = pathfinder.find_snipable_path(&map, start, goal).unwrap();
+        assert_eq!(path.len(), 4);
+
+        for (index, step) in path.iter().enumerate() {
+            assert_eq!(step.x, index);
+            assert_eq!(step.y, 0);
+        }
+    }
+
+    #[test]
+    fn test_shoot_path_diagonal() {
+        let map = TestMap::new(10, 10);
+        let mut pathfinder = PathFinder::default();
+
+        let start = Vector2::new(0, 0);
+        let goal = Vector2::new(3, 3);
+
+        let path = pathfinder.find_snipable_path(&map, start, goal).unwrap();
+        assert_eq!(path.len(), 4);
+
+        for (index, step) in path.iter().enumerate() {
+            assert_eq!(step.x, index);
+            assert_eq!(step.y, index);
+        }
+    }
+
+    #[test]
+    fn test_shoot_path_blocked() {
+        let mut map = TestMap::new(5, 5);
+        map.set_unsnipable(&[Vector2::new(1, 1)]);
+
+        let mut pathfinder = PathFinder::default();
+        let start = Vector2::new(0, 0);
+        let goal = Vector2::new(2, 2);
+
+        assert!(pathfinder.find_snipable_path(&map, start, goal).is_none());
+    }
+}


### PR DESCRIPTION
I found the path finding code highly complicated and also inefficient, since we allocated on the heap multiple times, without amortising the allocations.

This implementation provides a struct that implements the A* and also line of sight path finding in a way, that is compatible with the server implementations. We also re-use the heap allocations.

The A* algorithm is a basic implementation that uses a binary heap. Moved the code in korangar_utils, so that it can be properly optimized and also tested.