### PR TITLE
Properly handle and smooth client ticks

### DIFF
--- a/korangar/src/main.rs
+++ b/korangar/src/main.rs
@@ -931,6 +931,9 @@ impl Client {
                     let saved_login_data = self.saved_login_data.as_ref().unwrap();
                     self.networking_system.disconnect_from_character_server();
                     self.networking_system.connect_to_map_server(saved_login_data, login_data);
+                    // Ask for the client tick right away, so that the player isn't de-synced when
+                    // they spawn on the map.
+                    let _ = self.networking_system.request_client_tick();
 
                     let character_information = self
                         .saved_characters

--- a/korangar/src/system/timer.rs
+++ b/korangar/src/system/timer.rs
@@ -1,4 +1,3 @@
-use std::collections::VecDeque;
 use std::time::Instant;
 
 use chrono::prelude::*;
@@ -12,25 +11,13 @@ pub struct GameTimer {
     frames_per_second: usize,
     animation_timer: f32,
     day_timer: f32,
-    last_client_tick: Instant,
+    last_packet_receive_time: Instant,
     first_tick_received: bool,
-    base_client_tick: u32,
+    base_client_tick: f64,
     frequency: f64,
-    last_update: Instant,
-    last_error: f64,
-    integral_error: f64,
-    error_history: VecDeque<(Instant, f64)>,
 }
 
 const TIME_FACTOR: f32 = 1000.0;
-// PID constants
-const KP: f64 = 0.0005;
-const KI: f64 = 0.00005;
-const KD: f64 = 0.00005;
-// Gaussian filter constants
-const GAUSSIAN_SIGMA: f64 = 4.0;
-const GAUSSIAN_DENOMINATOR: f64 = 2.0 * GAUSSIAN_SIGMA * GAUSSIAN_SIGMA;
-const GAUSSIAN_WINDOW_SIZE: usize = 15;
 
 impl GameTimer {
     pub fn new() -> Self {
@@ -45,87 +32,53 @@ impl GameTimer {
             frames_per_second: Default::default(),
             animation_timer: Default::default(),
             day_timer,
-            last_client_tick: Instant::now(),
+            last_packet_receive_time: Instant::now(),
             first_tick_received: false,
-            base_client_tick: 0,
+            base_client_tick: 0.0,
             frequency: 0.0,
-            last_update: Instant::now(),
-            last_error: 0.0,
-            integral_error: 0.0,
-            error_history: VecDeque::with_capacity(GAUSSIAN_WINDOW_SIZE),
         }
     }
 
-    fn gaussian_filter(&self, packet_time: Instant) -> f64 {
-        if self.error_history.is_empty() {
-            return 0.0;
-        }
-
-        let mut weighted_sum = 0.0;
-        let mut weight_sum = 0.0;
-
-        for (time, error) in &self.error_history {
-            let dt = packet_time.duration_since(*time).as_secs_f64();
-            let weight = (-dt.powi(2) / GAUSSIAN_DENOMINATOR).exp();
-
-            weighted_sum += error * weight;
-            weight_sum += weight;
-        }
-
-        if weight_sum > 0.0 {
-            weighted_sum / weight_sum
-        } else {
-            0.0
-        }
-    }
-
-    /// Uses a simple PID regulator that uses a gaussian filter to be a bit more
-    /// resistant against network jitter to synchronize the client side tick and
-    /// the server tick.
-    pub fn set_client_tick(&mut self, server_tick: ClientTick, packet_receive_time: Instant) {
+    /// The networking system sends a request for the newest global tick rate
+    /// every 10 seconds and returns an update event that contains the estimated
+    /// server tick rate. We only need to gently adjust our frequency, so that
+    /// no discontinuation of the local client tick occur.
+    pub fn set_client_tick(&mut self, client_tick: ClientTick, packet_receive_time: Instant) {
         if !self.first_tick_received {
+            // We currently trust the first client tick too much. If, because of an
+            // asymmetry of the round trip time, the client tick deviates too much from the
+            // real server tick, then the client needs to catch-up the real value. Since we
+            // limit the client tick change to +/- 5 milliseconds each 10 seconds, such a
+            // catch-up could take quite some time. Such cases are rare though, so I'm not
+            // yet sure how to best counter such cases.
             self.first_tick_received = true;
-            self.base_client_tick = server_tick.0;
-            self.last_client_tick = packet_receive_time;
-            self.last_update = packet_receive_time;
-            self.last_error = 0.0;
-            self.integral_error = 0.0;
+            self.base_client_tick = client_tick.0 as f64;
+            self.last_packet_receive_time = packet_receive_time;
             return;
         }
 
-        let elapsed = packet_receive_time.duration_since(self.last_client_tick).as_secs_f64();
-        let adjustment = self.frequency * elapsed;
-        let tick_at_receive = self.base_client_tick as f64 + (elapsed * 1000.0) + adjustment;
+        let local_tick = self.get_client_tick_at(packet_receive_time);
+        let tick_difference = client_tick.0 as f64 - local_tick;
 
-        let error = server_tick.0 as f64 - tick_at_receive;
+        // Calculate frequency needed to make up the difference over the next 10
+        // seconds. We also clamp the difference, so that we are more resistant to
+        // cases, where the round trip time was highly asymmetric.
+        self.frequency = tick_difference.clamp(-5.0, 5.0) / 10000.0;
 
-        self.error_history.push_back((packet_receive_time, error));
-        while self.error_history.len() > GAUSSIAN_WINDOW_SIZE {
-            self.error_history.pop_front();
-        }
+        self.base_client_tick = local_tick;
+        self.last_packet_receive_time = packet_receive_time;
+    }
 
-        let filtered_error = self.gaussian_filter(packet_receive_time);
-
-        let dt = packet_receive_time.duration_since(self.last_update).as_secs_f64();
-
-        self.integral_error = (self.integral_error + filtered_error * dt).clamp(-10.0, 10.0);
-
-        let derivative = (filtered_error - self.last_error) / dt;
-
-        self.frequency = (KP * filtered_error + KI * self.integral_error + KD * derivative).clamp(-0.1, 0.1);
-
-        self.last_error = filtered_error;
-        self.base_client_tick = server_tick.0;
-        self.last_client_tick = packet_receive_time;
-        self.last_update = packet_receive_time;
+    #[cfg_attr(feature = "debug", korangar_debug::profile)]
+    pub fn get_client_tick_at(&self, time: Instant) -> f64 {
+        let elapsed = time.duration_since(self.last_packet_receive_time).as_secs_f64();
+        self.base_client_tick + (elapsed * 1000.0) + (elapsed * self.frequency * 1000.0)
     }
 
     #[cfg_attr(feature = "debug", korangar_debug::profile)]
     pub fn get_client_tick(&self) -> ClientTick {
-        let elapsed = self.last_client_tick.elapsed().as_secs_f64();
-        let adjustment = self.frequency * elapsed;
-        let tick = self.base_client_tick as f64 + (elapsed * 1000.0) + adjustment;
-        ClientTick(tick as u32)
+        let tick = self.get_client_tick_at(Instant::now());
+        ClientTick(tick.round() as u32)
     }
 
     #[cfg(feature = "debug")]


### PR DESCRIPTION
After long experimentation, I finally came to the conclusion that the client needs to properly estimate the client tick based on the round trip time. We then need to gently adjust the local tick rate so that no discolorations occur. We use the Cristian's algorithm for the synchronization itself.