### PR TITLE
Increase the texture wrapping cutoff point

### DIFF
--- a/korangar_util/src/texture_atlas/mod.rs
+++ b/korangar_util/src/texture_atlas/mod.rs
@@ -23,9 +23,9 @@ impl AtlasAllocation {
     pub fn map_to_atlas(&self, normalized_coordinates: Point2<f32>) -> Point2<f32> {
         // Textured coordinates, that are "clearly bigger" than 1.0 are wrapping. There
         // are some values, even though they are for example "1.0112", which are not
-        // wrapped in the original client. So we chose "1.1" arbitrarily as a cutoff
-        // point.
-        let wrapped = normalized_coordinates.map(|value: f32| if value > 1.1 { value.fract() } else { value });
+        // wrapped in the original client. So we chose "1.5" as a cutoff point. A value
+        // too low could lead to wrongly applied textures.
+        let wrapped = normalized_coordinates.map(|value: f32| if value > 1.5 { value.fract() } else { value });
         let x = ((wrapped.x * self.rectangle.width() as f32) + self.rectangle.min.x as f32) / self.atlas_size.x as f32;
         let y = ((wrapped.y * self.rectangle.height() as f32) + self.rectangle.min.y as f32) / self.atlas_size.y as f32;
         Point2::new(x, y)


### PR DESCRIPTION
This fixes an issue in Geffen, where stairs had stretched textures. Textures in lou_in01 are still applied correctly.

<img width="239" alt="Screenshot 2025-01-07 080208" src="https://github.com/user-attachments/assets/5d36a35f-1a82-4637-b34f-3841fe132b53" />
