### PR TITLE
Create zip files as artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,11 +84,16 @@ jobs:
           ARTIFACT_NAME="${DATE}-${{ env.BINARY_NAME }}-v${VERSION_PART}-${{ matrix.architecture }}"
           echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >> $GITHUB_ENV
 
+      - name: Create zip archive
+        run: |
+          cd staging
+          zip -r "../${{ env.ARTIFACT_NAME }}.zip" .
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ARTIFACT_NAME }}
-          path: staging/**
+          path: ${{ env.ARTIFACT_NAME }}.zip
 
   create-github-release:
     name: Create GitHub Release


### PR DESCRIPTION
This is needed, since the "actions/download-artifact@v4" unzips the zip file and has no option to disable this behavior.