### PR TITLE
Implement texture atlas cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ target/
 # Korangar
 korangar/archive/data/font/*
 korangar/client/
+korangar/cache/
 korangar/data.grf
 korangar/rdata.grf
 korangar/lua_files/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,6 +313,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
 
 [[package]]
+name = "blake3"
+version = "1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8ee0c1824c4dea5b5f81736aff91bae041d2c07ee1192bec91054e10e3e601e"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,6 +549,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "core-foundation"
@@ -1150,6 +1169,7 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+ "serde",
 ]
 
 [[package]]
@@ -1606,6 +1626,7 @@ name = "korangar"
 version = "0.1.0"
 dependencies = [
  "arrayvec",
+ "blake3",
  "block_compression",
  "bumpalo",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = ["korangar", "ragnarok_*", "korangar_*"]
 [workspace.dependencies]
 arrayvec = "0.7"
 bitflags = "2"
+blake3 = { version = "1.5", default-features = true }
 block_compression = { version = "0.2", default-features = false }
 bumpalo = "3"
 bytemuck = "1"

--- a/korangar/Cargo.toml
+++ b/korangar/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 arrayvec = { workspace = true }
+blake3 = { workspace = true, features = ["std"] }
 block_compression = { workspace = true, features = ["bc7", "wgpu"] }
 bumpalo = { workspace = true, features = ["allocator_api"] }
 bytemuck = { workspace = true, features = ["derive", "extern_crate_std", "min_const_generics"] }
@@ -14,7 +15,7 @@ cosmic-text = { workspace = true, features = ["std", "fontconfig"] }
 derive-new = { workspace = true }
 encoding_rs = { workspace = true }
 flate2 = { workspace = true, features = ["zlib-rs"] }
-hashbrown = { workspace = true }
+hashbrown = { workspace = true, features = ["serde"] }
 image = { workspace = true, features = ["bmp", "jpeg", "png", "tga", "rayon"] }
 korangar_audio = { workspace = true }
 korangar_debug = { workspace = true, optional = true }

--- a/korangar/src/graphics/engine.rs
+++ b/korangar/src/graphics/engine.rs
@@ -17,7 +17,7 @@ use winit::window::Window;
 
 use super::{
     AntiAliasingResources, Capabilities, FramePacer, FrameStage, GlobalContext, LimitFramerate, Msaa, Prepare, PresentModeInfo,
-    ScreenSpaceAntiAliasing, ShadowDetail, Ssaa, Surface, TextureCompression, TextureSamplerType, RENDER_TO_TEXTURE_FORMAT,
+    ScreenSpaceAntiAliasing, ShadowDetail, Ssaa, Surface, TextureSamplerType, RENDER_TO_TEXTURE_FORMAT,
 };
 use crate::graphics::instruction::RenderInstruction;
 use crate::graphics::passes::*;
@@ -424,14 +424,6 @@ impl GraphicsEngine {
         }
 
         ssaa
-    }
-
-    pub fn check_texture_compression_requirements(&self, texture_compression: TextureCompression) -> TextureCompression {
-        if self.capabilities.supports_texture_compression() {
-            texture_compression
-        } else {
-            TextureCompression::Off
-        }
     }
 
     pub fn on_suspended(&mut self) {

--- a/korangar/src/graphics/settings.rs
+++ b/korangar/src/graphics/settings.rs
@@ -2,11 +2,9 @@ use std::fmt::{Display, Formatter};
 #[cfg(feature = "debug")]
 use std::num::NonZeroU32;
 
-use block_compression::{BC7Settings, CompressionVariant};
 #[cfg(feature = "debug")]
 use derive_new::new;
 use serde::{Deserialize, Serialize};
-use wgpu::TextureFormat;
 
 use crate::interface::layout::ScreenSize;
 
@@ -166,46 +164,6 @@ impl Display for ScreenSpaceAntiAliasing {
         match self {
             ScreenSpaceAntiAliasing::Off => "Off".fmt(f),
             ScreenSpaceAntiAliasing::Fxaa => "FXAA".fmt(f),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-pub enum TextureCompression {
-    Off,
-    UltraFast,
-    VeryFast,
-    Fast,
-    Normal,
-}
-
-impl TextureCompression {
-    pub fn is_uncompressed(&self) -> bool {
-        *self == TextureCompression::Off
-    }
-}
-
-impl From<TextureCompression> for TextureFormat {
-    fn from(value: TextureCompression) -> Self {
-        match value {
-            TextureCompression::Off => TextureFormat::Rgba8UnormSrgb,
-            TextureCompression::UltraFast | TextureCompression::VeryFast | TextureCompression::Fast | TextureCompression::Normal => {
-                TextureFormat::Bc7RgbaUnormSrgb
-            }
-        }
-    }
-}
-
-impl TryFrom<TextureCompression> for CompressionVariant {
-    type Error = ();
-
-    fn try_from(value: TextureCompression) -> Result<Self, Self::Error> {
-        match value {
-            TextureCompression::Off => Err(()),
-            TextureCompression::UltraFast => Ok(CompressionVariant::BC7(BC7Settings::alpha_ultrafast())),
-            TextureCompression::VeryFast => Ok(CompressionVariant::BC7(BC7Settings::alpha_very_fast())),
-            TextureCompression::Fast => Ok(CompressionVariant::BC7(BC7Settings::alpha_fast())),
-            TextureCompression::Normal => Ok(CompressionVariant::BC7(BC7Settings::alpha_basic())),
         }
     }
 }

--- a/korangar/src/interface/windows/settings/graphics.rs
+++ b/korangar/src/interface/windows/settings/graphics.rs
@@ -4,8 +4,7 @@ use korangar_interface::windows::{PrototypeWindow, Window, WindowBuilder};
 use korangar_interface::{dimension_bound, size_bound};
 
 use crate::graphics::{
-    LimitFramerate, Msaa, PresentModeInfo, ScreenSpaceAntiAliasing, ShadowDetail, ShadowQuality, Ssaa, TextureCompression,
-    TextureSamplerType,
+    LimitFramerate, Msaa, PresentModeInfo, ScreenSpaceAntiAliasing, ShadowDetail, ShadowQuality, Ssaa, TextureSamplerType,
 };
 use crate::interface::application::InterfaceSettings;
 use crate::interface::layout::ScreenSize;
@@ -24,7 +23,6 @@ pub struct GraphicsSettingsWindow<
     ShadowResolution,
     ShadowMode,
     HighQualityInterface,
-    Compression,
 > where
     LightingRenderMode: TrackedState<LightingMode> + 'static,
     Vsync: TrackedStateBinary<bool>,
@@ -37,7 +35,6 @@ pub struct GraphicsSettingsWindow<
     ShadowResolution: TrackedState<ShadowDetail> + 'static,
     ShadowMode: TrackedState<ShadowQuality> + 'static,
     HighQualityInterface: TrackedStateBinary<bool>,
-    Compression: TrackedState<TextureCompression> + 'static,
 {
     present_mode_info: PresentModeInfo,
     supported_msaa: Vec<(String, Msaa)>,
@@ -52,7 +49,6 @@ pub struct GraphicsSettingsWindow<
     shadow_detail: ShadowResolution,
     shadow_quality: ShadowMode,
     high_quality_interface: HighQualityInterface,
-    texture_compression: Compression,
 }
 
 impl<
@@ -67,7 +63,6 @@ impl<
         ShadowResolution,
         ShadowMode,
         HighQualityInterface,
-        Compression,
     >
     GraphicsSettingsWindow<
         LightingRenderMode,
@@ -81,7 +76,6 @@ impl<
         ShadowResolution,
         ShadowMode,
         HighQualityInterface,
-        Compression,
     >
 where
     LightingRenderMode: TrackedState<LightingMode> + 'static,
@@ -95,7 +89,6 @@ where
     ShadowResolution: TrackedState<ShadowDetail> + 'static,
     ShadowMode: TrackedState<ShadowQuality> + 'static,
     HighQualityInterface: TrackedStateBinary<bool>,
-    Compression: TrackedState<TextureCompression> + 'static,
 {
     pub const WINDOW_CLASS: &'static str = "graphics_settings";
 
@@ -113,7 +106,6 @@ where
         shadow_detail: ShadowResolution,
         shadow_quality: ShadowMode,
         high_quality_interface: HighQualityInterface,
-        texture_compression: Compression,
     ) -> Self {
         Self {
             present_mode_info,
@@ -129,7 +121,6 @@ where
             shadow_detail,
             shadow_quality,
             high_quality_interface,
-            texture_compression,
         }
     }
 }
@@ -146,7 +137,6 @@ impl<
         ShadowResolution,
         ShadowMode,
         HighQualityInterface,
-        Compression,
     > PrototypeWindow<InterfaceSettings>
     for GraphicsSettingsWindow<
         LightingRenderMode,
@@ -160,7 +150,6 @@ impl<
         ShadowResolution,
         ShadowMode,
         HighQualityInterface,
-        Compression,
     >
 where
     LightingRenderMode: TrackedState<LightingMode> + 'static,
@@ -174,7 +163,6 @@ where
     ShadowResolution: TrackedState<ShadowDetail> + 'static,
     ShadowMode: TrackedState<ShadowQuality> + 'static,
     HighQualityInterface: TrackedStateBinary<bool>,
-    Compression: TrackedState<TextureCompression> + 'static,
 {
     fn window_class(&self) -> Option<&str> {
         Self::WINDOW_CLASS.into()
@@ -213,22 +201,6 @@ where
                     ("Anisotropic x16", TextureSamplerType::Anisotropic(16)),
                 ])
                 .with_selected(self.texture_filtering.clone())
-                .with_event(Box::new(Vec::new))
-                .with_width(dimension_bound!(!))
-                .wrap(),
-            Text::default()
-                .with_text("Texture compression")
-                .with_width(dimension_bound!(50%))
-                .wrap(),
-            PickList::default()
-                .with_options(vec![
-                    ("Off", TextureCompression::Off),
-                    ("Ultra Fast", TextureCompression::UltraFast),
-                    ("Very Fast", TextureCompression::VeryFast),
-                    ("Fast", TextureCompression::Fast),
-                    ("Normal", TextureCompression::Normal),
-                ])
-                .with_selected(self.texture_compression.clone())
                 .with_event(Box::new(Vec::new))
                 .with_width(dimension_bound!(!))
                 .wrap(),

--- a/korangar/src/loaders/archive/native/builder.rs
+++ b/korangar/src/loaders/archive/native/builder.rs
@@ -1,88 +1,138 @@
-//! Implements a writable instance of a GRF File
+//! Implements a writable instance of a GRF File.
+//!
 //! This way, we can provide a temporal storage to files before the final write
 //! occurs while keeping it outside the
 //! [`NativeArchive`](super::NativeArchive) implementation
 
-use std::io::Read;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
 use flate2::bufread::ZlibEncoder;
 use flate2::Compression;
-use ragnarok_bytes::ToBytes;
+use ragnarok_bytes::{FixedByteSize, ToBytes};
 use ragnarok_formats::archive::{AssetTable, FileTableRow, Header};
 
 use super::FileTable;
 use crate::loaders::archive::Writable;
 
+struct FileTableEntry {
+    path: String,
+    compress: bool,
+    asset_data: Vec<u8>,
+}
+
 pub struct NativeArchiveBuilder {
     os_file_path: PathBuf,
-    file_table: FileTable,
-    data: Vec<u8>,
+    archive_entries: Vec<FileTableEntry>,
 }
 
 impl NativeArchiveBuilder {
     pub fn from_path(path: &Path) -> Self {
         Self {
             os_file_path: PathBuf::from(path),
-            file_table: FileTable::new(),
-            data: Vec::new(),
+            archive_entries: Vec::new(),
         }
     }
 }
 
 impl Writable for NativeArchiveBuilder {
-    fn add_file(&mut self, path: &str, asset: Vec<u8>) {
-        let mut encoder = ZlibEncoder::new(asset.as_slice(), Compression::default());
-        let mut compressed = Vec::default();
-        encoder.read_to_end(&mut compressed).expect("can't compress asset");
-
-        let compressed_size = compressed.len() as u32;
-        let compressed_size_aligned = compressed_size;
-        let uncompressed_size = asset.len() as u32;
-        let flags = 1;
-        let offset = self.data.len() as u32;
-
-        let file_information = FileTableRow {
-            file_name: String::from(path),
-            compressed_size,
-            compressed_size_aligned,
-            uncompressed_size,
-            flags,
-            offset,
-        };
-
-        self.data.extend_from_slice(&compressed);
-        self.file_table.insert(String::from(path), file_information);
+    fn add_file(&mut self, path: &str, asset_data: Vec<u8>, compress: bool) {
+        self.archive_entries.push(FileTableEntry {
+            path: path.to_string(),
+            compress,
+            asset_data,
+        });
     }
 
-    fn save(&self) {
-        let file_table_offset = self.data.len() as u32;
-        let reserved_files = 0;
-        let raw_file_count = self.file_table.len() as u32 + 7;
-        let version = 0x200;
-        let file_header = Header::new(file_table_offset, reserved_files, raw_file_count, version);
+    fn finish(&mut self) -> Result<(), std::io::Error> {
+        let file = File::create(self.os_file_path.as_path())?;
+        let mut file_writer = BufWriter::new(file);
+        let mut file_table = FileTable::new();
 
-        let mut bytes = file_header.to_bytes().unwrap();
-        bytes.extend_from_slice(&self.data);
+        let dummy_header_bytes = vec![0; Header::size_in_bytes()];
+        file_writer.write_all(&dummy_header_bytes)?;
+
+        let mut offset = 0;
+
+        for entry in self.archive_entries.drain(..) {
+            add_asset_to_file_table(
+                &mut file_writer,
+                &mut offset,
+                &mut file_table,
+                &entry.path,
+                entry.asset_data,
+                entry.compress,
+            );
+        }
 
         let mut file_table_data = Vec::new();
 
-        for file_information in self.file_table.values() {
+        for file_information in file_table.values() {
             file_table_data.extend(file_information.to_bytes().unwrap());
         }
 
-        let mut encoder = ZlibEncoder::new(file_table_data.as_slice(), Compression::default());
+        let mut encoder = ZlibEncoder::new(file_table_data.as_slice(), Compression::fast());
         let mut compressed = Vec::default();
-        encoder.read_to_end(&mut compressed).expect("can't compress file information");
+        encoder.read_to_end(&mut compressed)?;
 
-        let file_table = AssetTable {
+        let asset_table = AssetTable {
             compressed_size: compressed.len() as u32,
             uncompressed_size: file_table_data.len() as u32,
         };
 
-        bytes.extend(file_table.to_bytes().unwrap());
-        bytes.extend(compressed);
+        let file_table_bytes = asset_table.to_bytes().unwrap();
+        file_writer.write_all(&file_table_bytes)?;
+        file_writer.write_all(&compressed)?;
 
-        std::fs::write(&self.os_file_path, bytes).expect("unable to write file");
+        let reserved_files = 0;
+        let raw_file_count = file_table.len() as u32 + 7;
+        let version = 0x200;
+        let file_header_bytes = Header::new(offset, reserved_files, raw_file_count, version).to_bytes().unwrap();
+
+        file_writer.seek(SeekFrom::Start(0))?;
+        file_writer.write_all(&file_header_bytes)?;
+        file_writer.flush()?;
+
+        Ok(())
     }
+}
+
+fn add_asset_to_file_table(
+    file_writer: &mut BufWriter<File>,
+    offset: &mut u32,
+    file_table: &mut HashMap<String, FileTableRow>,
+    path: &str,
+    data: Vec<u8>,
+    compress: bool,
+) {
+    let uncompressed_size = data.len() as u32;
+
+    let data = match compress {
+        true => {
+            let mut encoder = ZlibEncoder::new(data.as_slice(), Compression::fast());
+            let mut compressed = Vec::default();
+            encoder.read_to_end(&mut compressed).expect("can't compress asset data");
+            compressed
+        }
+        false => data,
+    };
+
+    let compressed_size = data.len() as u32;
+    let compressed_size_aligned = compressed_size;
+    let flags = 1;
+
+    let file_information = FileTableRow {
+        file_name: path.to_string(),
+        compressed_size,
+        compressed_size_aligned,
+        uncompressed_size,
+        flags,
+        offset: *offset,
+    };
+    *offset = offset.checked_add(data.len() as u32).expect("offset overflow");
+
+    file_table.insert(path.to_string(), file_information);
+    file_writer.write_all(&data).unwrap()
 }

--- a/korangar/src/loaders/cache/format.rs
+++ b/korangar/src/loaders/cache/format.rs
@@ -1,0 +1,62 @@
+use cgmath::Point2;
+use ragnarok_bytes::{FromBytes, ToBytes};
+use ragnarok_formats::signature::Signature;
+use ragnarok_formats::version::{MajorFirst, Version};
+
+#[derive(ToBytes, FromBytes)]
+pub struct TextureAtlasData {
+    /// Korangar Texture Atlas
+    #[new_default]
+    pub signature: Signature<b"kta">,
+    /// Version of the texture atlas data.
+    #[version]
+    pub version: Version<MajorFirst>,
+    /// THe name of the texture atlas.
+    pub name: String,
+    /// Format of the compressed data. Currently only "0" is allowed and means
+    /// "BC7".
+    pub format: u32,
+    /// Width of the texture atlas in pixel.
+    pub width: u32,
+    /// Height of the texture atlas in pixel.
+    pub height: u32,
+    /// The mips level count. When no mips are present, then count must be 1.
+    pub mipmaps_count: u32,
+    /// The hash of the input textures (sorted by asset name).
+    pub hash: [u8; 32],
+    /// Number of lookup entries.
+    #[new_derive]
+    pub lookup_count: u32,
+    /// Texture lookup entries.
+    #[repeating(lookup_count)]
+    pub lookup: Vec<LookupEntry>,
+    /// Number of allocation entries.
+    #[new_derive]
+    pub allocations_count: u32,
+    /// Texture atlas allocations.
+    #[repeating(allocations_count)]
+    pub allocations: Vec<AllocationEntry>,
+    /// The size of the compressed data following.
+    pub compressed_data_size: u32,
+}
+
+#[derive(ToBytes, FromBytes)]
+pub struct LookupEntry {
+    /// The name of the asset texture.
+    pub name: String,
+    /// The ID of the allocation for this texture.
+    pub allocation_id: u32,
+    /// Marker if the texture contains pixel with an alpha value that is not
+    /// 255.
+    pub transparent: u32,
+}
+
+#[derive(ToBytes, FromBytes)]
+pub struct AllocationEntry {
+    /// ID of the allocation.
+    pub id: u32,
+    /// Min point of the position of the texture inside the atlas.
+    pub min: Point2<u32>,
+    /// Max point of the position of the texture inside the atlas.
+    pub max: Point2<u32>,
+}

--- a/korangar/src/loaders/cache/mod.rs
+++ b/korangar/src/loaders/cache/mod.rs
@@ -1,0 +1,336 @@
+mod format;
+
+use std::path::Path;
+use std::sync::Arc;
+
+use blake3::Hash;
+use cgmath::Vector2;
+use encoding_rs::UTF_8;
+use hashbrown::{HashMap, HashSet};
+#[cfg(feature = "debug")]
+use korangar_debug::logging::{print_debug, Colorize, Timer};
+use korangar_util::container::{SecondarySimpleSlab, SimpleKey};
+use korangar_util::texture_atlas::{AllocationId, AtlasAllocation};
+use korangar_util::Rectangle;
+use ragnarok_bytes::{ByteReader, ConversionResult, ConversionResultExt, FromBytes, ToBytes};
+use ragnarok_formats::signature::Signature;
+use ragnarok_formats::version::{InternalVersion, MajorFirst, Version};
+
+use crate::loaders::archive::folder::FolderArchive;
+use crate::loaders::archive::{os_specific_path, Archive, Writable};
+use crate::loaders::cache::format::{AllocationEntry, LookupEntry, TextureAtlasData};
+use crate::loaders::{GameFileLoader, MapLoader, ModelLoader, TextureAtlas, TextureAtlasEntry, TextureLoader, UncompressedTextureAtlas};
+
+const HASH_FILE_PATH: &str = "game_file_hash.txt";
+const CACHE_PATH_NAME: &str = "cache";
+const MAP_FILE_EXTENSION: &str = ".rsw";
+const ATLAS_FILE_EXTENSION: &str = ".kta";
+
+pub struct Cache {
+    archive: Option<Box<dyn Archive>>,
+    texture_compression_supported: bool,
+}
+
+impl Cache {
+    pub fn new(
+        game_file_loader: &GameFileLoader,
+        texture_loader: Arc<TextureLoader>,
+        map_loader: &MapLoader,
+        model_loader: &ModelLoader,
+        game_file_hash: Hash,
+        texture_compression_supported: bool,
+        sync_cache: bool,
+    ) -> Self {
+        let archive = match sync_cache {
+            true => Self::sync_cache_archive(game_file_loader, texture_loader, map_loader, model_loader, game_file_hash),
+            false => Self::get_cache_archive(game_file_hash),
+        };
+
+        Self {
+            archive,
+            texture_compression_supported,
+        }
+    }
+
+    #[allow(unused_variables)]
+    fn get_cache_archive(game_file_hash: Hash) -> Option<Box<dyn Archive>> {
+        let folder_path = Path::new(CACHE_PATH_NAME);
+
+        if !folder_path.exists() && !folder_path.is_dir() {
+            return None;
+        }
+
+        let folder_archive = Box::new(FolderArchive::from_path(folder_path));
+
+        let Some(hash_file) = folder_archive.get_file_by_path(HASH_FILE_PATH) else {
+            #[cfg(feature = "debug")]
+            print_debug!("Can't find game hash file. Using empty cache");
+            return None;
+        };
+        let Ok(_hash) = Hash::from_hex(hash_file) else {
+            #[cfg(feature = "debug")]
+            print_debug!("Can't read game hash file. Using empty cache");
+            return None;
+        };
+
+        #[cfg(feature = "debug")]
+        if _hash != game_file_hash {
+            print_debug!("[{}] Cache is out of sync. Please re-sync or delete the cache", "error".red());
+        }
+
+        Some(folder_archive)
+    }
+
+    fn sync_cache_archive(
+        game_file_loader: &GameFileLoader,
+        texture_loader: Arc<TextureLoader>,
+        map_loader: &MapLoader,
+        model_loader: &ModelLoader,
+        game_file_hash: Hash,
+    ) -> Option<Box<dyn Archive>> {
+        println!("Starting sync of cache");
+
+        let folder_path = Path::new(CACHE_PATH_NAME);
+
+        let mut folder_archive = Box::new(FolderArchive::from_path(folder_path));
+
+        let mut cached_texture_atlas_paths = Vec::new();
+        folder_archive.get_files_with_extension(&mut cached_texture_atlas_paths, ATLAS_FILE_EXTENSION);
+
+        let cached_texture_atlas_paths: HashSet<String> = HashSet::from_iter(cached_texture_atlas_paths.iter().map(|map_file_path| {
+            let os_path = os_specific_path(map_file_path);
+            os_path.file_stem().unwrap().to_string_lossy().to_string()
+        }));
+
+        let mut game_file_map_names: Vec<String> = game_file_loader
+            .get_files_with_extension(MAP_FILE_EXTENSION)
+            .iter()
+            .map(|map_file_path| {
+                let os_path = os_specific_path(map_file_path);
+                os_path.file_stem().unwrap().to_string_lossy().to_string()
+            })
+            .collect();
+        game_file_map_names.sort();
+
+        let unused_map_atlas_names: HashSet<String> = cached_texture_atlas_paths
+            .difference(&HashSet::from_iter(game_file_map_names.iter().cloned()))
+            .cloned()
+            .collect();
+
+        let mut outdated_map_names = HashSet::new();
+        let mut new_map_names = HashSet::new();
+
+        for map_name in game_file_map_names.iter() {
+            let atlas_path = Self::get_texture_atlas_cache_base_path(map_name);
+
+            if let Some(atlas_data) = folder_archive.get_file_by_path(&atlas_path) {
+                #[cfg(feature = "debug")]
+                print_debug!("Checking texture atlas for map `{}`", map_name);
+
+                let mut byte_reader: ByteReader<Option<InternalVersion>> = ByteReader::with_default_metadata(&atlas_data);
+                byte_reader.set_encoding(UTF_8);
+
+                if let Ok(cached_atlas) = CachedTextureAtlas::from_bytes(&mut byte_reader) {
+                    if let Ok(textures) = map_loader.collect_map_textures(model_loader, map_name) {
+                        let texture_atlas = Self::create_texture_atlas(texture_loader.clone(), map_name, textures);
+
+                        if texture_atlas.hash() != cached_atlas.hash {
+                            #[cfg(feature = "debug")]
+                            print_debug!("Outdated texture atlas found for map: `{}`", map_name.magenta());
+
+                            outdated_map_names.insert(map_name);
+                        }
+                    }
+                }
+            } else {
+                new_map_names.insert(map_name);
+            }
+        }
+
+        let mut created_count = 0;
+        let mut removed_count = 0;
+        let mut updated_count = 0;
+        let mut error_count = 0;
+
+        for map_name in unused_map_atlas_names.iter() {
+            let atlas_path = Self::get_texture_atlas_cache_base_path(map_name);
+
+            #[cfg(feature = "debug")]
+            print_debug!("Deleting unused texture atlas file `{}`", atlas_path.magenta());
+
+            folder_archive.remove_file(&atlas_path);
+
+            removed_count += 1;
+        }
+
+        for map_name in outdated_map_names.union(&new_map_names) {
+            #[cfg(feature = "debug")]
+            print_debug!("Re-creating texture atlas for map `{}`", map_name.magenta());
+
+            match map_loader.collect_map_textures(model_loader, map_name) {
+                Ok(textures) => {
+                    let texture_atlas = Self::create_texture_atlas(texture_loader.clone(), map_name, textures);
+
+                    if let Ok(data) = texture_atlas.to_cached_texture_atlas().to_bytes() {
+                        let atlas_path = Self::get_texture_atlas_cache_base_path(map_name);
+                        folder_archive.add_file(&atlas_path, data, true);
+
+                        match outdated_map_names.contains(map_name) {
+                            true => updated_count += 1,
+                            false => created_count += 1,
+                        }
+                    }
+                }
+                Err(_error) => {
+                    #[cfg(feature = "debug")]
+                    print_debug!(
+                        "[{}] Can't create texture atlas for map `{}`: {:?}",
+                        "error".red(),
+                        map_name.magenta(),
+                        _error
+                    );
+                    error_count += 1;
+                }
+            }
+        }
+
+        folder_archive.add_file(HASH_FILE_PATH, game_file_hash.to_hex().as_bytes().to_vec(), false);
+
+        println!(
+            "Cache sync finished. Created: {} Removed: {} Updated: {} Errors: {}",
+            created_count, removed_count, updated_count, error_count
+        );
+
+        Some(folder_archive)
+    }
+
+    fn create_texture_atlas(texture_loader: Arc<TextureLoader>, map_name: &str, textures: HashSet<String>) -> UncompressedTextureAtlas {
+        let mut textures: Vec<String> = textures.into_iter().collect();
+        textures.sort();
+
+        let mut texture_atlas = UncompressedTextureAtlas::new(texture_loader, map_name.to_string(), true, true, true);
+        textures.iter().for_each(|texture| {
+            let _ = texture_atlas.register(texture);
+        });
+        texture_atlas.build_atlas();
+
+        texture_atlas
+    }
+
+    fn get_texture_atlas_cache_base_path(name: &str) -> String {
+        format!("atlas\\{}.kta", name,)
+    }
+
+    pub fn load_texture_atlas(&self, name: &str) -> Option<CachedTextureAtlas> {
+        // Cached textures can only be used, if the graphics card supports BC texture
+        // compression (desktop class GPUs have nearly 100% support for it, including
+        // M1+ GPUs).
+        if !self.texture_compression_supported {
+            return None;
+        }
+
+        self.archive.as_ref().and_then(|archive| {
+            #[cfg(feature = "debug")]
+            let _timer = Timer::new_dynamic(format!("load cached texture atlas for {}", name.magenta()));
+
+            let data_path = Self::get_texture_atlas_cache_base_path(name);
+            let data = archive.get_file_by_path(&data_path)?;
+
+            let mut byte_reader: ByteReader<Option<InternalVersion>> = ByteReader::with_default_metadata(&data);
+            byte_reader.set_encoding(UTF_8);
+            let cached_atlas = CachedTextureAtlas::from_bytes(&mut byte_reader).ok()?;
+
+            Some(cached_atlas)
+        })
+    }
+}
+
+pub struct CachedTextureAtlas {
+    pub hash: Hash,
+    pub name: String,
+    pub width: u32,
+    pub height: u32,
+    pub mipmaps_count: u32,
+    pub transparent: bool,
+    pub lookup: HashMap<String, TextureAtlasEntry>,
+    pub allocations: SecondarySimpleSlab<AllocationId, AtlasAllocation>,
+    pub compressed_data: Vec<u8>,
+}
+
+impl FromBytes for CachedTextureAtlas {
+    fn from_bytes<Meta>(byte_reader: &mut ByteReader<Meta>) -> ConversionResult<Self> {
+        let mut atlas_data = TextureAtlasData::from_bytes(byte_reader).trace::<Self>()?;
+
+        let transparent = atlas_data.lookup.iter().any(|entry| entry.transparent != 0);
+
+        let mut lookup = HashMap::with_capacity(atlas_data.lookup.len());
+        atlas_data.lookup.drain(..).for_each(|entry| {
+            lookup.insert(entry.name, TextureAtlasEntry {
+                allocation_id: AllocationId::new(entry.allocation_id),
+                transparent: entry.transparent != 0,
+            });
+        });
+
+        let mut allocations = SecondarySimpleSlab::with_capacity(atlas_data.allocations.len() as _);
+
+        // It's faster to insert last to front, since we can then allocate all empty
+        // slots right from the start.
+        atlas_data.allocations.sort_by(|a, b| b.id.cmp(&a.id));
+
+        atlas_data.allocations.drain(..).for_each(|entry| {
+            allocations.insert(AllocationId::new(entry.id), AtlasAllocation {
+                rectangle: Rectangle::new(entry.min, entry.max),
+                atlas_size: Vector2::new(atlas_data.width, atlas_data.height),
+            });
+        });
+
+        let compressed_data = byte_reader.slice::<u8>(atlas_data.compressed_data_size as usize)?.to_vec();
+
+        Ok(CachedTextureAtlas {
+            hash: Hash::from_bytes(atlas_data.hash),
+            name: atlas_data.name,
+            width: atlas_data.width,
+            height: atlas_data.height,
+            mipmaps_count: atlas_data.mipmaps_count,
+            transparent,
+            compressed_data,
+            lookup,
+            allocations,
+        })
+    }
+}
+
+impl ToBytes for CachedTextureAtlas {
+    fn to_bytes(&self) -> ConversionResult<Vec<u8>> {
+        let lookup = Vec::from_iter(self.lookup.iter().map(|(name, atlas_entry)| LookupEntry {
+            name: name.clone(),
+            allocation_id: atlas_entry.allocation_id.key(),
+            transparent: u32::from(atlas_entry.transparent),
+        }));
+        let allocations = Vec::from_iter(self.allocations.iter().map(|(id, atlas_allocation)| AllocationEntry {
+            id: id.key(),
+            min: atlas_allocation.rectangle.min,
+            max: atlas_allocation.rectangle.max,
+        }));
+        let atlas_data = TextureAtlasData {
+            signature: Signature::<b"kta">,
+            version: Version::<MajorFirst>::new(1, 0),
+            name: self.name.clone(),
+            format: 0,
+            width: self.width,
+            height: self.height,
+            mipmaps_count: self.mipmaps_count,
+            hash: *self.hash.as_bytes(),
+            lookup_count: u32::try_from(lookup.len()).expect("lookup_count bigger than u32::MAX"),
+            lookup,
+            allocations_count: u32::try_from(allocations.len()).expect("allocations_count bigger than u32::MAX"),
+            allocations,
+            compressed_data_size: u32::try_from(self.compressed_data.len()).expect("compressed_data_size bigger than u32::MAX"),
+        };
+
+        let mut bytes = atlas_data.to_bytes().trace::<Self>()?;
+        bytes.extend(&self.compressed_data);
+
+        Ok(bytes)
+    }
+}

--- a/korangar/src/loaders/font/font_file.rs
+++ b/korangar/src/loaders/font/font_file.rs
@@ -1,9 +1,8 @@
-use std::io::{Cursor, Read};
+use std::io::Cursor;
 use std::sync::Arc;
 
 use cosmic_text::fontdb::{Source, ID};
 use cosmic_text::FontSystem;
-use flate2::bufread::GzDecoder;
 use hashbrown::HashMap;
 use image::{ImageFormat, ImageReader, RgbaImage};
 #[cfg(feature = "debug")]
@@ -30,7 +29,7 @@ impl FontFile {
         let font_base_path = format!("{}\\{}", FONT_FOLDER_PATH, name);
         let ttf_file_path = format!("{}.ttf", font_base_path);
         let map_file_path = format!("{}.png", font_base_path);
-        let map_description_file_path = format!("{}.csv.gz", font_base_path);
+        let map_description_file_path = format!("{}.csv", font_base_path);
 
         let Ok(font_data) = game_file_loader.get(&ttf_file_path) else {
             #[cfg(feature = "debug")]
@@ -58,7 +57,7 @@ impl FontFile {
         let font_map_width = font_map_rgba_image.width();
         let font_map_height = font_map_rgba_image.height();
 
-        let Ok(mut font_description_data) = game_file_loader.get(&map_description_file_path) else {
+        let Ok(font_description_data) = game_file_loader.get(&map_description_file_path) else {
             #[cfg(feature = "debug")]
             print_debug!(
                 "[{}] failed to load font map description file '{}'",
@@ -67,22 +66,6 @@ impl FontFile {
             );
             return None;
         };
-
-        let mut decoder = GzDecoder::new(&font_description_data[..]);
-        let mut data = Vec::with_capacity(font_description_data.len() * 2);
-
-        if let Err(_err) = decoder.read_to_end(&mut data) {
-            #[cfg(feature = "debug")]
-            print_debug!(
-                "[{}] failed to decompress font map description file '{}': {:?}",
-                "error".red(),
-                map_description_file_path.magenta(),
-                _err
-            );
-            return None;
-        }
-
-        font_description_data = data;
 
         let Ok(font_description_content) = String::from_utf8(font_description_data) else {
             #[cfg(feature = "debug")]

--- a/korangar/src/loaders/mod.rs
+++ b/korangar/src/loaders/mod.rs
@@ -3,6 +3,7 @@ mod animation;
 mod archive;
 
 mod r#async;
+mod cache;
 mod effect;
 pub mod error;
 mod font;
@@ -16,6 +17,7 @@ mod texture;
 
 pub use self::action::*;
 pub use self::animation::*;
+pub use self::cache::{Cache, CachedTextureAtlas};
 pub use self::effect::EffectLoader;
 pub use self::font::{FontLoader, FontSize, GlyphInstruction, Scaling};
 pub use self::gamefile::*;
@@ -25,7 +27,7 @@ pub use self::r#async::*;
 pub use self::server::{load_client_info, ClientInfo, ServiceId};
 pub use self::smoothing::{smooth_ground_normals, smooth_model_normals};
 pub use self::sprite::*;
-pub use self::texture::{ImageType, TextureAtlasFactory, TextureLoader};
+pub use self::texture::{ImageType, TextureAtlas, TextureAtlasEntry, TextureLoader, UncompressedTextureAtlas};
 
 pub const FALLBACK_BMP_FILE: &str = "missing.bmp";
 pub const FALLBACK_JPEG_FILE: &str = "missing.jpg";

--- a/korangar/src/settings/graphic.rs
+++ b/korangar/src/settings/graphic.rs
@@ -3,9 +3,7 @@ use korangar_debug::logging::{print_debug, Colorize};
 use ron::ser::PrettyConfig;
 use serde::{Deserialize, Serialize};
 
-use crate::graphics::{
-    LimitFramerate, Msaa, ScreenSpaceAntiAliasing, ShadowDetail, ShadowQuality, Ssaa, TextureCompression, TextureSamplerType,
-};
+use crate::graphics::{LimitFramerate, Msaa, ScreenSpaceAntiAliasing, ShadowDetail, ShadowQuality, Ssaa, TextureSamplerType};
 
 #[derive(Serialize, Deserialize)]
 pub struct GraphicsSettings {
@@ -20,7 +18,6 @@ pub struct GraphicsSettings {
     pub shadow_detail: ShadowDetail,
     pub shadow_quality: ShadowQuality,
     pub high_quality_interface: bool,
-    pub texture_compression: TextureCompression,
 }
 
 impl Default for GraphicsSettings {
@@ -37,7 +34,6 @@ impl Default for GraphicsSettings {
             shadow_detail: ShadowDetail::Normal,
             shadow_quality: ShadowQuality::SoftPCSSx16,
             high_quality_interface: true,
-            texture_compression: TextureCompression::Off,
         }
     }
 }

--- a/korangar/src/world/map/mod.rs
+++ b/korangar/src/world/map/mod.rs
@@ -66,7 +66,6 @@ impl MarkerIdentifier {
 
 #[derive(new)]
 pub struct Map {
-    resource_file: String,
     width: usize,
     height: usize,
     lighting: Lighting,
@@ -96,10 +95,6 @@ pub struct Map {
 impl Map {
     pub fn water_bounds(&self) -> Rectangle<f32> {
         self.water_bounds
-    }
-
-    pub fn get_resource_file(&self) -> &str {
-        &self.resource_file
     }
 
     fn average_tile_height(tile: &Tile) -> f32 {

--- a/korangar_util/src/texture_atlas/offline.rs
+++ b/korangar_util/src/texture_atlas/offline.rs
@@ -122,10 +122,15 @@ impl OfflineTextureAtlas {
         self.allocations.get(allocation_id).copied()
     }
 
+    /// Returns all allocations.
+    pub fn get_allocations(&self) -> SecondarySimpleSlab<AllocationId, AtlasAllocation> {
+        self.allocations.clone()
+    }
+
     /// Builds the atlas with the optimal atlas size.
     pub fn build_atlas(&mut self) {
         if self.image.is_some() {
-            panic!("atlas is already build");
+            return;
         }
 
         let mut deferred_allocations: Vec<(AllocationId, DeferredAllocation)> = self.deferred_allocation.drain().collect();
@@ -297,7 +302,7 @@ impl OfflineTextureAtlas {
     }
 
     /// Returns the bytes of the underlying image buffer.
-    pub fn get_atlas(mut self) -> RgbaImage {
+    pub fn get_atlas(&mut self) -> RgbaImage {
         self.image.take().expect("the atlas has not been build yet")
     }
 

--- a/korangar_util/src/texture_atlas/online.rs
+++ b/korangar_util/src/texture_atlas/online.rs
@@ -1,5 +1,4 @@
 //! A simple texture atlas for online generation.
-
 use cgmath::{Point2, Vector2};
 
 use super::AtlasAllocation;

--- a/ragnarok_bytes/src/from_bytes/implement.rs
+++ b/ragnarok_bytes/src/from_bytes/implement.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "cgmath")]
-use cgmath::{Matrix3, Point3, Quaternion, Vector2, Vector3, Vector4};
+use cgmath::{Matrix3, Point2, Point3, Quaternion, Vector2, Vector3, Vector4};
 
 use crate::{ByteReader, ConversionResult, ConversionResultExt, FromBytes};
 
@@ -121,6 +121,16 @@ impl<T: FromBytes> FromBytes for Vector4<T> {
         let fourth = T::from_bytes(byte_reader).trace::<Self>()?;
 
         Ok(Vector4::new(first, second, third, fourth))
+    }
+}
+
+#[cfg(feature = "cgmath")]
+impl<T: FromBytes> FromBytes for Point2<T> {
+    fn from_bytes<Meta>(byte_reader: &mut ByteReader<Meta>) -> ConversionResult<Self> {
+        let first = T::from_bytes(byte_reader).trace::<Self>()?;
+        let second = T::from_bytes(byte_reader).trace::<Self>()?;
+
+        Ok(Point2::new(first, second))
     }
 }
 

--- a/ragnarok_bytes/src/to_bytes/implement.rs
+++ b/ragnarok_bytes/src/to_bytes/implement.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "cgmath")]
-use cgmath::{Matrix3, Point3, Quaternion, Vector2, Vector3, Vector4};
+use cgmath::{Matrix3, Point2, Point3, Quaternion, Vector2, Vector3, Vector4};
 
 use crate::{ConversionResult, ConversionResultExt, ToBytes};
 
@@ -117,6 +117,16 @@ impl<T: ToBytes> ToBytes for Vector4<T> {
         bytes.append(&mut self.y.to_bytes().trace::<Self>()?);
         bytes.append(&mut self.z.to_bytes().trace::<Self>()?);
         bytes.append(&mut self.w.to_bytes().trace::<Self>()?);
+        Ok(bytes)
+    }
+}
+
+#[cfg(feature = "cgmath")]
+impl<T: ToBytes> ToBytes for Point2<T> {
+    fn to_bytes(&self) -> ConversionResult<Vec<u8>> {
+        let mut bytes = self.x.to_bytes().trace::<Self>()?;
+        bytes.append(&mut self.y.to_bytes().trace::<Self>()?);
+
         Ok(bytes)
     }
 }

--- a/ragnarok_formats/src/version.rs
+++ b/ragnarok_formats/src/version.rs
@@ -16,6 +16,16 @@ pub struct Version<T> {
     phantom_data: PhantomData<T>,
 }
 
+impl<T> Version<T> {
+    pub fn new(major: u8, minor: u8) -> Self {
+        Self {
+            major,
+            minor,
+            phantom_data: PhantomData,
+        }
+    }
+}
+
 impl FromBytes for Version<MajorFirst> {
     fn from_bytes<Meta>(byte_reader: &mut ByteReader<Meta>) -> ConversionResult<Self> {
         let major = byte_reader.byte::<Self>()?;


### PR DESCRIPTION
The cache can be generated by calling korangar with "sync-cache". It takes around 15 to 60 minutes for the first run. If the game files are updated, the cache can be re-synched by calling korangar with "sync-cache" again, which will then only takes around 3 minutes to check all texture atlases. We use blake3 for our checksums, since it's extremely fast.