### PR TITLE
Fix broken ambient lights

### DIFF
--- a/korangar/src/world/map/lighting.rs
+++ b/korangar/src/world/map/lighting.rs
@@ -24,8 +24,17 @@ pub struct Lighting {
 
 impl Lighting {
     pub fn new(settings: LightSettings) -> Self {
+        let mut ambient_color: Color = settings.ambient_color.unwrap().into();
+
+        // Workaround for map files with broken ambient color, where the ambient light
+        // outshines shadows (for example "yuno").
+        if ambient_color == Color::WHITE {
+            // Ambient color values of "prontera".
+            ambient_color = Color::rgb(0.55, 0.5, 0.5);
+        }
+
         Self {
-            ambient_color: settings.ambient_color.unwrap().into(),
+            ambient_color,
             diffuse_color: settings.diffuse_color.unwrap().into(),
             light_latitude: settings.light_latitude.unwrap() as f32,
             light_longitude: settings.light_longitude.unwrap() as f32,


### PR DESCRIPTION
Some maps, like "yuno", have ambient lights that outshine all shadows. This workaround detect such cases and sets a saner value.