### PR TITLE
Fix rustdoc json filename to upload artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ragnarok-packets.json
-          path: target/doc/ragnarok-packets.json
+          path: target/doc/ragnarok_packets.json
 
   build-nix-dev-shell:
     name: Build Nix devShell


### PR DESCRIPTION
After testing locally, it seems the file is using the `ragnarok_packets` to generate, but it will keep `ragnarok-packets` when uploading the file.