### PR TITLE
Simplify the string decode logic

### DIFF
--- a/korangar/src/world/library/mod.rs
+++ b/korangar/src/world/library/mod.rs
@@ -178,10 +178,8 @@ impl Library {
 
 fn fix_encoding(broken: String) -> String {
     let bytes: Vec<u8> = broken.chars().map(|char| char as u8).collect();
-    let (char, error) = EUC_KR.decode_without_bom_handling(&bytes);
-    if error {
-        broken.to_string()
-    } else {
-        char.to_string()
+    match EUC_KR.decode_without_bom_handling_and_without_replacement(&bytes) {
+        None => broken.to_string(),
+        Some(char) => char.to_string(),
     }
 }

--- a/ragnarok_bytes/src/reader.rs
+++ b/ragnarok_bytes/src/reader.rs
@@ -84,11 +84,9 @@ where
     }
 
     pub fn decode_string(&mut self, bytes: &[u8]) -> String {
-        let (cow, error) = self.encoding.decode_without_bom_handling(bytes);
-        if error {
-            bytes.iter().map(|byte| *byte as char).collect()
-        } else {
-            cow.to_string()
+        match self.encoding.decode_without_bom_handling_and_without_replacement(bytes) {
+            None => bytes.iter().map(|byte| *byte as char).collect(),
+            Some(chars) => chars.to_string(),
         }
     }
 


### PR DESCRIPTION
After having read the documentation, this is the function that is the cheapest and most correct for uns to use.