### PR TITLE
Add the build number to the map loader

### DIFF
--- a/ragnarok_formats/src/map.rs
+++ b/ragnarok_formats/src/map.rs
@@ -19,6 +19,7 @@ pub struct MapData {
     #[version]
     pub version: Version<MajorFirst>,
     #[version_equals_or_above(2, 5)]
+    #[build_number]
     pub build_number: Option<i32>,
     #[version_equals_or_above(2, 2)]
     pub _unknown: Option<u8>,
@@ -342,8 +343,7 @@ pub struct ObjectData {
     pub _animation_speed: Option<f32>,
     #[version_equals_or_above(1, 3)]
     pub _block_type: Option<i32>,
-    // FIX: only if build_version >= 186
-    #[version_equals_or_above(2, 6)]
+    #[version_build_equals_or_above(2, 6, 186)]
     #[new_default]
     pub _unknown: Option<u8>,
     #[length(80)]

--- a/ragnarok_formats/src/version.rs
+++ b/ragnarok_formats/src/version.rs
@@ -13,6 +13,7 @@ pub struct MinorFirst;
 pub struct Version<T> {
     pub major: u8,
     pub minor: u8,
+    pub build: i32,
     phantom_data: PhantomData<T>,
 }
 
@@ -21,6 +22,7 @@ impl<T> Version<T> {
         Self {
             major,
             minor,
+            build: 0,
             phantom_data: PhantomData,
         }
     }
@@ -34,6 +36,7 @@ impl FromBytes for Version<MajorFirst> {
         Ok(Self {
             major,
             minor,
+            build: 0,
             phantom_data: PhantomData,
         })
     }
@@ -47,6 +50,7 @@ impl FromBytes for Version<MinorFirst> {
         Ok(Self {
             minor,
             major,
+            build: 0,
             phantom_data: PhantomData,
         })
     }
@@ -84,12 +88,13 @@ impl<T> Display for Version<T> {
 pub struct InternalVersion {
     pub major: u8,
     pub minor: u8,
+    pub build: i32,
 }
 
 impl<T> From<Version<T>> for InternalVersion {
     fn from(version: Version<T>) -> Self {
-        let Version { major, minor, .. } = version;
-        Self { major, minor }
+        let Version { major, minor, build, .. } = version;
+        Self { major, minor, build }
     }
 }
 
@@ -101,11 +106,17 @@ impl InternalVersion {
     pub fn equals_or_above(&self, major: u8, minor: u8) -> bool {
         self.major > major || (self.major == major && self.minor >= minor)
     }
+
+    pub fn version_build_equals_or_above(&self, major: u8, minor: u8, build: i32) -> bool {
+        self.major > major
+            || (self.major == major && self.minor > minor)
+            || (self.major == major && self.minor == minor && self.build >= build)
+    }
 }
 
 impl Display for InternalVersion {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(formatter, "{}.{}", self.major, self.minor)
+        write!(formatter, "{}.{}.{}", self.major, self.minor, self.build)
     }
 }
 

--- a/ragnarok_procedural/src/helper.rs
+++ b/ragnarok_procedural/src/helper.rs
@@ -4,7 +4,7 @@ use proc_macro2::{Delimiter, TokenStream};
 use quote::{format_ident, quote};
 use syn::{DataStruct, Field};
 
-use crate::utils::{Version, get_unique_attribute};
+use crate::utils::{Version, VersionBuild, get_unique_attribute};
 
 pub fn byte_convertable_helper(data_struct: DataStruct) -> (TokenStream, Vec<TokenStream>, Vec<TokenStream>, Vec<TokenStream>, Delimiter) {
     let mut from_bytes_implementations = vec![];
@@ -26,6 +26,8 @@ pub fn byte_convertable_helper(data_struct: DataStruct) -> (TokenStream, Vec<Tok
         let field_type = field.ty.clone();
 
         let is_version = get_unique_attribute(&mut field.attrs, "version").is_some();
+
+        let is_build_number = get_unique_attribute(&mut field.attrs, "build_number").is_some();
 
         let length = get_unique_attribute(&mut field.attrs, "length").map(|attribute| match attribute.meta {
             syn::Meta::List(list) => list.tokens,
@@ -93,11 +95,16 @@ pub fn byte_convertable_helper(data_struct: DataStruct) -> (TokenStream, Vec<Tok
             .map(|version: Version| (version.major, version.minor))
             .map(|(major, minor)| quote!(equals_or_above(#major, #minor)));
 
+        let version_build_equals_or_above = get_unique_attribute(&mut field.attrs, "version_build_equals_or_above")
+            .map(|attribute| attribute.parse_args().expect("failed to parse build version"))
+            .map(|element: VersionBuild| (element.version.major, element.version.minor, element.build))
+            .map(|(major, minor, build)| quote!(version_build_equals_or_above(#major, #minor, #build)));
+
         assert!(
-            version_smaller.is_none() || version_equals_or_above.is_none(),
+            version_build_equals_or_above.is_none() || version_smaller.is_none() || version_equals_or_above.is_none(),
             "version restriction may only be specified once"
         );
-        let version_function = version_smaller.or(version_equals_or_above);
+        let version_function = version_build_equals_or_above.or(version_smaller.or(version_equals_or_above));
         let version_restricted = version_function.is_some();
 
         // base from bytes implementation
@@ -193,7 +200,19 @@ pub fn byte_convertable_helper(data_struct: DataStruct) -> (TokenStream, Vec<Tok
 
         if is_version {
             from_bytes_implementations.push(
-                quote!(*byte_reader.get_metadata_mut::<Self, Option<ragnarok_formats::version::InternalVersion>>()? = Some(ragnarok_formats::version::InternalVersion::from(#field_variable));),
+                quote!(
+                    *byte_reader.get_metadata_mut::<Self, Option<ragnarok_formats::version::InternalVersion>>()? = Some(ragnarok_formats::version::InternalVersion::from(#field_variable));
+                ));
+        }
+
+        if is_build_number {
+            from_bytes_implementations.push(
+                quote!(
+                    if let Some(mut build_metadata) = *byte_reader.get_metadata_mut::<Self, Option<ragnarok_formats::version::InternalVersion>>()?{
+                        build_metadata.build = #field_variable.unwrap_or(0);
+                        *byte_reader.get_metadata_mut::<Self, Option<ragnarok_formats::version::InternalVersion>>()? = Some(build_metadata)
+                    };
+                ),
             );
         }
     }

--- a/ragnarok_procedural/src/lib.rs
+++ b/ragnarok_procedural/src/lib.rs
@@ -47,6 +47,8 @@ pub fn derive_fixed_byte_size(token_stream: InterfaceTokenStream) -> InterfaceTo
         version,
         version_equals_or_above,
         version_smaller,
+        build_number,
+        version_build_equals_or_above,
     )
 )]
 pub fn derive_byte_convertable(token_stream: InterfaceTokenStream) -> InterfaceTokenStream {

--- a/ragnarok_procedural/src/utils.rs
+++ b/ragnarok_procedural/src/utils.rs
@@ -31,6 +31,20 @@ impl Parse for Version {
     }
 }
 
+#[derive(Clone)]
+pub struct VersionBuild {
+    pub version: Version,
+    pub build: LitInt,
+}
+impl Parse for VersionBuild {
+    fn parse(input: ParseStream) -> Result<Self, Error> {
+        let version = input.parse().expect("version format is not correct");
+        input.parse::<Punct>().expect("version build must be separated by commas");
+        let build = input.parse().expect("build must be two bytes long");
+        Ok(VersionBuild { version, build })
+    }
+}
+
 pub fn get_unique_attribute(attributes: &mut Vec<Attribute>, name: &str) -> Option<Attribute> {
     let mut matching_attributes = attributes.extract_if(.., |attribute| attribute.path().segments[0].ident == name);
     let return_attribute = matching_attributes.next();


### PR DESCRIPTION
Some maps need to use build number to parse the information for example 1@exds.