### PR TITLE
Fix pop sound on linux on startup

### DIFF
--- a/korangar/src/main.rs
+++ b/korangar/src/main.rs
@@ -294,9 +294,6 @@ struct Client {
     #[cfg(not(feature = "debug"))]
     networking_system: NetworkingSystem<NoPacketCallback>,
     audio_engine: Arc<AudioEngine<GameFileLoader>>,
-    // HACK: Workaround for audio artifacts on Linux when Korangar starts.
-    // Hopefully this can be removed in the future.
-    ambient_sound_sources_initialized: bool,
     graphics_engine: GraphicsEngine,
     #[cfg(feature = "debug")]
     queue: Arc<Queue>,
@@ -621,6 +618,7 @@ impl Client {
                 .expect("failed to load initial map");
 
             audio_engine.play_background_music_track(DEFAULT_BACKGROUND_MUSIC);
+            map.set_ambient_sound_sources(&audio_engine);
         });
 
         Some(Self {
@@ -723,7 +721,6 @@ impl Client {
             packet_history_callback,
             networking_system,
             audio_engine,
-            ambient_sound_sources_initialized: false,
             graphics_engine,
             #[cfg(feature = "debug")]
             queue,
@@ -2581,15 +2578,6 @@ impl ApplicationHandler for Client {
                 let mute_on_focus_loss = *self.mute_on_focus_loss.get();
                 if mute_on_focus_loss {
                     self.audio_engine.mute(!focused);
-                }
-
-                // HACK: Workaround for audio artifacts on Wayland when Korangar starts.
-                // Hopefully this can be removed in the future.
-                if let Some(map) = &self.map
-                    && !self.ambient_sound_sources_initialized
-                {
-                    map.set_ambient_sound_sources(&self.audio_engine);
-                    self.ambient_sound_sources_initialized = true;
                 }
             }
             WindowEvent::CursorLeft { .. } => self.mouse_cursor.hide(),

--- a/korangar_audio/src/lib.rs
+++ b/korangar_audio/src/lib.rs
@@ -13,7 +13,7 @@ use std::sync::mpsc::{Receiver, Sender, channel};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use cgmath::{InnerSpace, Matrix3, Point3, Quaternion, Vector3};
+use cgmath::{InnerSpace, Matrix3, One, Point3, Quaternion, Vector3};
 use cpal::BufferSize;
 use kira::backend::cpal::{CpalBackend, CpalBackendSettings};
 use kira::listener::ListenerHandle;
@@ -151,7 +151,7 @@ impl<F: FileLoader> AudioEngine<F> {
             .add_sub_track(TrackBuilder::new())
             .expect("Can't create spatial sound effect track");
         let position = Vector3::new(0.0, 0.0, 0.0);
-        let orientation = Quaternion::new(0.0, 0.0, 0.0, 0.0);
+        let orientation = Quaternion::one();
         let spatial_listener = manager.add_listener(position, orientation).expect("Can't create spatial listener");
 
         let loading_sound_effect = HashSet::new();


### PR DESCRIPTION
The maintainer of Kira found the root cause of the pop sound under linux on first start:

The initialized the ambient listener's rotation with a "zero" quaternion, which led to NAN values. We instead should initialize it to the identity value.

The previous workaround is not needed anymore.