### PR TITLE
Rework the ClientInfo XML parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,6 +1598,7 @@ dependencies = [
  "chrono",
  "cosmic-text",
  "derive-new",
+ "encoding_rs",
  "flate2",
  "glidesort",
  "hashbrown",
@@ -1612,6 +1613,7 @@ dependencies = [
  "num",
  "option-ext",
  "pollster",
+ "quick-xml 0.37.2",
  "ragnarok_bytes",
  "ragnarok_formats",
  "ragnarok_packets",
@@ -1620,12 +1622,10 @@ dependencies = [
  "rayon",
  "ron",
  "serde",
- "serde-xml-rs",
  "spin_sleep",
  "walkdir",
  "wgpu",
  "winit",
- "xml-rs",
 ]
 
 [[package]]
@@ -2661,6 +2661,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.37.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "165859e9e55f79d67b96c5d96f4e88b6f2695a1972849c15a6a3f5c59fc2c003"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3158,18 +3168,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-xml-rs"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3aa78ecda1ebc9ec9847d5d3aba7d618823446a049ba2491940506da6e2782"
-dependencies = [
- "log",
- "serde",
- "thiserror",
- "xml-rs",
 ]
 
 [[package]]
@@ -4076,7 +4074,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597f2001b2e5fc1121e3d5b9791d3e78f05ba6bfa4641053846248e3a13661c3"
 dependencies = [
  "proc-macro2",
- "quick-xml",
+ "quick-xml 0.36.2",
  "quote",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ chrono = "0.4"
 cosmic-text = { version = "0.12", default-features = false }
 cpal = "0.15"
 derive-new = "0.7"
+encoding_rs = "0.8"
 etherparse = "0.16"
 fast-srgb8 = "1"
 flate2 = { version = "1", default-features = false }
@@ -31,6 +32,7 @@ option-ext = "0.2"
 pcap = "2.2"
 pollster = "0.4"
 proc-macro2 = "1.0"
+quick-xml = "0.37"
 quote = "1.0"
 ragnarok_bytes = { path = "ragnarok_bytes" }
 ragnarok_formats = { path = "ragnarok_formats" }
@@ -42,14 +44,12 @@ rayon = "1.10"
 reqwest = "0.12"
 ron = "0.8"
 serde = "1.0"
-serde-xml-rs = "0.6"
 spin_sleep = "1.3"
 syn = "2.0"
 tokio = { version = "1.42", default-features = false }
 walkdir = "2.5"
 wgpu = "23.0"
 winit = "0.30"
-xml-rs = "0.8"
 
 [profile.dev.build-override]
 opt-level = 3

--- a/korangar/Cargo.toml
+++ b/korangar/Cargo.toml
@@ -11,6 +11,7 @@ cgmath = { workspace = true, features = ["mint", "serde"] }
 chrono = { workspace = true }
 cosmic-text = { workspace = true, features = ["std", "fontconfig"] }
 derive-new = { workspace = true }
+encoding_rs = { workspace = true }
 flate2 = { workspace = true, features = ["zlib-rs"] }
 hashbrown = { workspace = true }
 glidesort = { workspace = true }
@@ -25,6 +26,7 @@ mlua = { workspace = true, features = ["lua51", "vendored"] }
 num = { workspace = true }
 option-ext = { workspace = true }
 pollster = { workspace = true }
+quick-xml = { workspace = true, features = ["serde", "serialize"] }
 ragnarok_bytes = { workspace = true, features = ["derive", "cgmath"] }
 ragnarok_formats = { workspace = true, features = ["interface"] }
 ragnarok_packets = { workspace = true, features = ["derive", "interface", "packet-to-prototype-element"] }
@@ -33,12 +35,10 @@ random_color = { workspace = true, optional = true }
 rayon = { workspace = true }
 ron = { workspace = true }
 serde = { workspace = true }
-serde-xml-rs = { workspace = true }
 spin_sleep = { workspace = true }
 walkdir = { workspace = true }
 wgpu = { workspace = true }
 winit = { workspace = true }
-xml-rs = { workspace = true }
 
 [features]
 debug = ["korangar_debug", "korangar_audio/debug", "ragnarok_packets/debug", "random_color"]


### PR DESCRIPTION
Reduced the XML libraries to one by using the maintained quick_xml crate.

Properly decodes the XML if it defines a custom encoding.