### PR TITLE
Fix texture wrapping

### DIFF
--- a/korangar_util/src/texture_atlas/mod.rs
+++ b/korangar_util/src/texture_atlas/mod.rs
@@ -21,8 +21,13 @@ pub struct AtlasAllocation {
 impl AtlasAllocation {
     /// Maps normalized input coordinates to normalized atlas coordinates.
     pub fn map_to_atlas(&self, normalized_coordinates: Point2<f32>) -> Point2<f32> {
-        let x = ((normalized_coordinates.x * self.rectangle.width() as f32) + self.rectangle.min.x as f32) / self.atlas_size.x as f32;
-        let y = ((normalized_coordinates.y * self.rectangle.height() as f32) + self.rectangle.min.y as f32) / self.atlas_size.y as f32;
+        // Textured coordinates, that are "clearly bigger" than 1.0 are wrapping. There
+        // are some values, even though they are for example "1.0112", which are not
+        // wrapped in the original client. So we chose "1.1" arbitrarily as a cutoff
+        // point.
+        let wrapped = normalized_coordinates.map(|value: f32| if value > 1.1 { value.fract() } else { value });
+        let x = ((wrapped.x * self.rectangle.width() as f32) + self.rectangle.min.x as f32) / self.atlas_size.x as f32;
+        let y = ((wrapped.y * self.rectangle.height() as f32) + self.rectangle.min.y as f32) / self.atlas_size.y as f32;
         Point2::new(x, y)
     }
 }


### PR DESCRIPTION
The original client seems to have used texture wrapping, for values that are "clearly bigger" than 1.0. We chose the cutoff value between wrapping and clamping to be 1.1 arbitrarily.

<img width="789" alt="BROKEN" src="https://github.com/user-attachments/assets/d272ea9e-6e14-4550-802c-118d1f404afe" />

<img width="626" alt="FIXED" src="https://github.com/user-attachments/assets/f92b0f3a-0864-4323-a891-597690b7e44b" />

