### PR TITLE
Make loading the mapskydata.lub optional

### DIFF
--- a/korangar/src/world/library/mod.rs
+++ b/korangar/src/world/library/mod.rs
@@ -84,12 +84,14 @@ impl Library {
 
         let item_table = Self::load_item_table(&state)?;
 
-        let data = game_file_loader
-            .get("data\\luafiles514\\lua files\\mapskydata\\mapskydata.lub")
-            .unwrap();
-        state.load(&data).exec()?;
-
-        let map_sky_data_table = Self::load_map_sky_data_table(&state)?;
+        let map_sky_data_table = match game_file_loader.get("data\\luafiles514\\lua files\\mapskydata\\mapskydata.lub") {
+            Ok(data) => {
+                let state = Lua::new();
+                state.load(&data).exec()?;
+                Self::load_map_sky_data_table(&state)?
+            }
+            Err(_) => HashMap::new(),
+        };
 
         Ok(Self {
             job_identity_table,


### PR DESCRIPTION
Only newer client versions have them. Some older don't. Since they are not strictly needed for now, we make loading them optional. Don't know yet if we later need to hardcode some values later.