### PR TITLE
Fix the bottom facing point camera view

### DIFF
--- a/korangar/src/world/cameras/point_shadow.rs
+++ b/korangar/src/world/cameras/point_shadow.rs
@@ -35,7 +35,7 @@ impl PointShadowCamera {
             0 => (Vector3::unit_x(), Vector3::unit_y()),
             1 => (-Vector3::unit_x(), Vector3::unit_y()),
             2 => (Vector3::unit_y(), Vector3::unit_z()),
-            3 => (-Vector3::unit_y(), -Vector3::unit_z()),
+            3 => (-Vector3::unit_y(), Vector3::unit_z()),
             4 => (Vector3::unit_z(), Vector3::unit_y()),
             5 => (-Vector3::unit_z(), Vector3::unit_y()),
             _ => panic!(),


### PR DESCRIPTION
Fixes the following issue, where point shadows that are projected to the bottom are not rendered properly:

Before:
![grafik](https://github.com/user-attachments/assets/ee344d28-3e54-45d9-85f6-17faf354a213)

After:
![grafik](https://github.com/user-attachments/assets/5699fd0a-62f5-40dc-8013-7c7759e2dec0)
