### PR TITLE
Remove glidesort

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,12 +1033,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glidesort"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2e102e6eb644d3e0b186fc161e4460417880a0a0b87d235f2e5b8fb30f2e9e0"
-
-[[package]]
 name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1609,7 +1603,6 @@ dependencies = [
  "derive-new",
  "encoding_rs",
  "flate2",
- "glidesort",
  "hashbrown",
  "image",
  "korangar_audio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ encoding_rs = "0.8"
 etherparse = "0.17"
 fast-srgb8 = "1"
 flate2 = { version = "1", default-features = false }
-glidesort = "0.1"
 hashbrown = "0.15"
 image = { version = "0.25", default-features = false }
 kira = { version = "0.10", default-features = false }

--- a/korangar/Cargo.toml
+++ b/korangar/Cargo.toml
@@ -15,7 +15,6 @@ derive-new = { workspace = true }
 encoding_rs = { workspace = true }
 flate2 = { workspace = true, features = ["zlib-rs"] }
 hashbrown = { workspace = true }
-glidesort = { workspace = true }
 image = { workspace = true, features = ["bmp", "jpeg", "png", "tga", "rayon"] }
 korangar_audio = { workspace = true }
 korangar_debug = { workspace = true, optional = true }

--- a/korangar/src/world/model/mod.rs
+++ b/korangar/src/world/model/mod.rs
@@ -37,7 +37,8 @@ impl Model {
     ) {
         self.root_nodes
             .iter()
-            .for_each(|node| node.render_geometry(instructions, transform, client_tick, camera));
+            .enumerate()
+            .for_each(|(node_index, node)| node.render_geometry(instructions, transform, client_tick, camera, node_index));
     }
 
     #[cfg(feature = "debug")]


### PR DESCRIPTION
Glidesort is actually unmaintained, since it's successor, driftsort, is now the current implementation in std. Since we don't want to allocate each sort/frame, we use unstable sort again. For models, we now remove the z-fighting by using a very small offset for each node in a model.

Entities might fight, but this is very rare and should not be discernible, by the normal "z-fighting" that occurs by the normal entity movement.