### PR TITLE
Lower profile to baseline

### DIFF
--- a/korangar/src/loaders/gamefile/cache.rs
+++ b/korangar/src/loaders/gamefile/cache.rs
@@ -407,7 +407,7 @@ fn process_video(
         .arg("-vf")
         .arg("fps=30")
         .arg("-profile")
-        .arg("main")
+        .arg("baseline")
         .arg("-crf")
         .arg("18")
         .arg("-preset")


### PR DESCRIPTION
Just to make sure we don't use any fancy, advance features when decoding.