### PR TITLE
Refactor ToBytes to use a ByteWriter

### DIFF
--- a/korangar/src/interface/elements/containers/packet.rs
+++ b/korangar/src/interface/elements/containers/packet.rs
@@ -10,7 +10,7 @@ use korangar_interface::event::{ChangeEvent, HoverInformation};
 use korangar_interface::layout::PlacementResolver;
 use korangar_interface::size_bound;
 use korangar_interface::state::{PlainRemote, Remote, RemoteClone};
-use ragnarok_bytes::{ByteReader, ConversionError, ConversionResult, FromBytes};
+use ragnarok_bytes::{ByteReader, ByteWriter, ConversionError, ConversionResult, FromBytes};
 use ragnarok_packets::handler::PacketCallback;
 use ragnarok_packets::{Packet, PacketHeader};
 
@@ -35,7 +35,7 @@ impl Packet for UnknownPacket {
         unimplemented!()
     }
 
-    fn payload_to_bytes(&self) -> ConversionResult<Vec<u8>> {
+    fn payload_to_bytes(&self, _byte_writer: &mut ByteWriter) -> ConversionResult<usize> {
         unimplemented!()
     }
 
@@ -80,7 +80,7 @@ impl Packet for ErrorPacket {
         unimplemented!()
     }
 
-    fn payload_to_bytes(&self) -> ConversionResult<Vec<u8>> {
+    fn payload_to_bytes(&self, _byte_writer: &mut ByteWriter) -> ConversionResult<usize> {
         unimplemented!()
     }
 

--- a/korangar_util/src/container/lru.rs
+++ b/korangar_util/src/container/lru.rs
@@ -211,7 +211,7 @@ impl<I: GenerationalKey + Copy, V> Lru<I, V> {
 mod tests {
     use std::num::NonZeroU32;
 
-    use rand_aes::{Aes128Ctr128, Random};
+    use rand_aes::Aes128Ctr128;
 
     use super::Lru;
     use crate::container::GenerationalSlab;

--- a/ragnarok_bytes/src/lib.rs
+++ b/ragnarok_bytes/src/lib.rs
@@ -6,6 +6,7 @@ mod fixed;
 mod from_bytes;
 mod reader;
 mod to_bytes;
+mod writer;
 
 pub use encoding_rs as encoding;
 #[cfg(feature = "derive")]
@@ -16,18 +17,22 @@ pub use self::fixed::{FixedByteSize, FixedByteSizeCollection};
 pub use self::from_bytes::{FromBytes, FromBytesExt};
 pub use self::reader::ByteReader;
 pub use self::to_bytes::{ToBytes, ToBytesExt};
+pub use self::writer::ByteWriter;
 
 #[cfg(test)]
 mod conversion {
-    use crate::{ByteReader, FromBytes, ToBytes};
+    use crate::{ByteReader, ByteWriter, FromBytes, ToBytes};
 
     fn encode_decode<T: FromBytes + ToBytes>(input: &[u8]) {
         let mut byte_reader = ByteReader::without_metadata(input);
 
         let data = T::from_bytes(&mut byte_reader).unwrap();
-        let output = data.to_bytes().unwrap();
 
-        assert_eq!(input, output.as_slice());
+        let mut byte_writer = ByteWriter::new();
+        data.to_bytes(&mut byte_writer).unwrap();
+        let bytes = byte_writer.into_inner();
+
+        assert_eq!(input, bytes.as_slice());
     }
 
     #[test]

--- a/ragnarok_bytes/src/to_bytes/implement.rs
+++ b/ragnarok_bytes/src/to_bytes/implement.rs
@@ -1,174 +1,200 @@
 #[cfg(feature = "cgmath")]
 use cgmath::{Matrix3, Point2, Point3, Quaternion, Vector2, Vector3, Vector4};
 
-use crate::{ConversionResult, ConversionResultExt, ToBytes};
+use crate::{ByteWriter, ConversionResult, ConversionResultExt, ToBytes};
 
 impl ToBytes for u8 {
-    fn to_bytes(&self) -> ConversionResult<Vec<u8>> {
-        Ok(vec![*self])
+    fn to_bytes(&self, byte_writer: &mut ByteWriter) -> ConversionResult<usize> {
+        byte_writer.push(*self);
+        Ok(size_of::<Self>())
     }
 }
 
 impl ToBytes for u16 {
-    fn to_bytes(&self) -> ConversionResult<Vec<u8>> {
-        Ok(self.to_le_bytes().to_vec())
+    fn to_bytes(&self, byte_writer: &mut ByteWriter) -> ConversionResult<usize> {
+        byte_writer.extend_from_slice(&self.to_le_bytes());
+        Ok(size_of::<Self>())
     }
 }
 
 impl ToBytes for u32 {
-    fn to_bytes(&self) -> ConversionResult<Vec<u8>> {
-        Ok(self.to_le_bytes().to_vec())
+    fn to_bytes(&self, byte_writer: &mut ByteWriter) -> ConversionResult<usize> {
+        byte_writer.extend_from_slice(&self.to_le_bytes());
+        Ok(size_of::<Self>())
     }
 }
 
 impl ToBytes for u64 {
-    fn to_bytes(&self) -> ConversionResult<Vec<u8>> {
-        Ok(self.to_le_bytes().to_vec())
+    fn to_bytes(&self, byte_writer: &mut ByteWriter) -> ConversionResult<usize> {
+        byte_writer.extend_from_slice(&self.to_le_bytes());
+        Ok(size_of::<Self>())
     }
 }
 
 impl ToBytes for i8 {
-    fn to_bytes(&self) -> ConversionResult<Vec<u8>> {
-        Ok(vec![*self as u8])
+    fn to_bytes(&self, byte_writer: &mut ByteWriter) -> ConversionResult<usize> {
+        byte_writer.extend_from_slice(&self.to_le_bytes());
+        Ok(size_of::<Self>())
     }
 }
 
 impl ToBytes for i16 {
-    fn to_bytes(&self) -> ConversionResult<Vec<u8>> {
-        Ok(self.to_le_bytes().to_vec())
+    fn to_bytes(&self, byte_writer: &mut ByteWriter) -> ConversionResult<usize> {
+        byte_writer.extend_from_slice(&self.to_le_bytes());
+        Ok(size_of::<Self>())
     }
 }
 
 impl ToBytes for i32 {
-    fn to_bytes(&self) -> ConversionResult<Vec<u8>> {
-        Ok(self.to_le_bytes().to_vec())
+    fn to_bytes(&self, byte_writer: &mut ByteWriter) -> ConversionResult<usize> {
+        byte_writer.extend_from_slice(&self.to_le_bytes());
+        Ok(size_of::<Self>())
     }
 }
 
 impl ToBytes for i64 {
-    fn to_bytes(&self) -> ConversionResult<Vec<u8>> {
-        Ok(self.to_le_bytes().to_vec())
+    fn to_bytes(&self, byte_writer: &mut ByteWriter) -> ConversionResult<usize> {
+        byte_writer.extend_from_slice(&self.to_le_bytes());
+        Ok(size_of::<Self>())
     }
 }
 
 impl ToBytes for f32 {
-    fn to_bytes(&self) -> ConversionResult<Vec<u8>> {
-        Ok(self.to_ne_bytes().to_vec())
+    fn to_bytes(&self, byte_writer: &mut ByteWriter) -> ConversionResult<usize> {
+        byte_writer.extend_from_slice(&self.to_le_bytes());
+        Ok(size_of::<Self>())
     }
 }
 
 impl<T: ToBytes, const SIZE: usize> ToBytes for [T; SIZE] {
-    fn to_bytes(&self) -> ConversionResult<Vec<u8>> {
-        let mut bytes = Vec::new();
+    fn to_bytes(&self, byte_writer: &mut ByteWriter) -> ConversionResult<usize> {
+        byte_writer.write_counted(|writer| {
+            for item in self.iter() {
+                item.to_bytes(writer).trace::<Self>()?;
+            }
 
-        for item in self.iter() {
-            let item = item.to_bytes().trace::<Self>()?;
-            bytes.extend(item);
-        }
-
-        Ok(bytes)
+            Ok(())
+        })
     }
 }
 
 impl ToBytes for String {
-    fn to_bytes(&self) -> ConversionResult<Vec<u8>> {
-        Ok(self.bytes().chain(std::iter::once(0)).collect())
+    fn to_bytes(&self, byte_writer: &mut ByteWriter) -> ConversionResult<usize> {
+        byte_writer.write_counted(|writer| {
+            writer.encode_string(self.as_str());
+
+            Ok(())
+        })
     }
 }
 
 impl<T: ToBytes> ToBytes for Vec<T> {
-    fn to_bytes(&self) -> ConversionResult<Vec<u8>> {
-        let mut bytes = Vec::new();
+    fn to_bytes(&self, byte_writer: &mut ByteWriter) -> ConversionResult<usize> {
+        byte_writer.write_counted(|writer| {
+            for item in self.iter() {
+                item.to_bytes(writer).trace::<Self>()?;
+            }
 
-        for item in self.iter() {
-            let item = item.to_bytes().trace::<Self>()?;
-            bytes.extend(item);
-        }
-
-        Ok(bytes)
+            Ok(())
+        })
     }
 }
 
 #[cfg(feature = "cgmath")]
 impl<T: ToBytes> ToBytes for Vector2<T> {
-    fn to_bytes(&self) -> ConversionResult<Vec<u8>> {
-        let mut bytes = self.x.to_bytes().trace::<Self>()?;
-        bytes.append(&mut self.y.to_bytes().trace::<Self>()?);
+    fn to_bytes(&self, byte_writer: &mut ByteWriter) -> ConversionResult<usize> {
+        byte_writer.write_counted(|writer| {
+            self.x.to_bytes(writer).trace::<Self>()?;
+            self.y.to_bytes(writer).trace::<Self>()?;
 
-        Ok(bytes)
+            Ok(())
+        })
     }
 }
 
 #[cfg(feature = "cgmath")]
 impl<T: ToBytes> ToBytes for Vector3<T> {
-    fn to_bytes(&self) -> ConversionResult<Vec<u8>> {
-        let mut bytes = self.x.to_bytes().trace::<Self>()?;
-        bytes.append(&mut self.y.to_bytes().trace::<Self>()?);
-        bytes.append(&mut self.z.to_bytes().trace::<Self>()?);
+    fn to_bytes(&self, byte_writer: &mut ByteWriter) -> ConversionResult<usize> {
+        byte_writer.write_counted(|writer| {
+            self.x.to_bytes(writer).trace::<Self>()?;
+            self.y.to_bytes(writer).trace::<Self>()?;
+            self.z.to_bytes(writer).trace::<Self>()?;
 
-        Ok(bytes)
+            Ok(())
+        })
     }
 }
 
 #[cfg(feature = "cgmath")]
 impl<T: ToBytes> ToBytes for Vector4<T> {
-    fn to_bytes(&self) -> ConversionResult<Vec<u8>> {
-        let mut bytes = self.x.to_bytes().trace::<Self>()?;
-        bytes.append(&mut self.y.to_bytes().trace::<Self>()?);
-        bytes.append(&mut self.z.to_bytes().trace::<Self>()?);
-        bytes.append(&mut self.w.to_bytes().trace::<Self>()?);
-        Ok(bytes)
+    fn to_bytes(&self, byte_writer: &mut ByteWriter) -> ConversionResult<usize> {
+        byte_writer.write_counted(|writer| {
+            self.x.to_bytes(writer).trace::<Self>()?;
+            self.y.to_bytes(writer).trace::<Self>()?;
+            self.z.to_bytes(writer).trace::<Self>()?;
+            self.w.to_bytes(writer).trace::<Self>()?;
+
+            Ok(())
+        })
     }
 }
 
 #[cfg(feature = "cgmath")]
 impl<T: ToBytes> ToBytes for Point2<T> {
-    fn to_bytes(&self) -> ConversionResult<Vec<u8>> {
-        let mut bytes = self.x.to_bytes().trace::<Self>()?;
-        bytes.append(&mut self.y.to_bytes().trace::<Self>()?);
+    fn to_bytes(&self, byte_writer: &mut ByteWriter) -> ConversionResult<usize> {
+        byte_writer.write_counted(|writer| {
+            self.x.to_bytes(writer).trace::<Self>()?;
+            self.y.to_bytes(writer).trace::<Self>()?;
 
-        Ok(bytes)
+            Ok(())
+        })
     }
 }
 
 #[cfg(feature = "cgmath")]
 impl<T: ToBytes> ToBytes for Point3<T> {
-    fn to_bytes(&self) -> ConversionResult<Vec<u8>> {
-        let mut bytes = self.x.to_bytes().trace::<Self>()?;
-        bytes.append(&mut self.y.to_bytes().trace::<Self>()?);
-        bytes.append(&mut self.z.to_bytes().trace::<Self>()?);
+    fn to_bytes(&self, byte_writer: &mut ByteWriter) -> ConversionResult<usize> {
+        byte_writer.write_counted(|writer| {
+            self.x.to_bytes(writer).trace::<Self>()?;
+            self.y.to_bytes(writer).trace::<Self>()?;
+            self.z.to_bytes(writer).trace::<Self>()?;
 
-        Ok(bytes)
+            Ok(())
+        })
     }
 }
 
 #[cfg(feature = "cgmath")]
 impl<T: ToBytes> ToBytes for Quaternion<T> {
-    fn to_bytes(&self) -> ConversionResult<Vec<u8>> {
-        let mut bytes = self.v.x.to_bytes().trace::<Self>()?;
-        bytes.append(&mut self.v.y.to_bytes().trace::<Self>()?);
-        bytes.append(&mut self.v.z.to_bytes().trace::<Self>()?);
-        bytes.append(&mut self.s.to_bytes().trace::<Self>()?);
+    fn to_bytes(&self, byte_writer: &mut ByteWriter) -> ConversionResult<usize> {
+        byte_writer.write_counted(|writer| {
+            self.v.x.to_bytes(writer).trace::<Self>()?;
+            self.v.y.to_bytes(writer).trace::<Self>()?;
+            self.v.z.to_bytes(writer).trace::<Self>()?;
+            self.s.to_bytes(writer).trace::<Self>()?;
 
-        Ok(bytes)
+            Ok(())
+        })
     }
 }
 
 #[cfg(feature = "cgmath")]
 impl<T: ToBytes> ToBytes for Matrix3<T> {
-    fn to_bytes(&self) -> ConversionResult<Vec<u8>> {
-        let mut bytes = self.x.x.to_bytes().trace::<Self>()?;
-        bytes.append(&mut self.x.y.to_bytes().trace::<Self>()?);
-        bytes.append(&mut self.x.z.to_bytes().trace::<Self>()?);
+    fn to_bytes(&self, byte_writer: &mut ByteWriter) -> ConversionResult<usize> {
+        byte_writer.write_counted(|writer| {
+            self.x.x.to_bytes(writer).trace::<Self>()?;
+            self.x.y.to_bytes(writer).trace::<Self>()?;
+            self.x.z.to_bytes(writer).trace::<Self>()?;
 
-        bytes.append(&mut self.y.x.to_bytes().trace::<Self>()?);
-        bytes.append(&mut self.y.y.to_bytes().trace::<Self>()?);
-        bytes.append(&mut self.y.z.to_bytes().trace::<Self>()?);
+            self.y.x.to_bytes(writer).trace::<Self>()?;
+            self.y.y.to_bytes(writer).trace::<Self>()?;
+            self.y.z.to_bytes(writer).trace::<Self>()?;
 
-        bytes.append(&mut self.z.x.to_bytes().trace::<Self>()?);
-        bytes.append(&mut self.z.y.to_bytes().trace::<Self>()?);
-        bytes.append(&mut self.z.z.to_bytes().trace::<Self>()?);
+            self.z.x.to_bytes(writer).trace::<Self>()?;
+            self.z.y.to_bytes(writer).trace::<Self>()?;
+            self.z.z.to_bytes(writer).trace::<Self>()?;
 
-        Ok(bytes)
+            Ok(())
+        })
     }
 }

--- a/ragnarok_bytes/src/to_bytes/mod.rs
+++ b/ragnarok_bytes/src/to_bytes/mod.rs
@@ -1,18 +1,22 @@
-use crate::{ConversionError, ConversionErrorType, ConversionResult};
+use crate::{ByteWriter, ConversionError, ConversionErrorType, ConversionResult};
 
 mod implement;
 
 /// Trait to serialize into bytes.
 pub trait ToBytes {
-    /// Converts self to a [`Vec`] of bytes.
-    fn to_bytes(&self) -> ConversionResult<Vec<u8>>;
+    /// Converts self into bytes and write these into the [`ByteWriter`].
+    ///
+    /// Returns the count of the written bytes.
+    fn to_bytes(&self, byte_writer: &mut ByteWriter) -> ConversionResult<usize>;
 }
 
 /// Extension trait for [`ToBytes`].
 pub trait ToBytesExt: ToBytes {
-    /// Converts self to a [`Vec`] of bytes and pads it with zeros to match the
-    /// size of `size`.
-    fn to_n_bytes(&self, size: usize) -> ConversionResult<Vec<u8>>
+    /// Converts self into bytes, pads it with zeros to match the
+    /// size of `size` and then writes these into the [`ByteWriter`].
+    ///
+    /// Returns the count of the written bytes.
+    fn to_n_bytes(&self, byte_writer: &mut ByteWriter, size: usize) -> ConversionResult<usize>
     where
         Self: Sized;
 }
@@ -21,60 +25,73 @@ impl<T> ToBytesExt for T
 where
     T: ToBytes,
 {
-    fn to_n_bytes(&self, size: usize) -> ConversionResult<Vec<u8>>
+    fn to_n_bytes(&self, byte_writer: &mut ByteWriter, size: usize) -> ConversionResult<usize>
     where
         Self: Sized,
     {
-        let mut data = T::to_bytes(self)?;
+        let written = T::to_bytes(self, byte_writer)?;
 
-        if data.len() > size {
-            return Err(ConversionError::from_error_type(ConversionErrorType::DataTooBig {
-                type_name: std::any::type_name::<T>(),
-            }));
+        match size.checked_sub(written) {
+            None => {
+                return Err(ConversionError::from_error_type(ConversionErrorType::DataTooBig {
+                    type_name: std::any::type_name::<T>(),
+                }));
+            }
+            Some(add_count) => {
+                byte_writer.extend(add_count, 0);
+            }
         }
 
-        data.resize(size, 0);
-        Ok(data)
+        Ok(size)
     }
 }
 
 #[cfg(test)]
 mod to_n_bytes {
     use super::ToBytes;
-    use crate::ToBytesExt;
+    use crate::{ByteWriter, ToBytesExt};
 
     struct Test;
 
     const TEST_BYTE_SIZE: usize = 4;
 
     impl ToBytes for Test {
-        fn to_bytes(&self) -> crate::ConversionResult<Vec<u8>> {
-            Ok(vec![9; TEST_BYTE_SIZE])
+        fn to_bytes(&self, byte_writer: &mut ByteWriter) -> crate::ConversionResult<usize> {
+            byte_writer.write_counted(|writer| {
+                writer.extend(TEST_BYTE_SIZE, 9);
+                Ok(())
+            })
         }
     }
 
     #[test]
     fn data_saturated() {
-        let result = Test.to_n_bytes(TEST_BYTE_SIZE);
+        let mut byte_writer = ByteWriter::new();
+        let result = Test.to_n_bytes(&mut byte_writer, TEST_BYTE_SIZE);
+        let bytes = byte_writer.into_inner();
 
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), vec![9; TEST_BYTE_SIZE]);
+        assert_eq!(result.unwrap(), TEST_BYTE_SIZE);
+        assert_eq!(bytes, vec![9; TEST_BYTE_SIZE]);
     }
 
     #[test]
     fn data_smaller() {
-        let result = Test.to_n_bytes(TEST_BYTE_SIZE * 2);
+        let mut byte_writer = ByteWriter::new();
+        let result = Test.to_n_bytes(&mut byte_writer, TEST_BYTE_SIZE * 2);
 
         assert!(result.is_ok());
+        assert_eq!(result.unwrap(), TEST_BYTE_SIZE * 2);
 
-        let data = result.unwrap();
-        assert_eq!(&data[..TEST_BYTE_SIZE], vec![9; TEST_BYTE_SIZE]);
-        assert_eq!(&data[TEST_BYTE_SIZE..], vec![0; TEST_BYTE_SIZE]);
+        let bytes = byte_writer.into_inner();
+        assert_eq!(&bytes[..TEST_BYTE_SIZE], vec![9; TEST_BYTE_SIZE]);
+        assert_eq!(&bytes[TEST_BYTE_SIZE..], vec![0; TEST_BYTE_SIZE]);
     }
 
     #[test]
     fn data_bigger() {
-        let result = Test.to_n_bytes(TEST_BYTE_SIZE / 2);
+        let mut byte_writer = ByteWriter::new();
+        let result = Test.to_n_bytes(&mut byte_writer, TEST_BYTE_SIZE / 2);
 
         assert!(result.is_err());
     }

--- a/ragnarok_bytes/src/writer.rs
+++ b/ragnarok_bytes/src/writer.rs
@@ -1,0 +1,110 @@
+use encoding_rs::{EUC_KR, Encoding};
+
+use crate::{ConversionError, ConversionErrorType, ConversionResult};
+
+/// A writer of bytes into a [`Vec<u8>`].
+///
+/// used in conjunction with the [`ToBytes`] trait.
+pub struct ByteWriter {
+    data: Vec<u8>,
+    encoding: &'static Encoding,
+}
+
+impl Default for ByteWriter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ByteWriter {
+    /// Creates a new [`ByteWriter`]. The default encoding is `EUC_KR`.
+    pub fn new() -> Self {
+        Self {
+            data: Vec::default(),
+            encoding: EUC_KR,
+        }
+    }
+
+    /// Creates a new [`ByteWriter`] that uses the given encoding to encode
+    /// strings.
+    pub fn with_encoding(encoding: &'static Encoding) -> Self {
+        Self {
+            data: Vec::default(),
+            encoding,
+        }
+    }
+
+    /// Executes the given write function and returns the count of bytes
+    /// written.
+    pub fn write_counted(&mut self, write: impl FnOnce(&mut Self) -> ConversionResult<()>) -> ConversionResult<usize> {
+        let start = self.data.len();
+        write(self)?;
+        Ok(self.data.len() - start)
+    }
+
+    /// Encodes the given string and appends it's bytes to the data.
+    pub fn encode_string(&mut self, string: &str) {
+        let (bytes, ..) = self.encoding.encode(string);
+        self.data.extend_from_slice(bytes.as_ref());
+        self.data.push(0);
+    }
+
+    /// Adds the given byte to the data.
+    #[inline(always)]
+    pub fn push(&mut self, byte: u8) {
+        self.data.push(byte);
+    }
+
+    /// Adds the given bytes to the data.
+    #[inline(always)]
+    pub fn extend_from_slice(&mut self, bytes: &[u8]) {
+        self.data.extend_from_slice(bytes);
+    }
+
+    /// Adds the given count of bytes to the data.
+    #[inline(always)]
+    pub fn extend(&mut self, add_count: usize, value: u8) {
+        self.data.extend(std::iter::repeat_n(value, add_count));
+    }
+
+    /// Returns the current length of the data.
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Returns `true` if there is no inner data.
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    /// Overwrites bytes at the given position with the provided slice
+    #[inline(always)]
+    pub fn overwrite_at<const SIZE: usize>(&mut self, position: usize, bytes: [u8; SIZE]) -> ConversionResult<()> {
+        let end = position + bytes.len();
+        if end > self.data.len() {
+            return Err(ConversionError::from_error_type(ConversionErrorType::DataTooBig {
+                type_name: std::any::type_name::<[u8; SIZE]>(),
+            }));
+        }
+        self.data[position..end].copy_from_slice(&bytes);
+        Ok(())
+    }
+
+    /// Returns the inner bytes.
+    #[must_use]
+    pub fn into_inner(self) -> Vec<u8> {
+        self.data
+    }
+
+    /// Returns a slice to the inner bytes.
+    #[must_use]
+    pub fn as_slice(&self) -> &[u8] {
+        self.data.as_slice()
+    }
+
+    /// Clears the inner bytes.
+    pub fn clear(&mut self) {
+        self.data.clear();
+    }
+}

--- a/ragnarok_formats/src/model.rs
+++ b/ragnarok_formats/src/model.rs
@@ -1,6 +1,6 @@
 use cgmath::{Matrix3, Point3, Quaternion, Vector2, Vector3};
 use ragnarok_bytes::{
-    ByteConvertable, ByteReader, ConversionError, ConversionResult, ConversionResultExt, FromBytes, FromBytesExt, ToBytes,
+    ByteConvertable, ByteReader, ByteWriter, ConversionError, ConversionResult, ConversionResultExt, FromBytes, FromBytesExt, ToBytes,
 };
 
 use crate::signature::Signature;
@@ -34,7 +34,7 @@ impl<const LENGTH: usize> FromBytes for ModelString<LENGTH> {
 }
 
 impl<const LENGTH: usize> ToBytes for ModelString<LENGTH> {
-    fn to_bytes(&self) -> ConversionResult<Vec<u8>> {
+    fn to_bytes(&self, _byte_writer: &mut ByteWriter) -> ConversionResult<usize> {
         panic!("ModelString can not be serialized currently because it depends on a version requirement");
     }
 }

--- a/ragnarok_formats/src/signature.rs
+++ b/ragnarok_formats/src/signature.rs
@@ -1,4 +1,4 @@
-use ragnarok_bytes::{ByteReader, ConversionError, ConversionResult, FixedByteSize, FromBytes, ToBytes};
+use ragnarok_bytes::{ByteReader, ByteWriter, ConversionError, ConversionResult, FixedByteSize, FromBytes, ToBytes};
 
 #[derive(Debug, Clone, Default)]
 pub struct Signature<const MAGIC: &'static [u8]>;
@@ -23,8 +23,9 @@ impl<const MAGIC: &'static [u8]> FromBytes for Signature<MAGIC> {
 }
 
 impl<const MAGIC: &'static [u8]> ToBytes for Signature<MAGIC> {
-    fn to_bytes(&self) -> ConversionResult<Vec<u8>> {
-        Ok(MAGIC.to_vec())
+    fn to_bytes(&self, byte_writer: &mut ByteWriter) -> ConversionResult<usize> {
+        byte_writer.extend_from_slice(MAGIC);
+        Ok(MAGIC.len())
     }
 }
 

--- a/ragnarok_formats/src/sprite.rs
+++ b/ragnarok_formats/src/sprite.rs
@@ -1,5 +1,5 @@
 use ragnarok_bytes::{
-    ByteConvertable, ByteReader, ConversionError, ConversionResult, ConversionResultExt, FromBytes, FromBytesExt, ToBytes,
+    ByteConvertable, ByteReader, ByteWriter, ConversionError, ConversionResult, ConversionResultExt, FromBytes, FromBytesExt, ToBytes,
 };
 
 use crate::signature::Signature;
@@ -76,7 +76,7 @@ impl FromBytes for PaletteImageData {
 }
 
 impl ToBytes for PaletteImageData {
-    fn to_bytes(&self) -> ConversionResult<Vec<u8>> {
+    fn to_bytes(&self, _byte_writer: &mut ByteWriter) -> ConversionResult<usize> {
         panic!("PalletteImageData can not be serialized currently because it depends on a version requirement");
     }
 }

--- a/ragnarok_procedural/src/convertable.rs
+++ b/ragnarok_procedural/src/convertable.rs
@@ -48,8 +48,11 @@ fn derive_for_struct(
             impl #impl_generics ragnarok_bytes::ToBytes for #name #type_generics #where_clause {
                 // Temporary until serialization is always possible
                 #[allow(unreachable_code)]
-                fn to_bytes(&self) -> ragnarok_bytes::ConversionResult<Vec<u8>> {
-                    Ok([#(#to_bytes_implementations),*].concat())
+                fn to_bytes(&self, byte_writer: &mut ragnarok_bytes::ByteWriter) -> ragnarok_bytes::ConversionResult<usize> {
+                    byte_writer.write_counted(|writer| {
+                        #(#to_bytes_implementations)*
+                        Ok(())
+                    })
                 }
             }
         }
@@ -113,9 +116,9 @@ fn derive_for_enum(
             impl #impl_generics ragnarok_bytes::ToBytes for #name #type_generics #where_clause {
                 // Temporary until serialization is always possible
                 #[allow(unreachable_code)]
-                fn to_bytes(&self) -> ragnarok_bytes::ConversionResult<Vec<u8>> {
+                fn to_bytes(&self, byte_writer: &mut ragnarok_bytes::ByteWriter) -> ragnarok_bytes::ConversionResult<usize> {
                     match self {
-                        #( #name::#values => ragnarok_bytes::ConversionResultExt::trace::<Self>((#indices as #numeric_type).to_bytes()), )*
+                        #( #name::#values => ragnarok_bytes::ConversionResultExt::trace::<Self>((#indices as #numeric_type).to_bytes(byte_writer)), )*
                     }
                 }
             }

--- a/ragnarok_procedural/src/helper.rs
+++ b/ragnarok_procedural/src/helper.rs
@@ -55,10 +55,10 @@ pub fn byte_convertable_helper(data_struct: DataStruct) -> (TokenStream, Vec<Tok
 
         let to_length = match length {
             Some(length) if syn::parse::<syn::Ident>(length.clone().into()).is_ok() => {
-                quote!(ragnarok_bytes::ToBytesExt::to_n_bytes(&self.#field_identifier, self.#length as usize))
+                quote!(ragnarok_bytes::ToBytesExt::to_n_bytes(&self.#field_identifier, writer, self.#length as usize))
             }
-            Some(length) => quote!(ragnarok_bytes::ToBytesExt::to_n_bytes(&self.#field_identifier, #length as usize)),
-            None => quote!(ragnarok_bytes::ToBytes::to_bytes(&self.#field_identifier)),
+            Some(length) => quote!(ragnarok_bytes::ToBytesExt::to_n_bytes(&self.#field_identifier, writer, #length as usize)),
+            None => quote!(ragnarok_bytes::ToBytes::to_bytes(&self.#field_identifier, writer)),
         };
 
         let mut repeating: Option<(syn::Ident, bool)> = None;
@@ -186,13 +186,8 @@ pub fn byte_convertable_helper(data_struct: DataStruct) -> (TokenStream, Vec<Tok
 
         // base to byte implementation
         let to_implementation = match version_restricted {
-            true => quote!({
-                panic!("version restricted fields can't be serialized at the moment");
-                [0u8].as_slice()
-            }),
-            false => {
-                quote!(ragnarok_bytes::ConversionResultExt::trace::<Self>(#to_length)?.as_slice())
-            }
+            true => quote!(panic!("version restricted fields can't be serialized at the moment");),
+            false => quote!(ragnarok_bytes::ConversionResultExt::trace::<Self>(#to_length)?;),
         };
         to_bytes_implementations.push(to_implementation);
 


### PR DESCRIPTION
This reduces the amount of allocation when using the ToBytes trait and also properly selects the string encoding.