### PR TITLE
Enable wayland to render frames uncapped

### DIFF
--- a/korangar/src/graphics/engine.rs
+++ b/korangar/src/graphics/engine.rs
@@ -639,7 +639,7 @@ impl GraphicsEngine {
     }
 
     #[cfg_attr(feature = "debug", korangar_debug::profile)]
-    pub fn render_next_frame(&mut self, window: &Window, frame: SurfaceTexture, mut instruction: RenderInstruction) {
+    pub fn render_next_frame(&mut self, frame: SurfaceTexture, mut instruction: RenderInstruction) {
         assert!(instruction.point_light_shadow_caster.len() <= NUMBER_OF_POINT_LIGHTS_WITH_SHADOWS);
 
         self.sort_instructions(&mut instruction);
@@ -677,7 +677,9 @@ impl GraphicsEngine {
         );
 
         // Schedule the presentation of the frame.
-        window.pre_present_notify();
+        // We do not call `Windows::pre_present_notify()` here, since it will force a
+        // framerate limit under Wayland, even when the user would want to have
+        // an uncapped framerate.
         frame.present();
 
         self.frame_pacer.end_frame_stage(self.cpu_stage, Instant::now());

--- a/korangar/src/main.rs
+++ b/korangar/src/main.rs
@@ -1945,8 +1945,6 @@ impl Client {
         #[cfg(feature = "debug")]
         loads_measurement.stop();
 
-        let window = self.window.as_ref().expect("window missing");
-
         // Main map update and render loop
         if let Some(map) = self.map.as_ref() {
             #[cfg(feature = "debug")]
@@ -2440,7 +2438,7 @@ impl Client {
                 marker: self.debug_marker_renderer.get_instructions(),
             };
 
-            self.graphics_engine.render_next_frame(window, frame, render_instruction);
+            self.graphics_engine.render_next_frame(frame, render_instruction);
 
             #[cfg(feature = "debug")]
             render_frame_measurement.stop();
@@ -2448,7 +2446,7 @@ impl Client {
             #[cfg(feature = "debug")]
             let render_frame_measurement = Profiler::start_measurement("render next frame");
 
-            self.graphics_engine.render_next_frame(window, frame, RenderInstruction::default());
+            self.graphics_engine.render_next_frame(frame, RenderInstruction::default());
 
             #[cfg(feature = "debug")]
             render_frame_measurement.stop();


### PR DESCRIPTION
Removes the previously added call to `Windows::pre_present_notify()`, since users report that wayland is always capping the framerate when we include this call.

It seems to be a footgun in the winit API for games.