### PR TITLE
Fix the profiler for the loader and frame selection

### DIFF
--- a/korangar/src/interface/elements/profiler/frame.rs
+++ b/korangar/src/interface/elements/profiler/frame.rs
@@ -80,8 +80,10 @@ impl Element<InterfaceSettings> for FrameView {
         let mouse_position = self.state.mouse_position.get();
         let number_of_frames = korangar_debug::profiling::get_number_of_saved_frames(visible_thread);
 
-        let bar_width = self.state.cached_size.width / number_of_frames as f32;
-        let clicked_frame = (mouse_position.left / bar_width) as usize;
+        let gap_width = 1.0;
+        let total_gaps = (number_of_frames - 1) as f32 * gap_width;
+        let bar_width = (self.state.cached_size.width - total_gaps) / number_of_frames as f32;
+        let clicked_frame = (mouse_position.left / (bar_width + gap_width)) as usize;
 
         let measurement = korangar_debug::profiling::get_frame_by_index(visible_thread, clicked_frame);
         vec![ClickAction::OpenWindow(Box::new(FrameInspectorWindow::new(measurement)))]

--- a/korangar/src/loaders/async/mod.rs
+++ b/korangar/src/loaders/async/mod.rs
@@ -5,6 +5,8 @@ use hashbrown::HashMap;
 #[cfg(feature = "debug")]
 use korangar_debug::logging::print_debug;
 #[cfg(feature = "debug")]
+use korangar_debug::profiling::Profiler;
+#[cfg(feature = "debug")]
 use korangar_util::texture_atlas::AtlasAllocation;
 use ragnarok_packets::{EntityId, ItemId, TilePosition};
 use rayon::{ThreadPool, ThreadPoolBuilder};
@@ -100,6 +102,9 @@ impl AsyncLoader {
                 let animation_loader = self.animation_loader.clone();
 
                 self.request_load(LoaderId::AnimationData(entity_id), move || {
+                    #[cfg(feature = "debug")]
+                    let _load_measurement = Profiler::start_measurement("animation data load");
+
                     let animation_data = match animation_loader.get(&entity_part_files) {
                         Some(animation_data) => animation_data,
                         None => animation_loader.load(&sprite_loader, &action_loader, entity_type, &entity_part_files)?,
@@ -127,6 +132,9 @@ impl AsyncLoader {
                 let path = path.to_string();
 
                 self.request_load(LoaderId::ItemSprite(item_id), move || {
+                    #[cfg(feature = "debug")]
+                    let _load_measurement = Profiler::start_measurement("item sprite load");
+
                     let texture = match texture_loader.get(&path, image_type) {
                         None => texture_loader.load(&path, image_type)?,
                         Some(texture) => texture,
@@ -153,6 +161,9 @@ impl AsyncLoader {
         let texture_loader = self.texture_loader.clone();
 
         self.request_load(LoaderId::Map(map_name.clone()), move || {
+            #[cfg(feature = "debug")]
+            let _load_measurement = Profiler::start_measurement("map load");
+
             let map = map_loader.load(
                 map_name,
                 &model_loader,

--- a/korangar_debug/src/profiling/frame_measurement.rs
+++ b/korangar_debug/src/profiling/frame_measurement.rs
@@ -29,6 +29,11 @@ impl FrameMeasurement {
         index
     }
 
+    /// Returns `true` if the frame has measurements.
+    pub fn has_measurements(&self) -> bool {
+        !self.buffer.is_empty()
+    }
+
     /// Returns the root measurement of the frame's measurement.
     pub fn root_measurement(&self) -> &Measurement {
         &self.buffer[0]

--- a/korangar_debug/src/profiling/profiler.rs
+++ b/korangar_debug/src/profiling/profiler.rs
@@ -84,8 +84,9 @@ impl Profiler {
             );
         }
 
-        // Discard the currents frame measurement if profiling is halted.
-        if !PROFILER_HALTED.load(std::sync::atomic::Ordering::Relaxed) {
+        // Make sure that the profiler is not halted and only save the frame data when
+        // there is at least one measurement.
+        if !PROFILER_HALTED.load(std::sync::atomic::Ordering::Relaxed) && self.latest_frame.has_measurements() {
             self.saved_frames.push_default_or_recycle();
 
             // Swap the current and the replaced frame to avoid allocating new vectors on

--- a/korangar_debug/src/profiling/statistics.rs
+++ b/korangar_debug/src/profiling/statistics.rs
@@ -90,12 +90,12 @@ pub fn get_statistics_data(thread: impl LockThreadProfiler) -> (Vec<FrameData>, 
     let mut timing_map = HashMap::new();
 
     saved_frames.iter().take(frame_count).for_each(|frame_measurement| {
-        let root_measurement = &frame_measurement.root_measurement();
+        let root_measurement = frame_measurement.root_measurement();
         process_timing(root_measurement, &mut timing_map);
         root_measurement.indices.iter().for_each(|index| {
             let measurement = &frame_measurement[*index];
             process_timing(measurement, &mut timing_map)
-        })
+        });
     });
 
     let statistics_map = timing_map


### PR DESCRIPTION
This allows the frame profiler to be used to profile async load tasks.