### PR TITLE
Pre-notify winit that we present the next frame

### DIFF
--- a/korangar/src/graphics/engine.rs
+++ b/korangar/src/graphics/engine.rs
@@ -643,7 +643,7 @@ impl GraphicsEngine {
     }
 
     #[cfg_attr(feature = "debug", korangar_debug::profile)]
-    pub fn render_next_frame(&mut self, frame: SurfaceTexture, mut instruction: RenderInstruction) {
+    pub fn render_next_frame(&mut self, window: &Window, frame: SurfaceTexture, mut instruction: RenderInstruction) {
         assert!(instruction.point_light_shadow_caster.len() <= NUMBER_OF_POINT_LIGHTS_WITH_SHADOWS);
 
         self.sort_instructions(&mut instruction);
@@ -681,6 +681,7 @@ impl GraphicsEngine {
         );
 
         // Schedule the presentation of the frame.
+        window.pre_present_notify();
         frame.present();
 
         self.frame_pacer.end_frame_stage(self.cpu_stage, Instant::now());

--- a/korangar/src/main.rs
+++ b/korangar/src/main.rs
@@ -1921,6 +1921,8 @@ impl Client {
         #[cfg(feature = "debug")]
         loads_measurement.stop();
 
+        let window = self.window.as_ref().expect("window missing");
+
         // Main map update and render loop
         if let Some(map) = self.map.as_ref() {
             #[cfg(feature = "debug")]
@@ -2414,7 +2416,7 @@ impl Client {
                 marker: self.debug_marker_renderer.get_instructions(),
             };
 
-            self.graphics_engine.render_next_frame(frame, render_instruction);
+            self.graphics_engine.render_next_frame(window, frame, render_instruction);
 
             #[cfg(feature = "debug")]
             render_frame_measurement.stop();
@@ -2422,7 +2424,7 @@ impl Client {
             #[cfg(feature = "debug")]
             let render_frame_measurement = Profiler::start_measurement("render next frame");
 
-            self.graphics_engine.render_next_frame(frame, RenderInstruction::default());
+            self.graphics_engine.render_next_frame(window, frame, RenderInstruction::default());
 
             #[cfg(feature = "debug")]
             render_frame_measurement.stop();


### PR DESCRIPTION
This enables winit to reason about the internal state. For example, it can properly throttle WindowEvent::RedrawRequested under Wayland.