### PR TITLE
Support texture compression

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+# Steam Hardware survey: https://store.steampowered.com/hwsurvey/Steam-Hardware-Software-Survey-Welcome-to-Steam
+[target.'cfg(target_arch="x86_64")']
+rustflags = ["-C", "target-feature=+aes,+avx,+avx2,+cmpxchg16b,+fma,+sse3,+ssse3,+sse4.1,+sse4.2"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,6 +328,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "block_compression"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ba559a2fa71d562c6fb6d03f04334a60520016e60d1b9667aed1f61b4af37f"
+dependencies = [
+ "bytemuck",
+ "wgpu",
+]
+
+[[package]]
 name = "bstr"
 version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.9"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "jobserver",
  "libc",
@@ -759,6 +769,12 @@ checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -1149,15 +1165,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "http"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1455,9 +1462,9 @@ checksum = "d0263a3d970d5c054ed9312c0057b4f3bde9c0b33836d3637361d4a9e6e7a408"
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1485,9 +1492,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "itertools"
@@ -1573,9 +1580,9 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "kira"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50679def12511d0a12c261ecffad7bf0c39d83250b62a3f905fa52343613ca77"
+checksum = "a6c094dc109f5735ce9586c9865c7059fe2e951a2a74ccda7350f756ee98cbc2"
 dependencies = [
  "atomic-arena",
  "cpal",
@@ -1593,6 +1600,7 @@ name = "korangar"
 version = "0.1.0"
 dependencies = [
  "arrayvec",
+ "block_compression",
  "bumpalo",
  "bytemuck",
  "cgmath",
@@ -1799,9 +1807,9 @@ dependencies = [
 
 [[package]]
 name = "luajit-src"
-version = "210.5.11+97813fb"
+version = "210.5.12+a4f56a4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3015551c284515db7c30c559fc1080f9cb9ee990d1f6fca315451a107c7540bb"
+checksum = "b3a8e7962a5368d5f264d045a5a255e90f9aa3fc1941ae15a8d2940d42cac671"
 dependencies = [
  "cc",
  "which",
@@ -2779,9 +2787,9 @@ dependencies = [
 
 [[package]]
 name = "range-alloc"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8a99fddc9f0ba0a85884b8d14e3592853e787d581ca1816c91349b10e4eeab"
+checksum = "c3d6831663a5098ea164f89cff59c6284e95f4e3c76ce9848d4529f5ccca9bde"
 
 [[package]]
 name = "rangemap"
@@ -3027,9 +3035,9 @@ checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 
 [[package]]
 name = "rustix"
-version = "0.38.43"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
  "bitflags 2.8.0",
  "errno 0.3.10",
@@ -3206,9 +3214,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.135"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
+checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
  "itoa",
  "memchr",
@@ -4313,12 +4321,12 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "6.0.3"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+checksum = "fb4a9e33648339dc1642b0e36e21b3385e6148e289226f657c809dee59df5028"
 dependencies = [
  "either",
- "home",
+ "env_home",
  "rustix",
  "winsafe",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = ["korangar", "ragnarok_*", "korangar_*"]
 [workspace.dependencies]
 arrayvec = "0.7"
 bitflags = "2.6"
+block_compression = { version = "0.2", default-features = false }
 bumpalo = "3.16"
 bytemuck = "1.21"
 cgmath = "0.18"
@@ -51,6 +52,9 @@ tokio = { version = "1.42", default-features = false }
 walkdir = "2.5"
 wgpu = "24"
 winit = "0.30"
+
+[profile.release]
+lto = "thin"
 
 [profile.dev.build-override]
 opt-level = 3

--- a/korangar/Cargo.toml
+++ b/korangar/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 arrayvec = { workspace = true }
+block_compression = { workspace = true, features = ["bc7", "wgpu"] }
 bumpalo = { workspace = true, features = ["allocator_api"] }
 bytemuck = { workspace = true, features = ["derive", "extern_crate_std", "min_const_generics"] }
 cgmath = { workspace = true, features = ["mint", "serde"] }

--- a/korangar/src/graphics/capabilities.rs
+++ b/korangar/src/graphics/capabilities.rs
@@ -17,6 +17,7 @@ pub struct Capabilities {
     bindless: bool,
     multidraw_indirect: bool,
     clamp_to_border: bool,
+    texture_compression: bool,
     #[cfg(feature = "debug")]
     polygon_mode_line: bool,
     required_features: Features,
@@ -37,6 +38,7 @@ impl Capabilities {
             bindless: false,
             multidraw_indirect: false,
             clamp_to_border: false,
+            texture_compression: false,
             #[cfg(feature = "debug")]
             polygon_mode_line: false,
             required_features: Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES,
@@ -58,6 +60,7 @@ impl Capabilities {
                 adapter_features,
                 Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING,
             );
+            Self::check_feature(adapter_features, Features::TEXTURE_COMPRESSION_BC);
             Self::check_feature(adapter_features, Features::TEXTURE_BINDING_ARRAY);
             Self::check_feature(adapter_features, Features::POLYGON_MODE_LINE);
         }
@@ -83,6 +86,11 @@ impl Capabilities {
         if adapter_features.contains(Features::ADDRESS_MODE_CLAMP_TO_BORDER | Features::ADDRESS_MODE_CLAMP_TO_ZERO) {
             capabilities.clamp_to_border = true;
             capabilities.required_features |= Features::ADDRESS_MODE_CLAMP_TO_BORDER | Features::ADDRESS_MODE_CLAMP_TO_ZERO;
+        }
+
+        if adapter_features.contains(Features::TEXTURE_COMPRESSION_BC) {
+            capabilities.texture_compression = true;
+            capabilities.required_features |= Features::TEXTURE_COMPRESSION_BC;
         }
 
         #[cfg(feature = "debug")]
@@ -133,6 +141,11 @@ impl Capabilities {
     /// a specific value.
     pub fn supports_clamp_to_border(&self) -> bool {
         self.clamp_to_border
+    }
+
+    /// Returns `true` if the backend supports BC texture compression.
+    pub fn supports_texture_compression(&self) -> bool {
+        self.texture_compression
     }
 
     /// Returns `true` if the backend allows drawing triangles as lines

--- a/korangar/src/graphics/engine.rs
+++ b/korangar/src/graphics/engine.rs
@@ -17,7 +17,8 @@ use winit::window::Window;
 
 use super::{
     AntiAliasingResource, Capabilities, EntityInstruction, FramePacer, FrameStage, GlobalContext, LimitFramerate, ModelInstruction, Msaa,
-    Prepare, PresentModeInfo, ScreenSpaceAntiAliasing, ShadowDetail, Ssaa, Surface, TextureSamplerType, RENDER_TO_TEXTURE_FORMAT,
+    Prepare, PresentModeInfo, ScreenSpaceAntiAliasing, ShadowDetail, Ssaa, Surface, TextureCompression, TextureSamplerType,
+    RENDER_TO_TEXTURE_FORMAT,
 };
 use crate::graphics::instruction::RenderInstruction;
 use crate::graphics::passes::*;
@@ -426,6 +427,14 @@ impl GraphicsEngine {
         }
 
         ssaa
+    }
+
+    pub fn check_texture_compression_requirements(&self, texture_compression: TextureCompression) -> TextureCompression {
+        if self.capabilities.supports_texture_compression() {
+            texture_compression
+        } else {
+            TextureCompression::Off
+        }
     }
 
     pub fn on_suspended(&mut self) {

--- a/korangar/src/graphics/passes/directional_shadow/shader/model.wgsl
+++ b/korangar/src/graphics/passes/directional_shadow/shader/model.wgsl
@@ -42,7 +42,7 @@ fn vs_main(
 fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     var diffuse_color = textureSampleLevel(texture, texture_sampler, input.texture_coordinates, 0.0);
 
-    if (diffuse_color.a < 1.0) {
+    if (diffuse_color.a == 0.0) {
         discard;
     }
 

--- a/korangar/src/graphics/passes/point_shadow/shader/model.wgsl
+++ b/korangar/src/graphics/passes/point_shadow/shader/model.wgsl
@@ -47,7 +47,7 @@ fn fs_main(input: VertexOutput) -> @builtin(frag_depth) f32 {
 
     let light_distance = length(input.world_position.xyz - pass_uniforms.light_position.xyz);
 
-    if (diffuse_color.a != 1.0) {
+    if (diffuse_color.a == 0.0) {
         discard;
     }
 

--- a/korangar/src/graphics/settings.rs
+++ b/korangar/src/graphics/settings.rs
@@ -2,9 +2,11 @@ use std::fmt::{Display, Formatter};
 #[cfg(feature = "debug")]
 use std::num::NonZeroU32;
 
+use block_compression::{BC7Settings, CompressionVariant};
 #[cfg(feature = "debug")]
 use derive_new::new;
 use serde::{Deserialize, Serialize};
+use wgpu::TextureFormat;
 
 use crate::interface::layout::ScreenSize;
 
@@ -156,6 +158,46 @@ impl Display for ScreenSpaceAntiAliasing {
         match self {
             ScreenSpaceAntiAliasing::Off => "Off".fmt(f),
             ScreenSpaceAntiAliasing::Fxaa => "FXAA".fmt(f),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum TextureCompression {
+    Off,
+    UltraFast,
+    VeryFast,
+    Fast,
+    Normal,
+}
+
+impl TextureCompression {
+    pub fn is_uncompressed(&self) -> bool {
+        *self == TextureCompression::Off
+    }
+}
+
+impl From<TextureCompression> for TextureFormat {
+    fn from(value: TextureCompression) -> Self {
+        match value {
+            TextureCompression::Off => TextureFormat::Rgba8UnormSrgb,
+            TextureCompression::UltraFast | TextureCompression::VeryFast | TextureCompression::Fast | TextureCompression::Normal => {
+                TextureFormat::Bc7RgbaUnormSrgb
+            }
+        }
+    }
+}
+
+impl TryFrom<TextureCompression> for CompressionVariant {
+    type Error = ();
+
+    fn try_from(value: TextureCompression) -> Result<Self, Self::Error> {
+        match value {
+            TextureCompression::Off => Err(()),
+            TextureCompression::UltraFast => Ok(CompressionVariant::BC7(BC7Settings::alpha_ultrafast())),
+            TextureCompression::VeryFast => Ok(CompressionVariant::BC7(BC7Settings::alpha_very_fast())),
+            TextureCompression::Fast => Ok(CompressionVariant::BC7(BC7Settings::alpha_fast())),
+            TextureCompression::Normal => Ok(CompressionVariant::BC7(BC7Settings::alpha_basic())),
         }
     }
 }

--- a/korangar/src/graphics/texture.rs
+++ b/korangar/src/graphics/texture.rs
@@ -7,8 +7,9 @@ use hashbrown::HashMap;
 use korangar_util::container::Cacheable;
 use wgpu::{
     BindGroup, BindGroupDescriptor, BindGroupEntry, BindGroupLayout, BindGroupLayoutDescriptor, BindGroupLayoutEntry, BindingResource,
-    BindingType, Device, Extent3d, Queue, ShaderStages, TexelCopyBufferLayout, TextureAspect, TextureDescriptor, TextureDimension,
-    TextureFormat, TextureSampleType, TextureUsages, TextureView, TextureViewDescriptor, TextureViewDimension,
+    BindingType, Device, Extent3d, Origin3d, Queue, ShaderStages, TexelCopyBufferLayout, TexelCopyTextureInfo, TextureAspect,
+    TextureDescriptor, TextureDimension, TextureFormat, TextureSampleType, TextureUsages, TextureView, TextureViewDescriptor,
+    TextureViewDimension,
 };
 
 use crate::interface::layout::ScreenSize;
@@ -80,24 +81,54 @@ impl Texture {
         }
     }
 
-    /// This function doesn't upload mip-map data. Mip maps should be written
-    /// using the `MipMapRenderPassContext` & `Lanczos3Drawer`.
     pub fn new_with_data(device: &Device, queue: &Queue, descriptor: &TextureDescriptor, image_data: &[u8], transparent: bool) -> Self {
         let id = TEXTURE_ID.fetch_add(1, Ordering::Relaxed);
         let label = descriptor.label.map(|label| label.to_string());
         let texture = device.create_texture(descriptor);
-        let block_size = texture.format().block_copy_size(None).unwrap();
+        let format = texture.format();
 
-        queue.write_texture(
-            texture.as_image_copy(),
-            image_data,
-            TexelCopyBufferLayout {
-                offset: 0,
-                bytes_per_row: Some(descriptor.size.width * block_size),
-                rows_per_image: Some(descriptor.size.height),
-            },
-            descriptor.size,
-        );
+        let (block_width, block_height) = format.block_dimensions();
+        let block_size = format.block_copy_size(None).unwrap();
+
+        let mut offset = 0;
+        let mut mip_width = descriptor.size.width;
+        let mut mip_height = descriptor.size.height;
+
+        for mip_level in 0..descriptor.mip_level_count {
+            let width_blocks = mip_width.div_ceil(block_width);
+            let height_blocks = mip_height.div_ceil(block_height);
+
+            let bytes_per_row = width_blocks * block_size;
+            let mip_size = bytes_per_row * height_blocks;
+
+            if offset + mip_size as usize <= image_data.len() {
+                queue.write_texture(
+                    TexelCopyTextureInfo {
+                        texture: &texture,
+                        mip_level,
+                        origin: Origin3d::ZERO,
+                        aspect: TextureAspect::All,
+                    },
+                    &image_data[offset..offset + mip_size as usize],
+                    TexelCopyBufferLayout {
+                        offset: 0,
+                        bytes_per_row: Some(bytes_per_row),
+                        rows_per_image: None,
+                    },
+                    Extent3d {
+                        width: mip_width,
+                        height: mip_height,
+                        depth_or_array_layers: 1,
+                    },
+                );
+
+                offset += mip_size as usize;
+                mip_width = (mip_width / 2).max(1);
+                mip_height = (mip_height / 2).max(1);
+            } else {
+                break;
+            }
+        }
 
         let texture_view = texture.create_view(&TextureViewDescriptor {
             label: descriptor.label,

--- a/korangar/src/interface/windows/settings/graphics.rs
+++ b/korangar/src/interface/windows/settings/graphics.rs
@@ -4,7 +4,8 @@ use korangar_interface::windows::{PrototypeWindow, Window, WindowBuilder};
 use korangar_interface::{dimension_bound, size_bound};
 
 use crate::graphics::{
-    LimitFramerate, Msaa, PresentModeInfo, ScreenSpaceAntiAliasing, ShadowDetail, ShadowQuality, Ssaa, TextureSamplerType,
+    LimitFramerate, Msaa, PresentModeInfo, ScreenSpaceAntiAliasing, ShadowDetail, ShadowQuality, Ssaa, TextureCompression,
+    TextureSamplerType,
 };
 use crate::interface::application::InterfaceSettings;
 use crate::interface::layout::ScreenSize;
@@ -23,6 +24,7 @@ pub struct GraphicsSettingsWindow<
     ShadowResolution,
     ShadowMode,
     HighQualityInterface,
+    Compression,
 > where
     LightingRenderMode: TrackedState<LightingMode> + 'static,
     Vsync: TrackedStateBinary<bool>,
@@ -35,6 +37,7 @@ pub struct GraphicsSettingsWindow<
     ShadowResolution: TrackedState<ShadowDetail> + 'static,
     ShadowMode: TrackedState<ShadowQuality> + 'static,
     HighQualityInterface: TrackedStateBinary<bool>,
+    Compression: TrackedState<TextureCompression> + 'static,
 {
     present_mode_info: PresentModeInfo,
     supported_msaa: Vec<(String, Msaa)>,
@@ -49,6 +52,7 @@ pub struct GraphicsSettingsWindow<
     shadow_detail: ShadowResolution,
     shadow_quality: ShadowMode,
     high_quality_interface: HighQualityInterface,
+    texture_compression: Compression,
 }
 
 impl<
@@ -63,6 +67,7 @@ impl<
         ShadowResolution,
         ShadowMode,
         HighQualityInterface,
+        Compression,
     >
     GraphicsSettingsWindow<
         LightingRenderMode,
@@ -76,6 +81,7 @@ impl<
         ShadowResolution,
         ShadowMode,
         HighQualityInterface,
+        Compression,
     >
 where
     LightingRenderMode: TrackedState<LightingMode> + 'static,
@@ -89,6 +95,7 @@ where
     ShadowResolution: TrackedState<ShadowDetail> + 'static,
     ShadowMode: TrackedState<ShadowQuality> + 'static,
     HighQualityInterface: TrackedStateBinary<bool>,
+    Compression: TrackedState<TextureCompression> + 'static,
 {
     pub const WINDOW_CLASS: &'static str = "graphics_settings";
 
@@ -106,6 +113,7 @@ where
         shadow_detail: ShadowResolution,
         shadow_quality: ShadowMode,
         high_quality_interface: HighQualityInterface,
+        texture_compression: Compression,
     ) -> Self {
         Self {
             present_mode_info,
@@ -121,6 +129,7 @@ where
             shadow_detail,
             shadow_quality,
             high_quality_interface,
+            texture_compression,
         }
     }
 }
@@ -137,6 +146,7 @@ impl<
         ShadowResolution,
         ShadowMode,
         HighQualityInterface,
+        Compression,
     > PrototypeWindow<InterfaceSettings>
     for GraphicsSettingsWindow<
         LightingRenderMode,
@@ -150,6 +160,7 @@ impl<
         ShadowResolution,
         ShadowMode,
         HighQualityInterface,
+        Compression,
     >
 where
     LightingRenderMode: TrackedState<LightingMode> + 'static,
@@ -163,6 +174,7 @@ where
     ShadowResolution: TrackedState<ShadowDetail> + 'static,
     ShadowMode: TrackedState<ShadowQuality> + 'static,
     HighQualityInterface: TrackedStateBinary<bool>,
+    Compression: TrackedState<TextureCompression> + 'static,
 {
     fn window_class(&self) -> Option<&str> {
         Self::WINDOW_CLASS.into()
@@ -201,6 +213,22 @@ where
                     ("Anisotropic x16", TextureSamplerType::Anisotropic(16)),
                 ])
                 .with_selected(self.texture_filtering.clone())
+                .with_event(Box::new(Vec::new))
+                .with_width(dimension_bound!(!))
+                .wrap(),
+            Text::default()
+                .with_text("Texture compression")
+                .with_width(dimension_bound!(50%))
+                .wrap(),
+            PickList::default()
+                .with_options(vec![
+                    ("Off", TextureCompression::Off),
+                    ("Ultra Fast", TextureCompression::UltraFast),
+                    ("Very Fast", TextureCompression::VeryFast),
+                    ("Fast", TextureCompression::Fast),
+                    ("Normal", TextureCompression::Normal),
+                ])
+                .with_selected(self.texture_compression.clone())
                 .with_event(Box::new(Vec::new))
                 .with_width(dimension_bound!(!))
                 .wrap(),

--- a/korangar/src/loaders/map/mod.rs
+++ b/korangar/src/loaders/map/mod.rs
@@ -21,7 +21,7 @@ use wgpu::{BufferUsages, Device, Queue};
 pub use self::vertices::MAP_TILE_SIZE;
 use self::vertices::{generate_tile_vertices, ground_vertices};
 use super::error::LoadError;
-use crate::graphics::{Buffer, ModelVertex, NativeModelVertex, Texture};
+use crate::graphics::{Buffer, ModelVertex, NativeModelVertex, Texture, TextureCompression};
 use crate::loaders::{GameFileLoader, ImageType, ModelLoader, TextureAtlasFactory, TextureLoader};
 use crate::world::{LightSourceKey, Model};
 use crate::{EffectSourceExt, LightSourceExt, Map, Object, ObjectKey, SoundSourceExt};
@@ -57,6 +57,7 @@ pub struct MapLoader {
 impl MapLoader {
     pub fn load(
         &self,
+        texture_compression: TextureCompression,
         resource_file: String,
         model_loader: &ModelLoader,
         texture_loader: Arc<TextureLoader>,
@@ -65,7 +66,7 @@ impl MapLoader {
         #[cfg(feature = "debug")]
         let timer = Timer::new_dynamic(format!("load map from {}", &resource_file));
 
-        let mut texture_atlas_factory = TextureAtlasFactory::new(texture_loader.clone(), "map", true, true);
+        let mut texture_atlas_factory = TextureAtlasFactory::new(texture_loader.clone(), "map", true, true, texture_compression);
         let mut deferred_vertex_generation: Vec<DeferredVertexGeneration> = Vec::new();
 
         let map_file_name = format!("data\\{}.rsw", resource_file);
@@ -207,6 +208,7 @@ impl MapLoader {
             .filter(|_| !(water_bounds.min == Point2::from_value(f32::MAX) && water_bounds.max == Point2::from_value(f32::MIN)));
 
         let map = Map::new(
+            resource_file,
             gat_data.map_width as usize,
             gat_data.map_height as usize,
             water_settings,

--- a/korangar/src/main.rs
+++ b/korangar/src/main.rs
@@ -207,9 +207,9 @@ struct Client {
     ssaa: MappedRemote<GraphicsSettings, Ssaa>,
     screen_space_anti_aliasing: MappedRemote<GraphicsSettings, ScreenSpaceAntiAliasing>,
     high_quality_interface: MappedRemote<GraphicsSettings, bool>,
+    texture_compression: MappedRemote<GraphicsSettings, TextureCompression>,
     #[cfg(feature = "debug")]
     render_settings: PlainTrackedState<RenderSettings>,
-
     mute_on_focus_loss: MappedRemote<AudioSettings, bool>,
 
     application: InterfaceSettings,
@@ -295,6 +295,7 @@ impl Client {
                 .mapped(|settings| &settings.screen_space_anti_aliasing)
                 .new_remote();
             let high_quality_interface = graphics_settings.mapped(|settings| &settings.high_quality_interface).new_remote();
+            let texture_compression = graphics_settings.mapped(|settings| &settings.texture_compression).new_remote();
 
             #[cfg(feature = "debug")]
             let render_settings = PlainTrackedState::new(RenderSettings::new());
@@ -380,7 +381,7 @@ impl Client {
                 game_file_loader.clone(),
                 audio_engine.clone(),
             ));
-            let sprite_loader = Arc::new(SpriteLoader::new(device.clone(), queue.clone(), game_file_loader.clone()));
+            let sprite_loader = Arc::new(SpriteLoader::new(game_file_loader.clone(), texture_loader.clone()));
             let action_loader = Arc::new(ActionLoader::new(game_file_loader.clone(), audio_engine.clone()));
             let effect_loader = Arc::new(EffectLoader::new(game_file_loader.clone()));
             let animation_loader = Arc::new(AnimationLoader::new());
@@ -531,23 +532,30 @@ impl Client {
             let bounding_box_object_set_buffer = ResourceSetBuffer::default();
 
             #[cfg(feature = "debug")]
-            let (pathing_texture_mapping, pathing_texture) =
-                TextureAtlasFactory::create_from_group(texture_loader.clone(), "pathing", false, &[
-                    "pathing_goal.png",
-                    "pathing_straight.png",
-                    "pathing_diagonal.png",
-                ]);
+            let (pathing_texture_mapping, pathing_texture) = TextureAtlasFactory::create_from_group(
+                texture_loader.clone(),
+                "pathing",
+                false,
+                &["pathing_goal.png", "pathing_straight.png", "pathing_diagonal.png"],
+                graphics_engine.check_texture_compression_requirements(*texture_compression.get()),
+            );
 
             #[cfg(feature = "debug")]
-            let (tile_texture_mapping, tile_texture) = TextureAtlasFactory::create_from_group(texture_loader.clone(), "tile", false, &[
-                "tile_0.png",
-                "tile_1.png",
-                "tile_2.png",
-                "tile_3.png",
-                "tile_4.png",
-                "tile_5.png",
-                "tile_6.png",
-            ]);
+            let (tile_texture_mapping, tile_texture) = TextureAtlasFactory::create_from_group(
+                texture_loader.clone(),
+                "tile",
+                false,
+                &[
+                    "tile_0.png",
+                    "tile_1.png",
+                    "tile_2.png",
+                    "tile_3.png",
+                    "tile_4.png",
+                    "tile_5.png",
+                    "tile_6.png",
+                ],
+                graphics_engine.check_texture_compression_requirements(*texture_compression.get()),
+            );
             #[cfg(feature = "debug")]
             let tile_texture_mapping = Arc::new(tile_texture_mapping);
 
@@ -564,8 +572,11 @@ impl Client {
         });
 
         time_phase!("load default map", {
+            let compression = graphics_engine.check_texture_compression_requirements(*texture_compression.get());
+
             let map = map_loader
                 .load(
+                    compression,
                     DEFAULT_MAP.to_string(),
                     &model_loader,
                     texture_loader.clone(),
@@ -632,6 +643,7 @@ impl Client {
             ssaa,
             screen_space_anti_aliasing,
             high_quality_interface,
+            texture_compression,
             #[cfg(feature = "debug")]
             render_settings,
             mute_on_focus_loss,
@@ -856,17 +868,22 @@ impl Client {
                     self.networking_system.connect_to_character_server(login_data, server);
 
                     self.map = None;
-                    self.entities.clear();
                     self.particle_holder.clear();
                     self.effect_holder.clear();
                     self.point_light_manager.clear();
+                    self.audio_engine.clear_ambient_sound();
+
+                    self.entities.clear();
+
                     self.audio_engine.play_background_music_track(None);
 
                     self.interface.close_all_windows_except(&mut self.focus_state);
 
                     self.async_loader.request_map_load(
+                        self.graphics_engine
+                            .check_texture_compression_requirements(*self.texture_compression.get()),
                         DEFAULT_MAP.to_string(),
-                        TilePosition::new(0, 0),
+                        Some(TilePosition::new(0, 0)),
                         #[cfg(feature = "debug")]
                         self.tile_texture_mapping.clone(),
                     );
@@ -969,6 +986,10 @@ impl Client {
                     self.dialog_system.close_dialog();
 
                     self.map = None;
+                    self.particle_holder.clear();
+                    self.effect_holder.clear();
+                    self.point_light_manager.clear();
+                    self.audio_engine.clear_ambient_sound();
                 }
                 NetworkEvent::CharacterCreated { character_information } => {
                     self.saved_characters.push(character_information);
@@ -1059,13 +1080,19 @@ impl Client {
                 }
                 NetworkEvent::ChangeMap(map_name, player_position) => {
                     self.map = None;
+                    self.particle_holder.clear();
+                    self.effect_holder.clear();
+                    self.point_light_manager.clear();
+                    self.audio_engine.clear_ambient_sound();
 
                     // Only the player must stay alive between map changes.
                     self.entities.truncate(1);
 
                     self.async_loader.request_map_load(
+                        self.graphics_engine
+                            .check_texture_compression_requirements(*self.texture_compression.get()),
                         map_name,
-                        player_position,
+                        Some(player_position),
                         #[cfg(feature = "debug")]
                         self.tile_texture_mapping.clone(),
                     );
@@ -1506,6 +1533,7 @@ impl Client {
                         self.shadow_detail.clone_state(),
                         self.shadow_quality.clone_state(),
                         self.high_quality_interface.clone_state(),
+                        self.texture_compression.clone_state(),
                     ),
                 ),
                 UserEvent::OpenAudioSettingsWindow => self.interface.open_window(
@@ -1859,13 +1887,12 @@ impl Client {
                         map.set_ambient_sound_sources(&self.audio_engine);
                         self.audio_engine.play_background_music_track(map.background_music_track_name());
 
-                        let player_position = Vector2::new(player_position.x as usize, player_position.y as usize);
-                        self.entities[0].set_position(map, player_position, client_tick);
-                        self.player_camera.set_focus_point(self.entities[0].get_position());
+                        if let Some(player_position) = player_position {
+                            let player_position = Vector2::new(player_position.x as usize, player_position.y as usize);
+                            self.entities[0].set_position(map, player_position, client_tick);
+                            self.player_camera.set_focus_point(self.entities[0].get_position());
+                        }
 
-                        self.particle_holder.clear();
-                        self.effect_holder.clear();
-                        self.point_light_manager.clear();
                         self.interface.schedule_render();
                         let _ = self.networking_system.map_loaded();
                     }
@@ -2424,6 +2451,19 @@ impl Client {
             self.interface_renderer.update_high_quality_interface(high_quality_interface);
             self.graphics_engine.set_high_quality_interface(high_quality_interface);
             update_interface = true;
+        }
+
+        if self.texture_compression.consume_changed() {
+            if let Some(map) = self.map.as_ref() {
+                self.async_loader.request_map_load(
+                    self.graphics_engine
+                        .check_texture_compression_requirements(*self.texture_compression.get()),
+                    map.get_resource_file().to_string(),
+                    None,
+                    #[cfg(feature = "debug")]
+                    self.tile_texture_mapping.clone(),
+                );
+            }
         }
 
         if update_interface {

--- a/korangar/src/settings/graphic.rs
+++ b/korangar/src/settings/graphic.rs
@@ -3,7 +3,9 @@ use korangar_debug::logging::{print_debug, Colorize};
 use ron::ser::PrettyConfig;
 use serde::{Deserialize, Serialize};
 
-use crate::graphics::{LimitFramerate, Msaa, ScreenSpaceAntiAliasing, ShadowDetail, ShadowQuality, Ssaa, TextureSamplerType};
+use crate::graphics::{
+    LimitFramerate, Msaa, ScreenSpaceAntiAliasing, ShadowDetail, ShadowQuality, Ssaa, TextureCompression, TextureSamplerType,
+};
 
 #[derive(Serialize, Deserialize)]
 pub struct GraphicsSettings {
@@ -18,6 +20,7 @@ pub struct GraphicsSettings {
     pub shadow_detail: ShadowDetail,
     pub shadow_quality: ShadowQuality,
     pub high_quality_interface: bool,
+    pub texture_compression: TextureCompression,
 }
 
 impl Default for GraphicsSettings {
@@ -34,6 +37,7 @@ impl Default for GraphicsSettings {
             shadow_detail: ShadowDetail::Medium,
             shadow_quality: ShadowQuality::Soft,
             high_quality_interface: true,
+            texture_compression: TextureCompression::Off,
         }
     }
 }

--- a/korangar/src/world/map/mod.rs
+++ b/korangar/src/world/map/mod.rs
@@ -116,6 +116,7 @@ impl MarkerIdentifier {
 
 #[derive(new)]
 pub struct Map {
+    resource_file: String,
     width: usize,
     height: usize,
     water_settings: Option<WaterSettings>,
@@ -145,6 +146,10 @@ pub struct Map {
 impl Map {
     pub fn water_bounds(&self) -> Rectangle<f32> {
         self.water_bounds
+    }
+
+    pub fn get_resource_file(&self) -> &str {
+        &self.resource_file
     }
 
     pub fn get_world_position(&self, position: Vector2<usize>) -> Point3<f32> {


### PR DESCRIPTION
This uses the block_compression crate that I wrote.

It is using WGPU compute shader to compress the textures using BC7 on the fly when loading the map.

Textures using BC7 are 1/4 of the uncompressed texture size. Quality is defined by "speed" like video encoders do: the slower, the better the quality.