### PR TITLE
Update nightly version of Rust

### DIFF
--- a/korangar/src/graphics/buffer.rs
+++ b/korangar/src/graphics/buffer.rs
@@ -264,7 +264,7 @@ impl<T: Sized + Pod + Zeroable> DynamicUniformBuffer<T> {
         }
     }
 
-    pub fn get_binding_resource(&self) -> BindingResource {
+    pub fn get_binding_resource(&self) -> BindingResource<'_> {
         BindingResource::Buffer(wgpu::BufferBinding {
             buffer: self.buffer.get_buffer(),
             offset: 0,

--- a/korangar/src/inventory/hotbar.rs
+++ b/korangar/src/inventory/hotbar.rs
@@ -96,7 +96,7 @@ impl Hotbar {
         });
     }
 
-    pub fn get_skill_in_slot(&self, slot: HotbarSlot) -> Ref<Option<Skill>> {
+    pub fn get_skill_in_slot(&self, slot: HotbarSlot) -> Ref<'_, Option<Skill>> {
         Ref::map(self.skills.get(), |skills| &skills[slot.0 as usize])
     }
 

--- a/korangar/src/main.rs
+++ b/korangar/src/main.rs
@@ -4,7 +4,6 @@
 #![feature(allocator_api)]
 #![feature(generic_const_exprs)]
 #![feature(iter_next_chunk)]
-#![feature(let_chains)]
 #![feature(negative_impls)]
 #![feature(proc_macro_hygiene)]
 #![feature(random)]

--- a/korangar/src/renderer/game_interface.rs
+++ b/korangar/src/renderer/game_interface.rs
@@ -163,7 +163,7 @@ impl GameInterfaceRenderer {
         self.instructions.borrow_mut().clear();
     }
 
-    pub fn get_instructions(&self) -> Ref<Vec<RectangleInstruction>> {
+    pub fn get_instructions(&self) -> Ref<'_, Vec<RectangleInstruction>> {
         self.instructions.borrow()
     }
 

--- a/korangar/src/renderer/interface.rs
+++ b/korangar/src/renderer/interface.rs
@@ -59,7 +59,7 @@ impl InterfaceRenderer {
         self.instructions.borrow_mut().clear();
     }
 
-    pub fn get_instructions(&self) -> Ref<Vec<InterfaceRectangleInstruction>> {
+    pub fn get_instructions(&self) -> Ref<'_, Vec<InterfaceRectangleInstruction>> {
         self.instructions.borrow()
     }
 

--- a/korangar/src/world/effect/lookup.rs
+++ b/korangar/src/world/effect/lookup.rs
@@ -1,6 +1,7 @@
 use korangar_interface::elements::PrototypeElement;
 use ragnarok_bytes::ByteConvertable;
 
+#[allow(unused)]
 #[derive(Clone, Debug, ByteConvertable, PrototypeElement)]
 #[numeric_type(u32)]
 pub enum EffectId {

--- a/korangar/src/world/light/mod.rs
+++ b/korangar/src/world/light/mod.rs
@@ -162,7 +162,7 @@ impl PointLightManager {
     }
 
     #[cfg_attr(feature = "debug", korangar_debug::profile)]
-    pub fn create_point_light_set(&mut self, shadow_map_count: usize) -> PointLightSet {
+    pub fn create_point_light_set(&mut self, shadow_map_count: usize) -> PointLightSet<'_> {
         for (index, point_light) in self.point_lights.iter().enumerate() {
             self.scored_point_lights
                 .push((index, point_light.id, self.score_point_light(point_light)))

--- a/korangar_audio/src/lib.rs
+++ b/korangar_audio/src/lib.rs
@@ -1,5 +1,4 @@
 //! This crate exposes an audio engine for the client
-#![feature(let_chains)]
 #![forbid(missing_docs)]
 
 use std::cmp::Ordering;

--- a/korangar_debug/src/lib.rs
+++ b/korangar_debug/src/lib.rs
@@ -1,6 +1,4 @@
 #![feature(decl_macro)]
-#![feature(let_chains)]
-#![feature(slice_take)]
 #![feature(thread_local)]
 
 #[macro_use]

--- a/korangar_interface/procedural/src/lib.rs
+++ b/korangar_interface/procedural/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(extract_if)]
-
 mod bound;
 mod element;
 mod helper;

--- a/korangar_interface/src/elements/prototype.rs
+++ b/korangar_interface/src/elements/prototype.rs
@@ -1,3 +1,4 @@
+use std::alloc::Allocator;
 use std::fmt::Display;
 use std::rc::Rc;
 
@@ -105,12 +106,13 @@ impl<T: ElementDisplay> ElementDisplay for cgmath::Rad<T> {
 
 // workaround for not having negative trait bounds or better specialization
 auto trait NoPrototype {}
-impl<T> !NoPrototype for std::sync::Arc<T> {}
+
+impl<T: ?Sized, A: Allocator> !NoPrototype for std::sync::Arc<T, A> {}
 impl<T> !NoPrototype for Option<T> {}
 impl<T, const N: usize> !NoPrototype for [T; N] {}
 impl<T> !NoPrototype for &[T] {}
-impl<T> !NoPrototype for Vec<T> {}
-impl<T> !NoPrototype for Rc<T> {}
+impl<T: ?Sized, A: Allocator> !NoPrototype for Vec<T, A> {}
+impl<T: ?Sized, A: Allocator> !NoPrototype for Rc<T, A> {}
 
 impl NoPrototype for &str {}
 impl NoPrototype for String {}

--- a/korangar_interface/src/lib.rs
+++ b/korangar_interface/src/lib.rs
@@ -1,9 +1,9 @@
 #![allow(incomplete_features)]
 #![feature(auto_traits)]
-#![feature(let_chains)]
 #![feature(negative_impls)]
 #![feature(option_zip)]
 #![feature(type_changing_struct_update)]
+#![feature(allocator_api)]
 
 pub mod application;
 pub mod event;

--- a/korangar_networking/src/lib.rs
+++ b/korangar_networking/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(let_chains)]
-
 mod entity;
 mod event;
 mod hotkey;

--- a/korangar_util/src/container/generational_slab.rs
+++ b/korangar_util/src/container/generational_slab.rs
@@ -121,7 +121,7 @@ impl<I: GenerationalKey, V> GenerationalSlab<I, V> {
 
     /// Iterates over all non-empty entries.
     #[must_use]
-    pub fn iter(&self) -> GenerationalIter<I, V> {
+    pub fn iter(&self) -> GenerationalIter<'_, I, V> {
         GenerationalIter {
             entries: self.entries.iter().enumerate(),
             size: self.entries.len(),

--- a/korangar_util/src/container/simple_slab.rs
+++ b/korangar_util/src/container/simple_slab.rs
@@ -139,7 +139,7 @@ impl<I: SimpleKey, T> SimpleSlab<I, T> {
 
     /// Iterates over all non-empty entries.
     #[must_use]
-    pub fn iter(&self) -> SimpleIterator<I, T> {
+    pub fn iter(&self) -> SimpleIterator<'_, I, T> {
         SimpleIterator {
             entries: self.entries.iter().enumerate(),
             size: self.entries.len(),
@@ -148,7 +148,7 @@ impl<I: SimpleKey, T> SimpleSlab<I, T> {
     }
 
     /// Removes all elements from the slab, returning them as an iterator.
-    pub fn drain(&mut self) -> DrainIter<I, T> {
+    pub fn drain(&mut self) -> DrainIter<'_, I, T> {
         let old_len = self.entries.len();
         self.next_free = None;
         self.count = 0;
@@ -282,7 +282,7 @@ impl<I: SimpleKey, V> SecondarySimpleSlab<I, V> {
 
     /// Iterates over all non-empty entries.
     #[must_use]
-    pub fn iter(&self) -> SecondarySimpleIterator<I, V> {
+    pub fn iter(&self) -> SecondarySimpleIterator<'_, I, V> {
         SecondarySimpleIterator {
             entries: self.entries.iter().enumerate(),
             size: self.entries.len(),

--- a/korangar_util/src/lib.rs
+++ b/korangar_util/src/lib.rs
@@ -1,6 +1,5 @@
 //! Utility crate that contains useful, common functionality.
 #![warn(missing_docs)]
-#![feature(let_chains)]
 
 pub mod collision;
 pub mod color;

--- a/korangar_video/src/lib.rs
+++ b/korangar_video/src/lib.rs
@@ -625,7 +625,7 @@ impl Picture {
     }
 
     /// Plane data of the `component` for the decoded frame.
-    pub fn plane(&self, component: PlanarImageComponent) -> Plane {
+    pub fn plane(&self, component: PlanarImageComponent) -> Plane<'_> {
         Plane(self, component)
     }
 

--- a/ragnarok_procedural/src/lib.rs
+++ b/ragnarok_procedural/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(extend_one)]
-#![feature(extract_if)]
 
 mod convertable;
 mod fixed_size;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2025-02-20"
+channel = "nightly-2025-07-06"
 # components for development
 components = ["rust-src", "rust-analyzer", "miri"]


### PR DESCRIPTION
Some unstable stuff turned stable. For negative traits we had to use the allocator API to be able to properly define the trait.

Also fixed clippy issues that popped up.

@vE5li Some stuff that might interact with your branch.