### PR TITLE
Make loader Send and Sync

### DIFF
--- a/korangar/Cargo.toml
+++ b/korangar/Cargo.toml
@@ -21,7 +21,7 @@ korangar_interface = { workspace = true, features = ["serde", "cgmath"] }
 korangar_networking = { workspace = true, features = ["debug"] }
 korangar_util = { workspace = true, features = ["interface"] }
 lunify = { workspace = true }
-mlua = { workspace = true, features = ["lua51", "vendored"] }
+mlua = { workspace = true, features = ["lua51", "send", "vendored"] }
 num = { workspace = true }
 option-ext = { workspace = true }
 pollster = { workspace = true }

--- a/korangar/src/interface/cursor/mod.rs
+++ b/korangar/src/interface/cursor/mod.rs
@@ -45,7 +45,7 @@ pub struct MouseCursor {
 }
 
 impl MouseCursor {
-    pub fn new(sprite_loader: &mut SpriteLoader, action_loader: &mut ActionLoader) -> Self {
+    pub fn new(sprite_loader: &SpriteLoader, action_loader: &ActionLoader) -> Self {
         let sprite = sprite_loader.get("cursors.spr").unwrap();
         let actions = action_loader.get("cursors.act").unwrap();
         let animation_state = SpriteAnimationState::new(ClientTick(0));

--- a/korangar/src/inventory/skills.rs
+++ b/korangar/src/inventory/skills.rs
@@ -25,8 +25,8 @@ pub struct SkillTree {
 impl SkillTree {
     pub fn fill(
         &mut self,
-        sprite_loader: &mut SpriteLoader,
-        action_loader: &mut ActionLoader,
+        sprite_loader: &SpriteLoader,
+        action_loader: &ActionLoader,
         skill_data: Vec<SkillInformation>,
         client_tick: ClientTick,
     ) {

--- a/korangar/src/loaders/map/mod.rs
+++ b/korangar/src/loaders/map/mod.rs
@@ -56,9 +56,9 @@ pub struct MapLoader {
 
 impl MapLoader {
     pub fn load(
-        &mut self,
+        &self,
         resource_file: String,
-        model_loader: &mut ModelLoader,
+        model_loader: &ModelLoader,
         texture_loader: Arc<TextureLoader>,
         #[cfg(feature = "debug")] tile_texture_mapping: &[AtlasAllocation],
     ) -> Result<Map, LoadError> {
@@ -236,7 +236,7 @@ impl MapLoader {
     }
 
     fn generate_vertex_buffer_and_atlas_texture(
-        &mut self,
+        &self,
         resource_file: &str,
         mut texture_atlas_factory: TextureAtlasFactory,
         mut deferred_vertex_generation: Vec<DeferredVertexGeneration>,

--- a/korangar/src/loaders/model/mod.rs
+++ b/korangar/src/loaders/model/mod.rs
@@ -350,7 +350,7 @@ impl ModelLoader {
     }
 
     pub fn load(
-        &mut self,
+        &self,
         texture_atlas_factory: &mut TextureAtlasFactory,
         vertex_offset: &mut usize,
         model_file: &str,

--- a/korangar/src/loaders/texture/mod.rs
+++ b/korangar/src/loaders/texture/mod.rs
@@ -346,8 +346,8 @@ impl TextureLoader {
     }
 
     pub fn get(&self, path: &str, image_type: ImageType) -> Result<Arc<Texture>, LoadError> {
-        let mut lock = self.cache.lock();
-        match lock.as_mut().unwrap().get(&(path.into(), image_type)) {
+        let mut lock = self.cache.lock().unwrap();
+        match lock.get(&(path.into(), image_type)) {
             Some(texture) => Ok(texture.clone()),
             None => {
                 // We need to drop to avoid a deadlock here.

--- a/korangar/src/world/entity/mod.rs
+++ b/korangar/src/world/entity/mod.rs
@@ -343,9 +343,9 @@ fn get_entity_part_files(
 
 impl Common {
     pub fn new(
-        sprite_loader: &mut SpriteLoader,
-        action_loader: &mut ActionLoader,
-        animation_loader: &mut AnimationLoader,
+        sprite_loader: &SpriteLoader,
+        action_loader: &ActionLoader,
+        animation_loader: &AnimationLoader,
         script_loader: &ScriptLoader,
         entity_data: &EntityData,
         grid_position: Vector2<usize>,
@@ -395,10 +395,10 @@ impl Common {
 
     pub fn reload_sprite(
         &mut self,
-        sprite_loader: &mut SpriteLoader,
-        action_loader: &mut ActionLoader,
+        sprite_loader: &SpriteLoader,
+        action_loader: &ActionLoader,
         script_loader: &ScriptLoader,
-        animation_loader: &mut AnimationLoader,
+        animation_loader: &AnimationLoader,
     ) {
         let entity_part_files = get_entity_part_files(script_loader, self.entity_type, self.job_id, self.sex, None);
         self.animation_data = animation_loader
@@ -792,9 +792,9 @@ impl Player {
     /// "void". When a new map is loaded on map change, the server sends
     /// the correct position we need to position the player to.
     pub fn new(
-        sprite_loader: &mut SpriteLoader,
-        action_loader: &mut ActionLoader,
-        animation_loader: &mut AnimationLoader,
+        sprite_loader: &SpriteLoader,
+        action_loader: &ActionLoader,
+        animation_loader: &AnimationLoader,
         script_loader: &ScriptLoader,
         account_id: AccountId,
         character_information: CharacterInformation,
@@ -917,10 +917,10 @@ impl Player {
 
     pub fn reload_sprite(
         &mut self,
-        sprite_loader: &mut SpriteLoader,
-        action_loader: &mut ActionLoader,
+        sprite_loader: &SpriteLoader,
+        action_loader: &ActionLoader,
         script_loader: &ScriptLoader,
-        animation_loader: &mut AnimationLoader,
+        animation_loader: &AnimationLoader,
     ) {
         let entity_part_files = get_entity_part_files(
             script_loader,
@@ -947,12 +947,11 @@ pub struct Npc {
 
 impl Npc {
     pub fn new(
-        sprite_loader: &mut SpriteLoader,
-        action_loader: &mut ActionLoader,
-        animation_loader: &mut AnimationLoader,
+        sprite_loader: &SpriteLoader,
+        action_loader: &ActionLoader,
+        animation_loader: &AnimationLoader,
         script_loader: &ScriptLoader,
         map: &Map,
-        path_finder: &mut PathFinder,
         entity_data: EntityData,
         client_tick: ClientTick,
     ) -> Self {
@@ -971,9 +970,10 @@ impl Npc {
         );
 
         if let Some(destination) = entity_data.destination {
+            let mut path_finder = PathFinder::default();
             let position_from = Vector2::new(entity_data.position.x, entity_data.position.y);
             let position_to = Vector2::new(destination.x, destination.y);
-            common.move_from_to(map, path_finder, position_from, position_to, client_tick);
+            common.move_from_to(map, &mut path_finder, position_from, position_to, client_tick);
         }
 
         Self { common }
@@ -1072,9 +1072,9 @@ impl Entity {
 
     pub fn reload_sprite(
         &mut self,
-        sprite_loader: &mut SpriteLoader,
-        action_loader: &mut ActionLoader,
-        animation_loader: &mut AnimationLoader,
+        sprite_loader: &SpriteLoader,
+        action_loader: &ActionLoader,
+        animation_loader: &AnimationLoader,
         script_loader: &ScriptLoader,
     ) {
         match self {


### PR DESCRIPTION
This is a requirement for loading entities and maps asynchronously without blocking the main render thread.