### PR TITLE
Improve first map server connect

### DIFF
--- a/korangar/src/graphics/engine.rs
+++ b/korangar/src/graphics/engine.rs
@@ -861,9 +861,12 @@ impl GraphicsEngine {
                         .picker_render_pass_context
                         .create_pass(&mut picker_encoder, &engine_context.global_context, None);
 
-                engine_context
-                    .picker_tile_drawer
-                    .draw(&mut render_pass, instruction.map_picker_tile_vertex_buffer);
+                if let Some(map_picker_tile_vertex_buffer) = instruction.map_picker_tile_vertex_buffer.as_ref() {
+                    engine_context
+                        .picker_tile_drawer
+                        .draw(&mut render_pass, map_picker_tile_vertex_buffer);
+                }
+
                 engine_context.picker_entity_drawer.draw(&mut render_pass, instruction.entities);
                 #[cfg(feature = "debug")]
                 {

--- a/korangar/src/graphics/instruction.rs
+++ b/korangar/src/graphics/instruction.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use cgmath::{Matrix4, Point3, Vector2, Vector3, Vector4};
+use cgmath::{Matrix4, Point3, SquareMatrix, Vector2, Vector3, Vector4, Zero};
 use korangar_util::Rectangle;
 use ragnarok_packets::EntityId;
 use wgpu::BlendFactor;
@@ -40,8 +40,8 @@ pub struct RenderInstruction<'a> {
     pub point_shadow_entities: &'a [EntityInstruction],
     pub effects: &'a [EffectInstruction],
     pub water: Option<WaterInstruction<'a>>,
-    pub map_picker_tile_vertex_buffer: &'a Buffer<TileVertex>,
-    pub font_map_texture: &'a Texture,
+    pub map_picker_tile_vertex_buffer: Option<&'a Buffer<TileVertex>>,
+    pub font_map_texture: Option<&'a Texture>,
     #[cfg(feature = "debug")]
     pub render_settings: RenderSettings,
     #[cfg(feature = "debug")]
@@ -54,6 +54,47 @@ pub struct RenderInstruction<'a> {
     pub marker: &'a [MarkerInstruction],
 }
 
+impl Default for RenderInstruction<'static> {
+    fn default() -> Self {
+        Self {
+            clear_interface: true,
+            show_interface: false,
+            picker_position: ScreenPosition::default(),
+            uniforms: Uniforms::default(),
+            indicator: None,
+            interface: &[],
+            bottom_layer_rectangles: &[],
+            middle_layer_rectangles: &[],
+            top_layer_rectangles: &[],
+            directional_light_with_shadow: DirectionalShadowCasterInstruction::default(),
+            point_light_shadow_caster: &[],
+            point_light: &[],
+            model_batches: &[],
+            models: &mut [],
+            entities: &mut [],
+            directional_model_batches: &[],
+            directional_shadow_models: &[],
+            directional_shadow_entities: &[],
+            point_shadow_models: &[],
+            point_shadow_entities: &[],
+            effects: &[],
+            water: None,
+            map_picker_tile_vertex_buffer: None,
+            font_map_texture: None,
+            #[cfg(feature = "debug")]
+            render_settings: RenderSettings::default(),
+            #[cfg(feature = "debug")]
+            aabb: &[],
+            #[cfg(feature = "debug")]
+            circles: &[],
+            #[cfg(feature = "debug")]
+            rectangles: &[],
+            #[cfg(feature = "debug")]
+            marker: &[],
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Uniforms {
     pub view_matrix: Matrix4<f32>,
@@ -64,6 +105,21 @@ pub struct Uniforms {
     pub ambient_light_color: Color,
     pub enhanced_lighting: bool,
     pub shadow_quality: ShadowQuality,
+}
+
+impl Default for Uniforms {
+    fn default() -> Self {
+        Self {
+            view_matrix: Matrix4::identity(),
+            projection_matrix: Matrix4::identity(),
+            camera_position: Vector4::zero(),
+            animation_timer: 0.0,
+            day_timer: 0.0,
+            ambient_light_color: Color::default(),
+            enhanced_lighting: false,
+            shadow_quality: ShadowQuality::Soft,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -84,6 +140,17 @@ pub struct DirectionalShadowCasterInstruction {
     pub view_matrix: Matrix4<f32>,
     pub direction: Vector3<f32>,
     pub color: Color,
+}
+
+impl Default for DirectionalShadowCasterInstruction {
+    fn default() -> Self {
+        Self {
+            view_projection_matrix: Matrix4::identity(),
+            view_matrix: Matrix4::identity(),
+            direction: Vector3::zero(),
+            color: Color::default(),
+        }
+    }
 }
 
 /// Right now point shadows can't cast shadows of models that are not part of

--- a/korangar/src/graphics/passes/interface/rectangle.rs
+++ b/korangar/src/graphics/passes/interface/rectangle.rs
@@ -250,6 +250,10 @@ impl Prepare for InterfaceRectangleDrawer {
             return;
         }
 
+        let Some(font_map_texture) = instructions.font_map_texture else {
+            return;
+        };
+
         self.instance_data.clear();
 
         if self.bindless_support {
@@ -381,8 +385,8 @@ impl Prepare for InterfaceRectangleDrawer {
                 &self.bind_group_layout,
                 &self.instance_data_buffer,
                 &texture_views,
-                instructions.font_map_texture.get_texture_view(),
-            )
+                font_map_texture.get_texture_view(),
+            );
         } else {
             for instruction in instructions.interface.iter() {
                 match instruction {
@@ -481,8 +485,8 @@ impl Prepare for InterfaceRectangleDrawer {
                 device,
                 &self.bind_group_layout,
                 &self.instance_data_buffer,
-                instructions.font_map_texture.get_texture_view(),
-            )
+                font_map_texture.get_texture_view(),
+            );
         }
     }
 

--- a/korangar/src/graphics/passes/postprocessing/buffer.rs
+++ b/korangar/src/graphics/passes/postprocessing/buffer.rs
@@ -114,7 +114,9 @@ impl Drawer<{ BindGroupCount::One }, { ColorAttachmentCount::One }, { DepthAttac
 
 impl Prepare for PostProcessingBufferDrawer {
     fn prepare(&mut self, device: &Device, instructions: &RenderInstruction) {
-        self.bind_group = Self::create_bind_group(device, &self.bind_group_layout, instructions.font_map_texture);
+        if let Some(font_map_texture) = instructions.font_map_texture {
+            self.bind_group = Self::create_bind_group(device, &self.bind_group_layout, font_map_texture);
+        }
     }
 
     fn upload(&mut self, _device: &Device, _staging_belt: &mut StagingBelt, _command_encoder: &mut CommandEncoder) {

--- a/korangar/src/graphics/passes/postprocessing/rectangle.rs
+++ b/korangar/src/graphics/passes/postprocessing/rectangle.rs
@@ -274,6 +274,10 @@ impl Prepare for PostProcessingRectangleDrawer {
             return;
         }
 
+        let Some(font_map_texture) = instructions.font_map_texture else {
+            return;
+        };
+
         self.instance_data.clear();
 
         if self.bindless_support {
@@ -409,7 +413,7 @@ impl Prepare for PostProcessingRectangleDrawer {
                 &self.bind_group_layout,
                 &self.instance_data_buffer,
                 &texture_views,
-                instructions.font_map_texture.get_texture_view(),
+                font_map_texture.get_texture_view(),
             );
         } else {
             let mut offset = 0;
@@ -507,12 +511,11 @@ impl Prepare for PostProcessingRectangleDrawer {
                 }
             }
 
-            self.instance_data_buffer.reserve(device, self.instance_data.len());
             self.bind_group = Self::create_bind_group(
                 device,
                 &self.bind_group_layout,
                 &self.instance_data_buffer,
-                instructions.font_map_texture.get_texture_view(),
+                font_map_texture.get_texture_view(),
             );
         }
     }

--- a/korangar/src/graphics/settings.rs
+++ b/korangar/src/graphics/settings.rs
@@ -161,7 +161,7 @@ impl Display for ScreenSpaceAntiAliasing {
 }
 
 #[cfg(feature = "debug")]
-#[derive(Copy, Clone, new)]
+#[derive(Copy, Clone, Default, new)]
 pub struct RenderSettings {
     #[new(value = "true")]
     pub show_frames_per_second: bool,

--- a/korangar/src/main.rs
+++ b/korangar/src/main.rs
@@ -274,7 +274,7 @@ struct Client {
     chat_messages: PlainTrackedState<Vec<ChatMessage>>,
     main_menu_click_sound_effect: SoundEffectKey,
 
-    map: Map,
+    map: Option<Map>,
 }
 
 impl Client {
@@ -679,7 +679,7 @@ impl Client {
             tile_texture,
             chat_messages,
             main_menu_click_sound_effect,
-            map,
+            map: Some(map),
         }
     }
 
@@ -853,7 +853,7 @@ impl Client {
                     self.point_light_manager.clear();
                     self.audio_engine.play_background_music_track(None);
 
-                    self.map = self
+                    let map = self
                         .map_loader
                         .load(
                             DEFAULT_MAP.to_string(),
@@ -864,7 +864,9 @@ impl Client {
                         )
                         .expect("failed to load initial map");
 
-                    self.map.set_ambient_sound_sources(&self.audio_engine);
+                    let map = self.map.insert(map);
+
+                    map.set_ambient_sound_sources(&self.audio_engine);
                     self.audio_engine.play_background_music_track(DEFAULT_BACKGROUND_MUSIC);
 
                     self.interface.close_all_windows_except(&mut self.focus_state);
@@ -923,7 +925,7 @@ impl Client {
                     self.interface
                         .open_window(&self.application, &mut self.focus_state, &ErrorWindow::new(message.to_owned()))
                 }
-                NetworkEvent::CharacterSelected { login_data, map_name } => {
+                NetworkEvent::CharacterSelected { login_data, .. } => {
                     self.audio_engine.play_sound_effect(self.main_menu_click_sound_effect);
 
                     let saved_login_data = self.saved_login_data.as_ref().unwrap();
@@ -938,21 +940,6 @@ impl Client {
                         .cloned()
                         .unwrap();
 
-                    self.map = self
-                        .map_loader
-                        .load(
-                            map_name,
-                            &mut self.model_loader,
-                            self.texture_loader.clone(),
-                            #[cfg(feature = "debug")]
-                            &self.tile_texture_mapping,
-                        )
-                        .unwrap();
-
-                    self.map.set_ambient_sound_sources(&self.audio_engine);
-                    self.audio_engine
-                        .play_background_music_track(self.map.background_music_track_name());
-
                     self.saved_player_name = character_information.name.clone();
 
                     let player = Player::new(
@@ -960,20 +947,15 @@ impl Client {
                         &mut self.action_loader,
                         &mut self.animation_loader,
                         &self.script_loader,
-                        &self.map,
-                        &mut self.path_finder,
                         saved_login_data.account_id,
                         character_information,
-                        WorldPosition::origin(),
                         client_tick,
                     );
-                    let player = Entity::Player(player);
 
-                    self.player_camera.set_focus_point(player.get_position());
-                    self.entities.push(player);
+                    self.entities.push(Entity::Player(player));
 
-                    // TODO: this will do one unnecessary restore_focus. check if
-                    // that will be problematic
+                    // TODO: This will do one unnecessary restore_focus. Check if
+                    //       that will be problematic.
                     self.interface
                         .close_window_with_class(&mut self.focus_state, CharacterSelectionWindow::WINDOW_CLASS);
                     self.interface
@@ -992,9 +974,7 @@ impl Client {
                     // Put the dialog system in a well-defined state.
                     self.dialog_system.close_dialog();
 
-                    self.particle_holder.clear();
-                    let _ = self.networking_system.map_loaded();
-                    self.game_timer.set_client_tick(client_tick);
+                    self.map = None;
                 }
                 NetworkEvent::CharacterCreated { character_information } => {
                     self.saved_characters.push(character_information);
@@ -1014,25 +994,26 @@ impl Client {
                     );
                 }
                 NetworkEvent::AddEntity(entity_appeared_data) => {
-                    // Sometimes (like after a job change) the server will tell the client
-                    // that a new entity appeared, even though it was already on screen. So
-                    // to prevent the entity existing twice, we remove the old one.
-                    self.entities
-                        .retain(|entity| entity.get_entity_id() != entity_appeared_data.entity_id);
+                    if let Some(map) = self.map.as_ref() {
+                        // Sometimes (like after a job change) the server will tell the client
+                        // that a new entity appeared, even though it was already on screen. So
+                        // to prevent the entity existing twice, we remove the old one.
+                        self.entities
+                            .retain(|entity| entity.get_entity_id() != entity_appeared_data.entity_id);
 
-                    let npc = Npc::new(
-                        &mut self.sprite_loader,
-                        &mut self.action_loader,
-                        &mut self.animation_loader,
-                        &self.script_loader,
-                        &self.map,
-                        &mut self.path_finder,
-                        entity_appeared_data,
-                        client_tick,
-                    );
+                        let npc = Npc::new(
+                            &mut self.sprite_loader,
+                            &mut self.action_loader,
+                            &mut self.animation_loader,
+                            &self.script_loader,
+                            map,
+                            &mut self.path_finder,
+                            entity_appeared_data,
+                            client_tick,
+                        );
 
-                    let npc = Entity::Npc(npc);
-                    self.entities.push(npc);
+                        self.entities.push(Entity::Npc(npc));
+                    }
                 }
                 NetworkEvent::RemoveEntity { entity_id, reason } => {
                     //If the motive is dead, you need to set the player to dead
@@ -1060,27 +1041,35 @@ impl Client {
                 NetworkEvent::EntityMove(entity_id, position_from, position_to, starting_timestamp) => {
                     let entity = self.entities.iter_mut().find(|entity| entity.get_entity_id() == entity_id);
 
-                    if let Some(entity) = entity {
+                    if let Some(entity) = entity
+                        && let Some(map) = self.map.as_ref()
+                    {
                         let position_from = Vector2::new(position_from.x, position_from.y);
                         let position_to = Vector2::new(position_to.x, position_to.y);
 
-                        entity.move_from_to(&self.map, &mut self.path_finder, position_from, position_to, starting_timestamp);
+                        entity.move_from_to(map, &mut self.path_finder, position_from, position_to, starting_timestamp);
                         #[cfg(feature = "debug")]
-                        entity.generate_pathing_mesh(&self.device, &self.queue, &self.map, &self.pathing_texture_mapping);
+                        entity.generate_pathing_mesh(&self.device, &self.queue, map, &self.pathing_texture_mapping);
                     }
                 }
                 NetworkEvent::PlayerMove(position_from, position_to, starting_timestamp) => {
-                    let position_from = Vector2::new(position_from.x, position_from.y);
-                    let position_to = Vector2::new(position_to.x, position_to.y);
-                    self.entities[0].move_from_to(&self.map, &mut self.path_finder, position_from, position_to, starting_timestamp);
+                    if let Some(map) = self.map.as_ref() {
+                        let position_from = Vector2::new(position_from.x, position_from.y);
+                        let position_to = Vector2::new(position_to.x, position_to.y);
+                        self.entities[0].move_from_to(map, &mut self.path_finder, position_from, position_to, starting_timestamp);
 
-                    #[cfg(feature = "debug")]
-                    self.entities[0].generate_pathing_mesh(&self.device, &self.queue, &self.map, &self.pathing_texture_mapping);
+                        #[cfg(feature = "debug")]
+                        self.entities[0].generate_pathing_mesh(&self.device, &self.queue, map, &self.pathing_texture_mapping);
+                    }
                 }
                 NetworkEvent::ChangeMap(map_name, player_position) => {
+                    self.map = None;
+
+                    // Only the player must stay alive between map changes.
                     self.entities.truncate(1);
 
-                    self.map = self
+                    // TODO: NHA Support async map loading.
+                    let new_map = self
                         .map_loader
                         .load(
                             map_name,
@@ -1091,23 +1080,19 @@ impl Client {
                         )
                         .unwrap();
 
-                    self.map.set_ambient_sound_sources(&self.audio_engine);
-                    self.audio_engine
-                        .play_background_music_track(self.map.background_music_track_name());
+                    let map = self.map.insert(new_map);
+
+                    map.set_ambient_sound_sources(&self.audio_engine);
+                    self.audio_engine.play_background_music_track(map.background_music_track_name());
 
                     let player_position = Vector2::new(player_position.x as usize, player_position.y as usize);
-                    self.entities[0].set_position(&self.map, player_position, client_tick);
+                    self.entities[0].set_position(map, player_position, client_tick);
                     self.player_camera.set_focus_point(self.entities[0].get_position());
 
                     self.particle_holder.clear();
                     self.effect_holder.clear();
                     self.point_light_manager.clear();
                     let _ = self.networking_system.map_loaded();
-                }
-                NetworkEvent::SetPlayerPosition(player_position) => {
-                    let player_position = Vector2::new(player_position.x, player_position.y);
-                    self.entities[0].set_position(&self.map, player_position, client_tick);
-                    self.player_camera.set_focus_point(self.entities[0].get_position());
                 }
                 NetworkEvent::UpdateClientTick(client_tick) => {
                     self.game_timer.set_client_tick(client_tick);
@@ -1165,7 +1150,9 @@ impl Client {
                 NetworkEvent::AddCloseButton => self.dialog_system.add_close_button(),
                 NetworkEvent::AddChoiceButtons(choices) => self.dialog_system.add_choice_buttons(choices),
                 NetworkEvent::AddQuestEffect(quest_effect) => {
-                    self.particle_holder.add_quest_icon(&self.texture_loader, &self.map, quest_effect)
+                    if let Some(map) = self.map.as_ref() {
+                        self.particle_holder.add_quest_icon(&self.texture_loader, map, quest_effect)
+                    }
                 }
                 NetworkEvent::RemoveQuestEffect(entity_id) => self.particle_holder.remove_quest_icon(entity_id),
                 NetworkEvent::SetInventory { items } => {
@@ -1262,51 +1249,55 @@ impl Client {
                         false,
                     )));
                 }
-                NetworkEvent::AddSkillUnit(entity_id, unit_id, position) => match unit_id {
-                    UnitId::Firewall => {
-                        let position = Vector2::new(position.x as usize, position.y as usize);
-                        let position = self.map.get_world_position(position);
-                        let effect = self.effect_loader.get("firewall.str", &self.texture_loader).unwrap();
-                        let frame_timer = effect.new_frame_timer();
+                NetworkEvent::AddSkillUnit(entity_id, unit_id, position) => {
+                    let Some(map) = self.map.as_ref() else { continue };
 
-                        self.effect_holder.add_unit(
-                            Box::new(EffectWithLight::new(
-                                effect,
-                                frame_timer,
-                                EffectCenter::Position(position),
-                                Vector3::new(0.0, 0.0, 0.0),
-                                PointLightId::new(unit_id as u32),
-                                Vector3::new(0.0, 6.0, 0.0),
-                                Color::rgb_u8(255, 30, 0),
-                                60.0,
-                                true,
-                            )),
-                            entity_id,
-                        );
-                    }
-                    UnitId::Pneuma => {
-                        let position = Vector2::new(position.x as usize, position.y as usize);
-                        let position = self.map.get_world_position(position);
-                        let effect = self.effect_loader.get("pneuma1.str", &self.texture_loader).unwrap();
-                        let frame_timer = effect.new_frame_timer();
+                    match unit_id {
+                        UnitId::Firewall => {
+                            let position = Vector2::new(position.x as usize, position.y as usize);
+                            let position = map.get_world_position(position);
+                            let effect = self.effect_loader.get("firewall.str", &self.texture_loader).unwrap();
+                            let frame_timer = effect.new_frame_timer();
 
-                        self.effect_holder.add_unit(
-                            Box::new(EffectWithLight::new(
-                                effect,
-                                frame_timer,
-                                EffectCenter::Position(position),
-                                Vector3::new(0.0, 0.0, 0.0),
-                                PointLightId::new(unit_id as u32),
-                                Vector3::new(0.0, 6.0, 0.0),
-                                Color::rgb_u8(83, 220, 108),
-                                40.0,
-                                false,
-                            )),
-                            entity_id,
-                        );
+                            self.effect_holder.add_unit(
+                                Box::new(EffectWithLight::new(
+                                    effect,
+                                    frame_timer,
+                                    EffectCenter::Position(position),
+                                    Vector3::new(0.0, 0.0, 0.0),
+                                    PointLightId::new(unit_id as u32),
+                                    Vector3::new(0.0, 6.0, 0.0),
+                                    Color::rgb_u8(255, 30, 0),
+                                    60.0,
+                                    true,
+                                )),
+                                entity_id,
+                            );
+                        }
+                        UnitId::Pneuma => {
+                            let position = Vector2::new(position.x as usize, position.y as usize);
+                            let position = map.get_world_position(position);
+                            let effect = self.effect_loader.get("pneuma1.str", &self.texture_loader).unwrap();
+                            let frame_timer = effect.new_frame_timer();
+
+                            self.effect_holder.add_unit(
+                                Box::new(EffectWithLight::new(
+                                    effect,
+                                    frame_timer,
+                                    EffectCenter::Position(position),
+                                    Vector3::new(0.0, 0.0, 0.0),
+                                    PointLightId::new(unit_id as u32),
+                                    Vector3::new(0.0, 6.0, 0.0),
+                                    Color::rgb_u8(83, 220, 108),
+                                    40.0,
+                                    false,
+                                )),
+                                entity_id,
+                            );
+                        }
+                        _ => {}
                     }
-                    _ => {}
-                },
+                }
                 NetworkEvent::RemoveSkillUnit(entity_id) => {
                     self.effect_holder.remove_unit(entity_id);
                 }
@@ -1758,11 +1749,15 @@ impl Client {
                         .focus_window_with_class(&mut self.focus_state, ChatWindow::WINDOW_CLASS);
                 }
                 #[cfg(feature = "debug")]
-                UserEvent::OpenMarkerDetails(marker_identifier) => self.interface.open_window(
-                    &self.application,
-                    &mut self.focus_state,
-                    self.map.resolve_marker(&self.entities, marker_identifier),
-                ),
+                UserEvent::OpenMarkerDetails(marker_identifier) => {
+                    if let Some(map) = self.map.as_ref() {
+                        self.interface.open_window(
+                            &self.application,
+                            &mut self.focus_state,
+                            map.resolve_marker(&self.entities, marker_identifier),
+                        );
+                    }
+                }
                 #[cfg(feature = "debug")]
                 UserEvent::OpenRenderSettingsWindow => self.interface.open_window(
                     &self.application,
@@ -1771,8 +1766,10 @@ impl Client {
                 ),
                 #[cfg(feature = "debug")]
                 UserEvent::OpenMapDataWindow => {
-                    self.interface
-                        .open_window(&self.application, &mut self.focus_state, self.map.to_prototype_window())
+                    if let Some(map) = self.map.as_ref() {
+                        self.interface
+                            .open_window(&self.application, &mut self.focus_state, map.to_prototype_window());
+                    }
                 }
                 #[cfg(feature = "debug")]
                 UserEvent::OpenMapsWindow => self.interface.open_window(&self.application, &mut self.focus_state, &MapsWindow),
@@ -1830,32 +1827,52 @@ impl Client {
         #[cfg(feature = "debug")]
         user_event_measurement.stop();
 
-        #[cfg(feature = "debug")]
-        let update_main_camera_measurement = Profiler::start_measurement("update main camera");
+        // Main map update and render loop
+        if let Some(map) = self.map.as_ref() {
+            #[cfg(feature = "debug")]
+            let update_main_camera_measurement = Profiler::start_measurement("update main camera");
 
-        let window_size = self.graphics_engine.get_window_size();
-        let screen_size: ScreenSize = window_size.into();
+            let window_size = self.graphics_engine.get_window_size();
+            let screen_size: ScreenSize = window_size.into();
 
-        if self.entities.is_empty() {
-            self.start_camera.update(delta_time);
-            self.start_camera.generate_view_projection(window_size);
-        } else {
-            self.player_camera.update(delta_time);
-            self.player_camera.generate_view_projection(window_size);
-        }
+            if self.entities.is_empty() {
+                self.start_camera.update(delta_time);
+                self.start_camera.generate_view_projection(window_size);
+            } else {
+                self.player_camera.update(delta_time);
+                self.player_camera.generate_view_projection(window_size);
+            }
 
-        #[cfg(feature = "debug")]
-        if self.render_settings.get().use_debug_camera {
-            self.debug_camera.generate_view_projection(window_size);
-        }
+            #[cfg(feature = "debug")]
+            if self.render_settings.get().use_debug_camera {
+                self.debug_camera.generate_view_projection(window_size);
+            }
 
-        #[cfg(feature = "debug")]
-        update_main_camera_measurement.stop();
+            #[cfg(feature = "debug")]
+            update_main_camera_measurement.stop();
 
-        #[cfg(feature = "debug")]
-        let update_entities_measurement = Profiler::start_measurement("update entities");
+            #[cfg(feature = "debug")]
+            let update_entities_measurement = Profiler::start_measurement("update entities");
 
-        {
+            {
+                let current_camera: &(dyn Camera + Send + Sync) = match self.entities.is_empty() {
+                    #[cfg(feature = "debug")]
+                    _ if self.render_settings.get().use_debug_camera => &self.debug_camera,
+                    true => &self.start_camera,
+                    false => &self.player_camera,
+                };
+
+                self.entities
+                    .iter_mut()
+                    .for_each(|entity| entity.update(&self.audio_engine, map, current_camera, client_tick));
+            }
+
+            if !self.entities.is_empty() {
+                let player_position = self.entities[0].get_position();
+                self.player_camera.set_smoothed_focus_point(player_position);
+                self.directional_shadow_camera.set_focus_point(self.player_camera.focus_point());
+            }
+
             let current_camera: &(dyn Camera + Send + Sync) = match self.entities.is_empty() {
                 #[cfg(feature = "debug")]
                 _ if self.render_settings.get().use_debug_camera => &self.debug_camera,
@@ -1863,465 +1880,450 @@ impl Client {
                 false => &self.player_camera,
             };
 
-            self.entities
-                .iter_mut()
-                .for_each(|entity| entity.update(&self.audio_engine, &self.map, current_camera, client_tick));
-        }
-
-        if !self.entities.is_empty() {
-            let player_position = self.entities[0].get_position();
-            self.player_camera.set_smoothed_focus_point(player_position);
-            self.directional_shadow_camera.set_focus_point(self.player_camera.focus_point());
-        }
-
-        let current_camera: &(dyn Camera + Send + Sync) = match self.entities.is_empty() {
-            #[cfg(feature = "debug")]
-            _ if self.render_settings.get().use_debug_camera => &self.debug_camera,
-            true => &self.start_camera,
-            false => &self.player_camera,
-        };
-
-        let (view_matrix, projection_matrix) = current_camera.view_projection_matrices();
-        let camera_position = current_camera.camera_position().to_homogeneous();
-
-        #[cfg(feature = "debug")]
-        update_entities_measurement.stop();
-
-        #[cfg(feature = "debug")]
-        let update_shadow_camera_measurement = Profiler::start_measurement("update directional shadow camera");
-
-        let lighting_mode = *self.lighting_mode.get();
-        let shadow_quality = *self.shadow_quality.get();
-        let ambient_light_color = self.map.get_ambient_light_color(lighting_mode, day_timer);
-        let (directional_light_direction, directional_light_color) = self.map.get_directional_light(lighting_mode, day_timer);
-
-        self.directional_shadow_camera
-            .update(directional_light_direction, current_camera.view_direction());
-        self.directional_shadow_camera.generate_view_projection(window_size);
-
-        let (directional_light_view_matrix, directional_light_projection_matrix) =
-            self.directional_shadow_camera.view_projection_matrices();
-        let directional_light_view_projection_matrix = directional_light_projection_matrix * directional_light_view_matrix;
-
-        #[cfg(feature = "debug")]
-        update_shadow_camera_measurement.stop();
-
-        #[cfg(feature = "debug")]
-        let frame_measurement = Profiler::start_measurement("update audio engine");
-
-        // We set the listener roughly at ear height.
-        const EAR_HEIGHT: Vector3<f32> = Vector3::new(0.0, 5.0, 0.0);
-        let listener = current_camera.focus_point() + EAR_HEIGHT;
-
-        self.audio_engine
-            .set_spatial_listener(listener, current_camera.view_direction(), current_camera.look_up_vector());
-        self.audio_engine.update();
-
-        #[cfg(feature = "debug")]
-        frame_measurement.stop();
-
-        #[cfg(feature = "debug")]
-        let prepare_frame_measurement = Profiler::start_measurement("prepare frame");
-
-        self.particle_holder.update(delta_time as f32);
-        self.effect_holder.update(&self.entities, delta_time as f32);
-
-        let (clear_interface, render_interface) = self
-            .interface
-            .update(&self.application, self.font_loader.clone(), &mut self.focus_state);
-        self.mouse_cursor.update(client_tick);
-
-        #[cfg(feature = "debug")]
-        let render_settings = &*self.render_settings.get();
-        let walk_indicator_color = self.application.get_game_theme().indicator.walking.get();
-
-        #[cfg(feature = "debug")]
-        let hovered_marker_identifier = match mouse_target {
-            Some(PickerTarget::Marker(marker_identifier)) => Some(marker_identifier),
-            _ => None,
-        };
-
-        #[cfg(feature = "debug")]
-        let point_light_manager_measurement = Profiler::start_measurement("point light manager");
-
-        let point_light_set = {
-            self.point_light_manager.prepare();
-
-            self.effect_holder
-                .register_point_lights(&mut self.point_light_manager, current_camera);
-
-            self.map
-                .register_point_lights(&mut self.point_light_manager, &mut self.point_light_set_buffer, current_camera);
-
-            match lighting_mode {
-                LightingMode::Classic => self.point_light_manager.create_point_light_set(0),
-                LightingMode::Enhanced => self.point_light_manager.create_point_light_set(NUMBER_OF_POINT_LIGHTS_WITH_SHADOWS),
-            }
-        };
-
-        #[cfg(feature = "debug")]
-        point_light_manager_measurement.stop();
-
-        #[cfg(feature = "debug")]
-        prepare_frame_measurement.stop();
-
-        #[cfg(feature = "debug")]
-        let collect_instructions_measurement = Profiler::start_measurement("collect instructions");
-
-        let picker_position = ScreenPosition {
-            left: mouse_position.left.clamp(0.0, window_size.x as f32),
-            top: mouse_position.top.clamp(0.0, window_size.y as f32),
-        };
-        let mut indicator_instruction = None;
-        let mut water_instruction = None;
-
-        // Marker
-        {
-            #[cfg(feature = "debug")]
-            self.map.render_markers(
-                &mut self.debug_marker_renderer,
-                current_camera,
-                render_settings,
-                &self.entities,
-                &point_light_set,
-                hovered_marker_identifier,
-            );
+            let (view_matrix, projection_matrix) = current_camera.view_projection_matrices();
+            let camera_position = current_camera.camera_position().to_homogeneous();
 
             #[cfg(feature = "debug")]
-            self.map.render_markers(
-                &mut self.middle_interface_renderer,
-                current_camera,
-                render_settings,
-                &self.entities,
-                &point_light_set,
-                hovered_marker_identifier,
-            );
-        }
-
-        // Directional Shadows
-        {
-            let object_set = self.map.cull_objects_with_frustum(
-                &self.directional_shadow_camera,
-                &mut self.directional_shadow_object_set_buffer,
-                #[cfg(feature = "debug")]
-                render_settings.frustum_culling,
-            );
-
-            let offset = self.directional_shadow_model_instructions.len();
-
-            #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_objects))]
-            self.map.render_objects(
-                &mut self.directional_shadow_model_instructions,
-                &object_set,
-                client_tick,
-                &self.directional_shadow_camera,
-            );
-
-            #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_map))]
-            self.map.render_ground(&mut self.directional_shadow_model_instructions);
-
-            let count = self.directional_shadow_model_instructions.len() - offset;
-
-            self.directional_shadow_model_batches.push(ModelBatch {
-                offset,
-                count,
-                texture: self.map.get_texture().clone(),
-                vertex_buffer: self.map.get_model_vertex_buffer().clone(),
-            });
+            update_entities_measurement.stop();
 
             #[cfg(feature = "debug")]
-            #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_map_tiles))]
-            self.map.render_overlay_tiles(
-                &mut self.directional_shadow_model_instructions,
-                &mut self.directional_shadow_model_batches,
-                &self.tile_texture,
-            );
+            let update_shadow_camera_measurement = Profiler::start_measurement("update directional shadow camera");
+
+            let lighting_mode = *self.lighting_mode.get();
+            let shadow_quality = *self.shadow_quality.get();
+            let ambient_light_color = map.get_ambient_light_color(lighting_mode, day_timer);
+            let (directional_light_direction, directional_light_color) = map.get_directional_light(lighting_mode, day_timer);
+
+            self.directional_shadow_camera
+                .update(directional_light_direction, current_camera.view_direction());
+            self.directional_shadow_camera.generate_view_projection(window_size);
+
+            let (directional_light_view_matrix, directional_light_projection_matrix) =
+                self.directional_shadow_camera.view_projection_matrices();
+            let directional_light_view_projection_matrix = directional_light_projection_matrix * directional_light_view_matrix;
 
             #[cfg(feature = "debug")]
-            #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_pathing))]
-            self.map.render_entity_pathing(
-                &mut self.directional_shadow_model_instructions,
-                &mut self.directional_shadow_model_batches,
-                &self.entities,
-                &self.pathing_texture,
-            );
-
-            #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_entities))]
-            self.map.render_entities(
-                &mut self.directional_shadow_entity_instructions,
-                &mut self.entities,
-                &self.directional_shadow_camera,
-            );
-        }
-
-        // Point Lights and Shadows
-        {
-            #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_point_lights))]
-            point_light_set.render_point_lights(&mut self.point_light_instructions);
-
-            #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_point_lights))]
-            point_light_set.render_point_lights_with_shadows(
-                &self.map,
-                &mut self.point_shadow_camera,
-                &mut self.point_shadow_object_set_buffer,
-                &mut self.point_shadow_model_instructions,
-                &mut self.point_light_with_shadow_instructions,
-                client_tick,
-                #[cfg(feature = "debug")]
-                render_settings,
-            );
-        }
-
-        // Geometry
-        {
-            let object_set = self.map.cull_objects_with_frustum(
-                current_camera,
-                &mut self.deferred_object_set_buffer,
-                #[cfg(feature = "debug")]
-                render_settings.frustum_culling,
-            );
-
-            let offset = self.model_instructions.len();
-
-            #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_objects))]
-            self.map
-                .render_objects(&mut self.model_instructions, &object_set, client_tick, current_camera);
-
-            #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_map))]
-            self.map.render_ground(&mut self.model_instructions);
-
-            let count = self.model_instructions.len() - offset;
-
-            self.model_batches.push(ModelBatch {
-                offset,
-                count,
-                texture: self.map.get_texture().clone(),
-                vertex_buffer: self.map.get_model_vertex_buffer().clone(),
-            });
+            update_shadow_camera_measurement.stop();
 
             #[cfg(feature = "debug")]
-            #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_map_tiles))]
-            self.map
-                .render_overlay_tiles(&mut self.model_instructions, &mut self.model_batches, &self.tile_texture);
+            let frame_measurement = Profiler::start_measurement("update audio engine");
+
+            // We set the listener roughly at ear height.
+            const EAR_HEIGHT: Vector3<f32> = Vector3::new(0.0, 5.0, 0.0);
+            let listener = current_camera.focus_point() + EAR_HEIGHT;
+
+            self.audio_engine
+                .set_spatial_listener(listener, current_camera.view_direction(), current_camera.look_up_vector());
+            self.audio_engine.update();
 
             #[cfg(feature = "debug")]
-            #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_pathing))]
-            self.map.render_entity_pathing(
-                &mut self.model_instructions,
-                &mut self.model_batches,
-                &self.entities,
-                &self.pathing_texture,
-            );
+            frame_measurement.stop();
 
-            let entity_camera = match true {
-                #[cfg(feature = "debug")]
-                _ if self.render_settings.get().show_entities_paper => &self.player_camera,
-                _ => current_camera,
+            #[cfg(feature = "debug")]
+            let prepare_frame_measurement = Profiler::start_measurement("prepare frame");
+
+            self.particle_holder.update(delta_time as f32);
+            self.effect_holder.update(&self.entities, delta_time as f32);
+
+            let (clear_interface, render_interface) =
+                self.interface
+                    .update(&self.application, self.font_loader.clone(), &mut self.focus_state);
+            self.mouse_cursor.update(client_tick);
+
+            #[cfg(feature = "debug")]
+            let render_settings = &*self.render_settings.get();
+            let walk_indicator_color = self.application.get_game_theme().indicator.walking.get();
+
+            #[cfg(feature = "debug")]
+            let hovered_marker_identifier = match mouse_target {
+                Some(PickerTarget::Marker(marker_identifier)) => Some(marker_identifier),
+                _ => None,
             };
 
-            #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_entities))]
-            self.map
-                .render_entities(&mut self.entity_instructions, &mut self.entities, entity_camera);
+            #[cfg(feature = "debug")]
+            let point_light_manager_measurement = Profiler::start_measurement("point light manager");
+
+            let point_light_set = {
+                self.point_light_manager.prepare();
+
+                self.effect_holder
+                    .register_point_lights(&mut self.point_light_manager, current_camera);
+
+                map.register_point_lights(&mut self.point_light_manager, &mut self.point_light_set_buffer, current_camera);
+
+                match lighting_mode {
+                    LightingMode::Classic => self.point_light_manager.create_point_light_set(0),
+                    LightingMode::Enhanced => self.point_light_manager.create_point_light_set(NUMBER_OF_POINT_LIGHTS_WITH_SHADOWS),
+                }
+            };
 
             #[cfg(feature = "debug")]
-            if render_settings.show_entities_debug {
-                self.map
-                    .render_entities_debug(&mut self.rectangle_instructions, &self.entities, entity_camera);
+            point_light_manager_measurement.stop();
+
+            #[cfg(feature = "debug")]
+            prepare_frame_measurement.stop();
+
+            #[cfg(feature = "debug")]
+            let collect_instructions_measurement = Profiler::start_measurement("collect instructions");
+
+            let picker_position = ScreenPosition {
+                left: mouse_position.left.clamp(0.0, window_size.x as f32),
+                top: mouse_position.top.clamp(0.0, window_size.y as f32),
+            };
+            let mut indicator_instruction = None;
+            let mut water_instruction = None;
+
+            // Marker
+            {
+                #[cfg(feature = "debug")]
+                map.render_markers(
+                    &mut self.debug_marker_renderer,
+                    current_camera,
+                    render_settings,
+                    &self.entities,
+                    &point_light_set,
+                    hovered_marker_identifier,
+                );
+
+                #[cfg(feature = "debug")]
+                map.render_markers(
+                    &mut self.middle_interface_renderer,
+                    current_camera,
+                    render_settings,
+                    &self.entities,
+                    &point_light_set,
+                    hovered_marker_identifier,
+                );
             }
 
-            #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_water))]
-            self.map.render_water(&mut water_instruction, client_tick);
-
-            #[cfg(feature = "debug")]
-            if render_settings.show_bounding_boxes {
-                let object_set = self.map.cull_objects_with_frustum(
-                    &self.player_camera,
-                    &mut self.bounding_box_object_set_buffer,
+            // Directional Shadows
+            {
+                let object_set = map.cull_objects_with_frustum(
+                    &self.directional_shadow_camera,
+                    &mut self.directional_shadow_object_set_buffer,
                     #[cfg(feature = "debug")]
                     render_settings.frustum_culling,
                 );
 
-                self.map
-                    .render_bounding(&mut self.aabb_instructions, render_settings.frustum_culling, &object_set);
-            }
-        }
+                let offset = self.directional_shadow_model_instructions.len();
 
-        //  Sprites and Interface
-        {
-            #[cfg(feature = "debug")]
-            if let Some(marker_identifier) = hovered_marker_identifier {
-                self.map.render_marker_overlay(
-                    &mut self.aabb_instructions,
-                    &mut self.circle_instructions,
-                    current_camera,
-                    marker_identifier,
-                    &point_light_set,
-                    animation_timer,
+                #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_objects))]
+                map.render_objects(
+                    &mut self.directional_shadow_model_instructions,
+                    &object_set,
+                    client_tick,
+                    &self.directional_shadow_camera,
+                );
+
+                #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_map))]
+                map.render_ground(&mut self.directional_shadow_model_instructions);
+
+                let count = self.directional_shadow_model_instructions.len() - offset;
+
+                self.directional_shadow_model_batches.push(ModelBatch {
+                    offset,
+                    count,
+                    texture: map.get_texture().clone(),
+                    vertex_buffer: map.get_model_vertex_buffer().clone(),
+                });
+
+                #[cfg(feature = "debug")]
+                #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_map_tiles))]
+                map.render_overlay_tiles(
+                    &mut self.directional_shadow_model_instructions,
+                    &mut self.directional_shadow_model_batches,
+                    &self.tile_texture,
+                );
+
+                #[cfg(feature = "debug")]
+                #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_pathing))]
+                map.render_entity_pathing(
+                    &mut self.directional_shadow_model_instructions,
+                    &mut self.directional_shadow_model_batches,
+                    &self.entities,
+                    &self.pathing_texture,
+                );
+
+                #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_entities))]
+                map.render_entities(
+                    &mut self.directional_shadow_entity_instructions,
+                    &mut self.entities,
+                    &self.directional_shadow_camera,
                 );
             }
 
-            self.particle_holder.render(
-                &self.bottom_interface_renderer,
-                current_camera,
-                screen_size,
-                scaling,
-                &self.entities,
-            );
-
-            self.effect_holder.render(&mut self.effect_renderer, current_camera);
-
-            if let Some(PickerTarget::Tile { x, y }) = mouse_target
-                && !&self.entities.is_empty()
+            // Point Lights and Shadows
             {
-                #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_indicators))]
-                self.map.render_walk_indicator(
-                    &mut indicator_instruction,
-                    walk_indicator_color,
-                    Vector2::new(x as usize, y as usize),
-                );
-            } else if let Some(PickerTarget::Entity(entity_id)) = mouse_target {
-                let entity = &self.entities.iter().find(|entity| entity.get_entity_id() == entity_id);
+                #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_point_lights))]
+                point_light_set.render_point_lights(&mut self.point_light_instructions);
 
-                if let Some(entity) = entity {
-                    entity.render_status(
+                #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_point_lights))]
+                point_light_set.render_point_lights_with_shadows(
+                    map,
+                    &mut self.point_shadow_camera,
+                    &mut self.point_shadow_object_set_buffer,
+                    &mut self.point_shadow_model_instructions,
+                    &mut self.point_light_with_shadow_instructions,
+                    client_tick,
+                    #[cfg(feature = "debug")]
+                    render_settings,
+                );
+            }
+
+            // Geometry
+            {
+                let object_set = map.cull_objects_with_frustum(
+                    current_camera,
+                    &mut self.deferred_object_set_buffer,
+                    #[cfg(feature = "debug")]
+                    render_settings.frustum_culling,
+                );
+
+                let offset = self.model_instructions.len();
+
+                #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_objects))]
+                map.render_objects(&mut self.model_instructions, &object_set, client_tick, current_camera);
+
+                #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_map))]
+                map.render_ground(&mut self.model_instructions);
+
+                let count = self.model_instructions.len() - offset;
+
+                self.model_batches.push(ModelBatch {
+                    offset,
+                    count,
+                    texture: map.get_texture().clone(),
+                    vertex_buffer: map.get_model_vertex_buffer().clone(),
+                });
+
+                #[cfg(feature = "debug")]
+                #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_map_tiles))]
+                map.render_overlay_tiles(&mut self.model_instructions, &mut self.model_batches, &self.tile_texture);
+
+                #[cfg(feature = "debug")]
+                #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_pathing))]
+                map.render_entity_pathing(
+                    &mut self.model_instructions,
+                    &mut self.model_batches,
+                    &self.entities,
+                    &self.pathing_texture,
+                );
+
+                let entity_camera = match true {
+                    #[cfg(feature = "debug")]
+                    _ if self.render_settings.get().show_entities_paper => &self.player_camera,
+                    _ => current_camera,
+                };
+
+                #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_entities))]
+                map.render_entities(&mut self.entity_instructions, &mut self.entities, entity_camera);
+
+                #[cfg(feature = "debug")]
+                if render_settings.show_entities_debug {
+                    map.render_entities_debug(&mut self.rectangle_instructions, &self.entities, entity_camera);
+                }
+
+                #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_water))]
+                map.render_water(&mut water_instruction, client_tick);
+
+                #[cfg(feature = "debug")]
+                if render_settings.show_bounding_boxes {
+                    let object_set = map.cull_objects_with_frustum(
+                        &self.player_camera,
+                        &mut self.bounding_box_object_set_buffer,
+                        #[cfg(feature = "debug")]
+                        render_settings.frustum_culling,
+                    );
+
+                    map.render_bounding(&mut self.aabb_instructions, render_settings.frustum_culling, &object_set);
+                }
+            }
+
+            //  Sprites and Interface
+            {
+                #[cfg(feature = "debug")]
+                if let Some(marker_identifier) = hovered_marker_identifier {
+                    map.render_marker_overlay(
+                        &mut self.aabb_instructions,
+                        &mut self.circle_instructions,
+                        current_camera,
+                        marker_identifier,
+                        &point_light_set,
+                        animation_timer,
+                    );
+                }
+
+                self.particle_holder.render(
+                    &self.bottom_interface_renderer,
+                    current_camera,
+                    screen_size,
+                    scaling,
+                    &self.entities,
+                );
+
+                self.effect_holder.render(&mut self.effect_renderer, current_camera);
+
+                if let Some(PickerTarget::Tile { x, y }) = mouse_target
+                    && !&self.entities.is_empty()
+                {
+                    #[cfg_attr(feature = "debug", korangar_debug::debug_condition(render_settings.show_indicators))]
+                    map.render_walk_indicator(
+                        &mut indicator_instruction,
+                        walk_indicator_color,
+                        Vector2::new(x as usize, y as usize),
+                    );
+                } else if let Some(PickerTarget::Entity(entity_id)) = mouse_target {
+                    let entity = &self.entities.iter().find(|entity| entity.get_entity_id() == entity_id);
+
+                    if let Some(entity) = entity {
+                        entity.render_status(
+                            &self.middle_interface_renderer,
+                            current_camera,
+                            self.application.get_game_theme(),
+                            screen_size,
+                        );
+
+                        if let Some(name) = &entity.get_details() {
+                            let name = name.split('#').next().unwrap();
+
+                            let offset = ScreenPosition { left: 15.0, top: 15.0 }.scaled(scaling);
+
+                            self.middle_interface_renderer.render_text(
+                                name,
+                                mouse_position + offset,
+                                Color::WHITE,
+                                FontSize::new(16.0),
+                                AlignHorizontal::Mid,
+                            );
+                        }
+                    }
+                }
+
+                if !&self.entities.is_empty() {
+                    #[cfg(feature = "debug")]
+                    profile_block!("render player status");
+
+                    self.entities[0].render_status(
                         &self.middle_interface_renderer,
                         current_camera,
                         self.application.get_game_theme(),
                         screen_size,
                     );
+                }
 
-                    if let Some(name) = &entity.get_details() {
-                        let name = name.split('#').next().unwrap();
+                if render_interface {
+                    #[cfg(feature = "debug")]
+                    profile_block!("render user interface");
 
-                        let offset = ScreenPosition { left: 15.0, top: 15.0 }.scaled(scaling);
+                    self.interface.render(
+                        &self.interface_renderer,
+                        &self.application,
+                        hovered_element,
+                        focused_element,
+                        self.input_system.get_mouse_mode(),
+                    );
+                }
 
-                        self.middle_interface_renderer.render_text(
-                            name,
-                            mouse_position + offset,
-                            Color::WHITE,
-                            FontSize::new(16.0),
-                            AlignHorizontal::Mid,
-                        );
-                    }
+                #[cfg(feature = "debug")]
+                if render_settings.show_frames_per_second {
+                    let game_theme = self.application.get_game_theme();
+
+                    self.top_interface_renderer.render_text(
+                        &self.game_timer.last_frames_per_second().to_string(),
+                        game_theme.overlay.text_offset.get(),
+                        game_theme.overlay.foreground_color.get(),
+                        game_theme.overlay.font_size.get(),
+                        AlignHorizontal::Left,
+                    );
+                }
+
+                if self.show_interface {
+                    self.mouse_cursor.render(
+                        &self.top_interface_renderer,
+                        mouse_position,
+                        self.input_system.get_mouse_mode().grabbed(),
+                        self.application.get_game_theme().cursor.color.get(),
+                        &self.application,
+                    );
                 }
             }
 
-            if !&self.entities.is_empty() {
-                #[cfg(feature = "debug")]
-                profile_block!("render player status");
-
-                self.entities[0].render_status(
-                    &self.middle_interface_renderer,
-                    current_camera,
-                    self.application.get_game_theme(),
-                    screen_size,
-                );
-            }
-
-            if render_interface {
-                #[cfg(feature = "debug")]
-                profile_block!("render user interface");
-
-                self.interface.render(
-                    &self.interface_renderer,
-                    &self.application,
-                    hovered_element,
-                    focused_element,
-                    self.input_system.get_mouse_mode(),
-                );
-            }
+            #[cfg(feature = "debug")]
+            collect_instructions_measurement.stop();
 
             #[cfg(feature = "debug")]
-            if render_settings.show_frames_per_second {
-                let game_theme = self.application.get_game_theme();
+            let render_frame_measurement = Profiler::start_measurement("render next frame");
 
-                self.top_interface_renderer.render_text(
-                    &self.game_timer.last_frames_per_second().to_string(),
-                    game_theme.overlay.text_offset.get(),
-                    game_theme.overlay.foreground_color.get(),
-                    game_theme.overlay.font_size.get(),
-                    AlignHorizontal::Left,
-                );
-            }
+            let interface_instructions = self.interface_renderer.get_instructions();
+            let bottom_layer_instructions = self.bottom_interface_renderer.get_instructions();
+            let middle_layer_instructions = self.middle_interface_renderer.get_instructions();
+            let top_layer_instructions = self.top_interface_renderer.get_instructions();
+            let font_loader = self.font_loader.borrow();
 
-            if self.show_interface {
-                self.mouse_cursor.render(
-                    &self.top_interface_renderer,
-                    mouse_position,
-                    self.input_system.get_mouse_mode().grabbed(),
-                    self.application.get_game_theme().cursor.color.get(),
-                    &self.application,
-                );
-            }
+            let render_instruction = RenderInstruction {
+                clear_interface,
+                show_interface: self.show_interface,
+                picker_position,
+                uniforms: Uniforms {
+                    view_matrix,
+                    projection_matrix,
+                    camera_position,
+                    animation_timer,
+                    day_timer,
+                    ambient_light_color,
+                    enhanced_lighting: lighting_mode == LightingMode::Enhanced,
+                    shadow_quality,
+                },
+                indicator: indicator_instruction,
+                interface: interface_instructions.as_slice(),
+                bottom_layer_rectangles: bottom_layer_instructions.as_slice(),
+                middle_layer_rectangles: middle_layer_instructions.as_slice(),
+                top_layer_rectangles: top_layer_instructions.as_slice(),
+                directional_light_with_shadow: DirectionalShadowCasterInstruction {
+                    view_projection_matrix: directional_light_view_projection_matrix,
+                    view_matrix: directional_light_view_matrix,
+                    direction: directional_light_direction,
+                    color: directional_light_color,
+                },
+                point_light_shadow_caster: &self.point_light_with_shadow_instructions,
+                point_light: &self.point_light_instructions,
+                model_batches: &self.model_batches,
+                models: &mut self.model_instructions,
+                entities: &mut self.entity_instructions,
+                directional_model_batches: &self.directional_shadow_model_batches,
+                directional_shadow_models: &self.directional_shadow_model_instructions,
+                directional_shadow_entities: &self.directional_shadow_entity_instructions,
+                point_shadow_models: &self.point_shadow_model_instructions,
+                point_shadow_entities: &self.point_shadow_entity_instructions,
+                effects: self.effect_renderer.get_instructions(),
+                water: water_instruction,
+                map_picker_tile_vertex_buffer: Some(map.get_tile_picker_vertex_buffer()),
+                font_map_texture: Some(font_loader.get_font_map()),
+                #[cfg(feature = "debug")]
+                render_settings: *self.render_settings.get(),
+                #[cfg(feature = "debug")]
+                aabb: &self.aabb_instructions,
+                #[cfg(feature = "debug")]
+                circles: &self.circle_instructions,
+                #[cfg(feature = "debug")]
+                rectangles: &self.rectangle_instructions,
+                #[cfg(feature = "debug")]
+                marker: self.debug_marker_renderer.get_instructions(),
+            };
+
+            self.graphics_engine.render_next_frame(frame, render_instruction);
+
+            #[cfg(feature = "debug")]
+            render_frame_measurement.stop();
+        } else {
+            #[cfg(feature = "debug")]
+            let render_frame_measurement = Profiler::start_measurement("render next frame");
+
+            self.graphics_engine.render_next_frame(frame, RenderInstruction::default());
+
+            #[cfg(feature = "debug")]
+            render_frame_measurement.stop();
         }
-
-        #[cfg(feature = "debug")]
-        collect_instructions_measurement.stop();
-
-        #[cfg(feature = "debug")]
-        let render_frame_measurement = Profiler::start_measurement("render next frame");
-
-        let interface_instructions = self.interface_renderer.get_instructions();
-        let bottom_layer_instructions = self.bottom_interface_renderer.get_instructions();
-        let middle_layer_instructions = self.middle_interface_renderer.get_instructions();
-        let top_layer_instructions = self.top_interface_renderer.get_instructions();
-        let font_loader = self.font_loader.borrow();
-
-        let render_instruction = RenderInstruction {
-            clear_interface,
-            show_interface: self.show_interface,
-            picker_position,
-            uniforms: Uniforms {
-                view_matrix,
-                projection_matrix,
-                camera_position,
-                animation_timer,
-                day_timer,
-                ambient_light_color,
-                enhanced_lighting: lighting_mode == LightingMode::Enhanced,
-                shadow_quality,
-            },
-            indicator: indicator_instruction,
-            interface: interface_instructions.as_slice(),
-            bottom_layer_rectangles: bottom_layer_instructions.as_slice(),
-            middle_layer_rectangles: middle_layer_instructions.as_slice(),
-            top_layer_rectangles: top_layer_instructions.as_slice(),
-            directional_light_with_shadow: DirectionalShadowCasterInstruction {
-                view_projection_matrix: directional_light_view_projection_matrix,
-                view_matrix: directional_light_view_matrix,
-                direction: directional_light_direction,
-                color: directional_light_color,
-            },
-            point_light_shadow_caster: &self.point_light_with_shadow_instructions,
-            point_light: &self.point_light_instructions,
-            model_batches: &self.model_batches,
-            models: &mut self.model_instructions,
-            entities: &mut self.entity_instructions,
-            directional_model_batches: &self.directional_shadow_model_batches,
-            directional_shadow_models: &self.directional_shadow_model_instructions,
-            directional_shadow_entities: &self.directional_shadow_entity_instructions,
-            point_shadow_models: &self.point_shadow_model_instructions,
-            point_shadow_entities: &self.point_shadow_entity_instructions,
-            effects: self.effect_renderer.get_instructions(),
-            water: water_instruction,
-            map_picker_tile_vertex_buffer: self.map.get_tile_picker_vertex_buffer(),
-            font_map_texture: font_loader.get_font_map(),
-            #[cfg(feature = "debug")]
-            render_settings: *self.render_settings.get(),
-            #[cfg(feature = "debug")]
-            aabb: &self.aabb_instructions,
-            #[cfg(feature = "debug")]
-            circles: &self.circle_instructions,
-            #[cfg(feature = "debug")]
-            rectangles: &self.rectangle_instructions,
-            #[cfg(feature = "debug")]
-            marker: self.debug_marker_renderer.get_instructions(),
-        };
-
-        self.graphics_engine.render_next_frame(frame, render_instruction);
-
-        #[cfg(feature = "debug")]
-        render_frame_measurement.stop();
     }
 
     #[cfg_attr(feature = "debug", korangar_debug::profile)]

--- a/korangar/src/world/action/mod.rs
+++ b/korangar/src/world/action/mod.rs
@@ -5,7 +5,9 @@ use derive_new::new;
 use korangar_audio::SoundEffectKey;
 use korangar_interface::elements::{ElementCell, PrototypeElement};
 use korangar_util::container::Cacheable;
-use ragnarok_formats::action::{Action, ActionsData};
+use ragnarok_formats::action::Action;
+#[cfg(feature = "debug")]
+use ragnarok_formats::action::ActionsData;
 use ragnarok_packets::ClientTick;
 
 use crate::graphics::Color;

--- a/korangar_networking/src/event.rs
+++ b/korangar_networking/src/event.rs
@@ -37,7 +37,6 @@ pub enum NetworkEvent {
     },
     CharacterSelected {
         login_data: CharacterServerLoginData,
-        map_name: String,
     },
     CharacterSelectionFailed {
         reason: UnifiedCharacterSelectionFailedReason,
@@ -126,7 +125,6 @@ pub enum NetworkEvent {
         account_id: AccountId,
         hair_id: u32,
     },
-    SetPlayerPosition(WorldPosition),
     LoggedOut,
     FriendRequest {
         requestee: Friend,
@@ -195,12 +193,6 @@ impl From<Option<NetworkEvent>> for NetworkEventList {
             Some(event) => Self(vec![event]),
             None => Self(Vec::new()),
         }
-    }
-}
-
-impl From<(NetworkEvent, NetworkEvent)> for NetworkEventList {
-    fn from(events: (NetworkEvent, NetworkEvent)) -> Self {
-        Self(vec![events.0, events.1])
     }
 }
 

--- a/korangar_networking/src/lib.rs
+++ b/korangar_networking/src/lib.rs
@@ -560,9 +560,8 @@ where
                 server_port: packet.map_server_port,
                 character_id: packet.character_id,
             };
-            let map_name = packet.map_name.strip_suffix(".gat").unwrap().to_owned();
 
-            NetworkEvent::CharacterSelected { login_data, map_name }
+            NetworkEvent::CharacterSelected { login_data }
         })?;
         packet_handler.register(|packet: CharacterSelectionFailedPacket| {
             let (reason, message) = match packet.reason {
@@ -998,12 +997,7 @@ where
         })?;
         packet_handler.register_noop::<Packet8302>()?;
         packet_handler.register_noop::<Packet0b18>()?;
-        packet_handler.register(|packet: MapServerLoginSuccessPacket| {
-            (
-                NetworkEvent::UpdateClientTick(packet.client_tick),
-                NetworkEvent::SetPlayerPosition(packet.position),
-            )
-        })?;
+        packet_handler.register(|packet: MapServerLoginSuccessPacket| NetworkEvent::UpdateClientTick(packet.client_tick))?;
         packet_handler.register(|packet: RestartResponsePacket| match packet.result {
             RestartResponseStatus::Ok => NetworkEvent::LoggedOut,
             RestartResponseStatus::Nothing => NetworkEvent::ChatMessage {

--- a/ragnarok_packets/src/handler.rs
+++ b/ragnarok_packets/src/handler.rs
@@ -60,7 +60,7 @@ impl PacketCallback for NoPacketCallback {}
 
 pub type HandlerFunction<Output, Meta> = Box<dyn Fn(&mut ByteReader<Meta>) -> ConversionResult<Output>>;
 
-/// A struct to help with reading packets from from a [`ByteReader`] and
+/// A struct to help with reading packets from a [`ByteReader`] and
 /// converting them to some common event type.
 ///
 /// It allows passing a packet callback to monitor incoming packets.


### PR DESCRIPTION
On first login the map server will send a command to change the map regardless, so we don't need to handle the map loading in the network event when we disconnect from the character server. We only initialize the player entity and interface in this case. We also now properly turn the screen black until we fully finished loading the map. Later we should also do the loading asynchronously on map change and turn the screen black while loading.