### PR TITLE
Proposal for different packet versions handling.

### DIFF
--- a/korangar-networking/Cargo.toml
+++ b/korangar-networking/Cargo.toml
@@ -12,9 +12,13 @@ tokio = { workspace = true, features = ["rt", "io-util", "net", "macros", "sync"
 
 [dev-dependencies]
 korangar-debug = { workspace = true }
+ragnarok-packets = { workspace = true, features = ["derive"]}
 reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true, features = ["derive"] }
 
 [features]
 debug = []
-interface = ["korangar-interface", "rust-state"]
+interface = ["korangar-interface", "rust-state", "ragnarok-packets/packet-to-state-element"]
+# This feature is required for specific-packet-version example, without it when running `cargo test` or `cargo test --all-features` on workspace
+# compiler will complain "missing `to_element` in implementation".
+packet-to-state-element = []

--- a/korangar-networking/README.md
+++ b/korangar-networking/README.md
@@ -17,3 +17,10 @@ cargo run --example ollama-chat-bot
 ```
 
 ##### Note: Make sure that Ollama is serving and the model specified in `OLLAMA_MODEL` is installed, otherwise you will get a `404`
+
+
+### Specific packet version
+
+A small example of how can be implement a specific packet version.
+
+It creates 3 server (login, char, map) and simulate packet exchange using actual packet from older version of the game.

--- a/korangar-networking/examples/ollama-chat-bot.rs
+++ b/korangar-networking/examples/ollama-chat-bot.rs
@@ -4,7 +4,8 @@ use std::thread::sleep;
 use std::time::Duration;
 
 use korangar_debug::logging::Colorize;
-use korangar_networking::{DisconnectReason, NetworkEvent, NetworkingSystem};
+use korangar_networking::packet_version::{CharPacketHandlerRegister, LoginPacketHandlerRegister, MapPacketHandlerRegister};
+use korangar_networking::{CharPacketFactory, DisconnectReason, LoginPacketFactory, MapPacketFactory, NetworkEvent, NetworkingSystem};
 use reqwest::StatusCode;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -59,6 +60,28 @@ impl MessageHistory {
     }
 }
 
+#[derive(Copy, Clone)]
+pub struct NoopLoginPacketFactory;
+#[derive(Copy, Clone)]
+pub struct NoopCharPacketFactory;
+#[derive(Copy, Clone)]
+pub struct NoopMapPacketFactory;
+
+#[derive(Copy, Clone)]
+pub struct NoopLoginPacketHandlerRegister;
+#[derive(Copy, Clone)]
+pub struct NoopCharPacketHandlerRegister;
+#[derive(Copy, Clone)]
+pub struct NoopMapPacketHandlerRegister;
+
+impl LoginPacketFactory for NoopLoginPacketFactory {}
+impl CharPacketFactory for NoopCharPacketFactory {}
+impl MapPacketFactory for NoopMapPacketFactory {}
+
+impl LoginPacketHandlerRegister for NoopLoginPacketHandlerRegister {}
+impl CharPacketHandlerRegister for NoopCharPacketHandlerRegister {}
+impl MapPacketHandlerRegister for NoopMapPacketHandlerRegister {}
+
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
     // Chat bot settings.
@@ -70,7 +93,14 @@ async fn main() {
     const CHARACTER_NAME: &str = "character name";
 
     // Create the networking system and HTTP client.
-    let (mut networking_system, mut network_event_buffer) = NetworkingSystem::spawn();
+    let (mut networking_system, mut network_event_buffer) = NetworkingSystem::spawn(
+        NoopLoginPacketFactory,
+        NoopCharPacketFactory,
+        NoopMapPacketFactory,
+        NoopLoginPacketHandlerRegister,
+        NoopCharPacketHandlerRegister,
+        NoopMapPacketHandlerRegister,
+    );
     let client = reqwest::Client::new();
 
     // Persistent data.

--- a/korangar-networking/examples/specific-packet-version.rs
+++ b/korangar-networking/examples/specific-packet-version.rs
@@ -1,0 +1,493 @@
+#![cfg_attr(feature = "interface", feature(negative_impls))]
+#![cfg_attr(feature = "interface", feature(impl_trait_in_assoc_type))]
+
+use std::io::{Read, Write};
+use std::net::{IpAddr, Ipv4Addr, Shutdown, SocketAddr, TcpListener, TcpStream};
+use std::sync::atomic::Ordering::SeqCst;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, RwLock};
+use std::thread::{JoinHandle, spawn};
+use std::time::Instant;
+
+use korangar_debug::logging::Colorize;
+use korangar_networking::event::NetworkEventList;
+use korangar_networking::packet_version::{
+    CharPacketHandlerRegister, LoginPacketHandlerRegister, MapPacketHandlerRegister, MapPacketHandlerState,
+};
+use korangar_networking::{
+    CharPacketFactory, CharacterServerLoginData, LoginPacketFactory, LoginServerLoginData, MapPacketFactory, NetworkEvent, NetworkingSystem,
+};
+use ragnarok_bytes::{ByteReader, ByteWriter, FromBytes, ToBytes};
+use ragnarok_packets::{
+    AccountId, CharacterId, CharacterInformation, CharacterServer, CharacterServerInformation, CharacterServerLoginPacket,
+    CharacterServerPacket, ClientPacket, ClientTick, Direction, LoginServer, LoginServerLoginPacket, LoginServerPacket, MapServer,
+    MapServerPacket, Packet, PacketExt, ServerAddress, ServerPacket, Sex, WorldPosition,
+};
+
+/// Example of how korangar can support a specific packet version, via an
+/// external crate.
+
+/// Old packets version
+#[derive(Debug, Clone, Packet, ServerPacket, LoginServer)]
+#[header(0x0069)]
+#[variable_length]
+#[cfg_attr(feature = "interface", derive(rust_state::RustState, korangar_interface::element::StateElement))]
+struct LoginServerLoginSuccessPacketOld {
+    pub auth_code: i32,
+    pub aid: u32,
+    pub user_level: u32,
+    pub last_login_ip: u32,
+    pub sex: Sex,
+    pub server_list: Vec<CharacterServerInformation>,
+}
+
+#[derive(Debug, Clone, Packet, ServerPacket, CharacterServer)]
+#[header(0x006B)]
+#[cfg_attr(feature = "interface", derive(rust_state::RustState, korangar_interface::element::StateElement))]
+pub struct CharacterServerLoginSuccessPacketOld {
+    pub total_slot_num: u8,
+    pub premium_start_slot: u8,
+    pub code: u8,
+    pub time1: u8,
+    pub time2: u8,
+    pub char_info: Vec<CharacterInformation>,
+}
+
+#[derive(Debug, Clone, Packet, ClientPacket, MapServer)]
+#[header(0x0072)]
+#[cfg_attr(feature = "interface", derive(rust_state::RustState, korangar_interface::element::StateElement))]
+pub struct MapServerLoginPacketOld {
+    pub account_id: AccountId,
+    pub character_id: CharacterId,
+    pub login_id1: u32,
+    pub client_tick: ClientTick,
+    pub sex: Sex,
+}
+
+#[derive(Debug, Clone, Packet, ServerPacket, MapServer)]
+#[header(0x0073)]
+#[cfg_attr(feature = "interface", derive(rust_state::RustState, korangar_interface::element::StateElement))]
+pub struct MapServerEnterOld {
+    pub client_tick: ClientTick,
+    pub position: WorldPosition,
+    #[new_default]
+    pub ignored: [u8; 2],
+}
+
+#[derive(Copy, Clone)]
+pub struct CustomLoginPacketFactory;
+#[derive(Copy, Clone)]
+pub struct CustomCharPacketFactory;
+#[derive(Copy, Clone)]
+pub struct CustomMapPacketFactory;
+
+#[derive(Copy, Clone)]
+pub struct CustomLoginPacketReceiver;
+#[derive(Copy, Clone)]
+pub struct CustomCharPacketReceiver;
+#[derive(Copy, Clone)]
+pub struct CustomMapPacketReceiver;
+
+/// Registering packet handlers for old packets sent by server
+impl LoginPacketHandlerRegister for CustomLoginPacketReceiver {
+    fn register_version_specific_handler<Output, Meta, Callback>(
+        &self,
+        packet_handler: &mut ragnarok_packets::handler::PacketHandler<Output, Meta, Callback>,
+    ) where
+        Output: From<NetworkEventList> + Default,
+        Meta: Default,
+        Callback: ragnarok_packets::handler::PacketCallback,
+    {
+        packet_handler
+            .register(|custom_login_response: LoginServerLoginSuccessPacketOld| {
+                println!("Login response received: account_id={}", custom_login_response.aid,);
+                NetworkEventList::from(NetworkEvent::LoginServerConnected {
+                    character_servers: custom_login_response.server_list,
+                    login_data: LoginServerLoginData {
+                        account_id: AccountId(custom_login_response.aid),
+                        login_id1: custom_login_response.auth_code as u32,
+                        login_id2: custom_login_response.user_level,
+                        sex: custom_login_response.sex,
+                    },
+                })
+            })
+            .unwrap();
+    }
+}
+
+impl CharPacketHandlerRegister for CustomCharPacketReceiver {
+    fn register_version_specific_handler<Output, Meta, Callback>(
+        &self,
+        packet_handler: &mut ragnarok_packets::handler::PacketHandler<Output, Meta, Callback>,
+    ) where
+        Output: From<NetworkEventList> + Default,
+        Meta: Default,
+        Callback: ragnarok_packets::handler::PacketCallback,
+    {
+        packet_handler
+            .register(|packet: CharacterServerLoginSuccessPacketOld| {
+                NetworkEventList::from(vec![
+                    NetworkEvent::CharacterServerConnected {
+                        normal_slot_count: packet.total_slot_num as usize,
+                    },
+                    NetworkEvent::CharacterList {
+                        characters: packet.char_info,
+                    },
+                ])
+            })
+            .unwrap();
+    }
+}
+
+impl MapPacketHandlerRegister for CustomMapPacketReceiver {
+    fn register_version_specific_handler<Output, Meta, Callback>(
+        &self,
+        packet_handler: &mut ragnarok_packets::handler::PacketHandler<Output, Meta, Callback>,
+        _state: &MapPacketHandlerState,
+    ) where
+        Output: From<NetworkEventList> + Default,
+        Meta: Default,
+        Callback: ragnarok_packets::handler::PacketCallback,
+    {
+        packet_handler
+            .register(|packet: MapServerEnterOld| {
+                NetworkEventList::from(NetworkEvent::UpdateClientTick {
+                    client_tick: packet.client_tick,
+                    received_at: Instant::now(),
+                })
+            })
+            .unwrap();
+    }
+}
+
+/// Define packets to be sent for this specific version
+impl LoginPacketFactory for CustomLoginPacketFactory {
+    fn login_server_login(&self, username: impl Into<String>, password: impl Into<String>) -> impl LoginServerPacket {
+        LoginServerLoginPacket::new(username.into(), password.into())
+    }
+}
+impl CharPacketFactory for CustomCharPacketFactory {
+    fn char_server_login(&self, login_data: &LoginServerLoginData) -> impl CharacterServerPacket {
+        CharacterServerLoginPacket::new(
+            login_data.account_id,
+            login_data.login_id1,
+            login_data.login_id2,
+            login_data.sex,
+        )
+    }
+}
+impl MapPacketFactory for CustomMapPacketFactory {
+    fn map_server_login(
+        &self,
+        account_id: AccountId,
+        character_id: CharacterId,
+        login_id1: u32,
+        client_tick: ClientTick,
+        sex: Sex,
+    ) -> impl MapServerPacket {
+        MapServerLoginPacketOld {
+            account_id,
+            character_id,
+            login_id1,
+            client_tick,
+            sex,
+        }
+    }
+}
+
+fn main() {
+    let login_server = Server {
+        name: "login".to_string(),
+        local_port: 8610,
+        specific_proxy: LoginServer {},
+        is_alive: Arc::new(AtomicBool::new(true)),
+    };
+    let char_server = Server {
+        name: "char".to_string(),
+        local_port: 8611,
+        specific_proxy: CharServer {},
+        is_alive: Arc::new(AtomicBool::new(true)),
+    };
+    let map_server = Server {
+        name: "map".to_string(),
+        local_port: 8612,
+        specific_proxy: MapServer {},
+        is_alive: Arc::new(AtomicBool::new(true)),
+    };
+    let mut handles: Vec<JoinHandle<()>> = Vec::new();
+    handles.push(login_server.start());
+    handles.push(char_server.start());
+    handles.push(map_server.start());
+
+    let (mut networking_system, mut network_event_buffer) = NetworkingSystem::spawn(
+        CustomLoginPacketFactory,
+        CustomCharPacketFactory,
+        CustomMapPacketFactory,
+        CustomLoginPacketReceiver,
+        CustomCharPacketReceiver,
+        CustomMapPacketReceiver,
+    );
+
+    networking_system.connect_to_login_server(
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), login_server.local_port),
+        "username",
+        "password",
+    );
+    let mut saved_login_data = None;
+
+    loop {
+        networking_system.get_events(&mut network_event_buffer);
+
+        for event in network_event_buffer.drain() {
+            match event {
+                NetworkEvent::LoginServerConnected {
+                    character_servers,
+                    login_data,
+                } => {
+                    println!("[{}] Successfully connected to login server", "Setup".green());
+
+                    networking_system.disconnect_from_login_server();
+                    networking_system.connect_to_character_server(&login_data, character_servers[0].clone());
+
+                    saved_login_data = Some(login_data);
+                }
+                NetworkEvent::CharacterServerConnected { normal_slot_count } => {
+                    println!(
+                        "[{}] Successfully connected to character server, slots {}",
+                        "Setup".green(),
+                        normal_slot_count
+                    );
+                }
+                NetworkEvent::CharacterList { characters } => {
+                    println!("Received character list: {}", characters.len());
+                    let data = CharacterServerLoginData {
+                        server_ip: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                        server_port: map_server.local_port,
+                        character_id: CharacterId(150000),
+                    };
+                    networking_system.connect_to_map_server(saved_login_data.as_ref().unwrap(), data);
+                }
+                NetworkEvent::UpdateClientTick { client_tick, .. } => {
+                    println!(
+                        "[{}] Successfully connected to map server, tick {:?}",
+                        "Setup".green(),
+                        client_tick
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+// Simulate server
+
+#[derive(Clone)]
+pub struct Server<T: PacketHandler> {
+    pub name: String,
+    pub local_port: u16,
+    pub specific_proxy: T,
+    pub is_alive: Arc<AtomicBool>,
+}
+
+pub trait PacketHandler {
+    fn handle_packet(&self, tcp_stream: Arc<RwLock<TcpStream>>, packet: &[u8]);
+}
+
+impl<T: 'static + PacketHandler + Clone + Send + Sync> Server<T> {
+    pub fn start(&self) -> JoinHandle<()> {
+        let listener = TcpListener::bind(format!("0.0.0.0:{}", self.local_port)).unwrap();
+        let immutable_self_ref = Arc::new(self.clone());
+        let server_ref = immutable_self_ref.clone();
+        spawn(move || {
+            println!("Start server {}, on port {}", server_ref.name, server_ref.local_port);
+            for tcp_stream in listener.incoming() {
+                if !server_ref.is_alive.load(Ordering::Relaxed) {
+                    break;
+                }
+                let server_ref = immutable_self_ref.clone();
+                // Receive new connection, starting new thread
+                spawn(move || {
+                    server_ref.listen(tcp_stream.unwrap());
+                });
+            }
+            println!("shutdown server {}", server_ref.name);
+        })
+    }
+
+    pub fn shutdown(&self) {
+        self.is_alive.store(false, SeqCst);
+        TcpStream::connect(format!("127.0.0.1:{}", self.local_port))
+            .map(|mut stream| stream.flush())
+            .ok();
+    }
+
+    fn listen(&self, mut incoming_stream: TcpStream) {
+        let mut buffer = [0; 2048];
+        let tcp_stream_arc = Arc::new(RwLock::new(incoming_stream.try_clone().unwrap()));
+        loop {
+            if !self.is_alive.load(Ordering::Relaxed) {
+                let _ = incoming_stream.shutdown(Shutdown::Both);
+                break;
+            }
+            match incoming_stream.read(&mut buffer) {
+                Ok(bytes_read) => {
+                    self.specific_proxy.handle_packet(tcp_stream_arc.clone(), &buffer[..bytes_read]);
+                }
+                Err(_) => {}
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+struct LoginServer {}
+#[derive(Clone)]
+struct CharServer {}
+#[derive(Clone)]
+struct MapServer {}
+
+impl PacketHandler for LoginServer {
+    fn handle_packet(&self, tcp_stream: Arc<RwLock<TcpStream>>, packet: &[u8]) {
+        if packet.is_empty() {
+            return;
+        }
+        println!("LoginServer received packet: {:02X?}", packet);
+
+        let mut byte_reader = ByteReader::without_metadata(packet);
+        match LoginServerLoginPacket::packet_from_bytes(&mut byte_reader) {
+            Ok(_login_packet) => {
+                let response = LoginServerLoginSuccessPacketOld {
+                    auth_code: 1234,
+                    aid: 2000000,
+                    user_level: 90,
+                    last_login_ip: 0,
+                    sex: Sex::Male,
+                    server_list: vec![CharacterServerInformation {
+                        server_ip: ServerAddress([127, 0, 0, 1]),
+                        server_port: 8611,
+                        server_name: "Korangar".to_string(),
+                        user_count: 0,
+                        server_type: 0,
+                        display_new: 0,
+                        unknown: [0; 128],
+                    }],
+                };
+
+                let mut byte_writer = ByteWriter::default();
+                if let Ok(_) = response.packet_to_bytes(&mut byte_writer) {
+                    if let Ok(mut stream) = tcp_stream.write() {
+                        let _ = stream.write_all(byte_writer.as_slice()).unwrap();
+                    }
+                }
+            }
+            Err(e) => println!("Failed to parse login packet: {:?}", e),
+        }
+    }
+}
+
+impl PacketHandler for CharServer {
+    fn handle_packet(&self, tcp_stream: Arc<RwLock<TcpStream>>, packet: &[u8]) {
+        if packet.is_empty() {
+            return;
+        }
+        println!("CharServer received packet: {:02X?}", packet);
+
+        let mut byte_reader = ByteReader::without_metadata(packet);
+        match CharacterServerLoginPacket::packet_from_bytes(&mut byte_reader) {
+            Ok(_char_packet) => {
+                let response = CharacterServerLoginSuccessPacketOld {
+                    total_slot_num: 12,
+                    premium_start_slot: 0,
+                    code: 12,
+                    time1: 1,
+                    time2: 2,
+                    char_info: vec![CharacterInformation {
+                        character_id: CharacterId(150000),
+                        experience: 0,
+                        money: 0,
+                        job_experience: 0,
+                        job_level: 0,
+                        body_state: 0,
+                        health_state: 0,
+                        effect_state: 0,
+                        virtue: 0,
+                        honor: 0,
+                        job_points: 0,
+                        health_points: 0,
+                        maximum_health_points: 0,
+                        spell_points: 0,
+                        maximum_spell_points: 0,
+                        movement_speed: 0,
+                        job: 0,
+                        head: 0,
+                        body: 0,
+                        weapon: 0,
+                        base_level: 0,
+                        sp_point: 0,
+                        accessory: 0,
+                        shield: 0,
+                        accessory2: 0,
+                        accessory3: 0,
+                        head_palette: 0,
+                        body_palette: 0,
+                        name: "".to_string(),
+                        strength: 0,
+                        agility: 0,
+                        vit: 0,
+                        intelligence: 0,
+                        dexterity: 0,
+                        luck: 0,
+                        character_number: 0,
+                        hair_color: 0,
+                        b_is_changed_char: 0,
+                        map_name: "".to_string(),
+                        deletion_reverse_date: 0,
+                        robe_palette: 0,
+                        character_slot_change_count: 0,
+                        character_name_change_count: 0,
+                        sex: Sex::Male,
+                    }],
+                };
+                let mut byte_writer = ByteWriter::default();
+                AccountId(200000).to_bytes(&mut byte_writer).unwrap();
+                if let Ok(_) = response.packet_to_bytes(&mut byte_writer) {
+                    if let Ok(mut stream) = tcp_stream.write() {
+                        let _ = stream.write_all(byte_writer.as_slice());
+                    }
+                }
+            }
+            Err(e) => println!("Failed to parse char packet: {:?}", e),
+        }
+    }
+}
+
+impl PacketHandler for MapServer {
+    fn handle_packet(&self, tcp_stream: Arc<RwLock<TcpStream>>, packet: &[u8]) {
+        println!("MapServer received packet: {:02X?}", packet);
+
+        let mut byte_reader = ByteReader::without_metadata(packet);
+        match MapServerLoginPacketOld::packet_from_bytes(&mut byte_reader) {
+            Ok(_map_packet) => {
+                // Send response using proper response packet
+                let response = MapServerEnterOld {
+                    client_tick: ClientTick(100),
+                    position: WorldPosition {
+                        x: 156,
+                        y: 112,
+                        direction: Direction::N,
+                    },
+                    ignored: [0; 2],
+                };
+
+                let mut byte_writer = ByteWriter::default();
+                if let Ok(_) = response.packet_to_bytes(&mut byte_writer) {
+                    if let Ok(mut stream) = tcp_stream.write() {
+                        let _ = stream.write_all(byte_writer.as_slice());
+                    }
+                }
+            }
+            Err(e) => println!("Failed to parse map packet: {:?}", e),
+        }
+    }
+}

--- a/korangar-networking/src/event.rs
+++ b/korangar-networking/src/event.rs
@@ -227,7 +227,7 @@ pub enum NetworkEvent {
 /// New-type so we can implement some `From` traits. This will help when
 /// registering the packet handlers.
 #[derive(Default)]
-pub(crate) struct NetworkEventList(pub Vec<NetworkEvent>);
+pub struct NetworkEventList(pub Vec<NetworkEvent>);
 
 pub(crate) struct NoNetworkEvents;
 

--- a/korangar-networking/src/packet_version/mod.rs
+++ b/korangar-networking/src/packet_version/mod.rs
@@ -1,0 +1,214 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use ragnarok_packets::handler::{PacketCallback, PacketHandler};
+use ragnarok_packets::{
+    AccountId, BuyOrSellOption, BuyShopItemInformation, CharacterId, CharacterServerPacket, ClientTick, EmptyCharServerPacket,
+    EmptyLoginServerPacket, EmptyMapServerPacket, EntityId, EquipPosition, HotbarSlot, HotbarTab, HotkeyData, InventoryIndex,
+    LoginServerPacket, MapServerPacket, Sex, ShopId, SkillId, SkillLevel, SoldItemInformation, TilePosition, WorldPosition,
+};
+
+use crate::event::NetworkEventList;
+use crate::{InventoryItem, LoginServerLoginData, NoMetadata};
+
+pub mod receiver_base;
+pub mod sender_base;
+
+pub struct MapPacketHandlerState {
+    pub inventory_items: Rc<RefCell<Option<Vec<InventoryItem<NoMetadata>>>>>,
+}
+
+pub trait LoginPacketHandlerRegister: Send + Copy + 'static {
+    fn register_version_specific_handler<Output, Meta, Callback>(&self, _packet_handler: &mut PacketHandler<Output, Meta, Callback>)
+    where
+        Output: From<NetworkEventList> + Default,
+        Meta: Default,
+        Callback: PacketCallback + Send,
+    {
+        // noop
+    }
+}
+pub trait CharPacketHandlerRegister: Send + Copy + 'static {
+    fn register_version_specific_handler<Output, Meta, Callback>(&self, _packet_handler: &mut PacketHandler<Output, Meta, Callback>)
+    where
+        Output: From<NetworkEventList> + Default,
+        Meta: Default,
+        Callback: PacketCallback + Send,
+    {
+        // noop
+    }
+}
+pub trait MapPacketHandlerRegister: Send + Copy + 'static {
+    fn register_version_specific_handler<Output, Meta, Callback>(
+        &self,
+        _packet_handler: &mut PacketHandler<Output, Meta, Callback>,
+        _state: &MapPacketHandlerState,
+    ) where
+        Output: From<NetworkEventList> + Default,
+        Meta: Default,
+        Callback: PacketCallback + Send,
+    {
+        // noop
+    }
+}
+
+pub trait LoginPacketFactory: Clone + Send + 'static {
+    fn login_server_login(&self, _username: impl Into<String>, _password: impl Into<String>) -> impl LoginServerPacket {
+        EmptyLoginServerPacket {}
+    }
+}
+
+pub trait CharPacketFactory: Clone + Send + 'static {
+    fn char_server_login(&self, _login_data: &LoginServerLoginData) -> impl CharacterServerPacket {
+        EmptyCharServerPacket {}
+    }
+    fn request_character_list(&self) -> impl CharacterServerPacket {
+        EmptyCharServerPacket {}
+    }
+
+    fn select_character(&self, _character_slot: usize) -> impl CharacterServerPacket {
+        EmptyCharServerPacket {}
+    }
+
+    fn create_character(
+        &self,
+        _slot: usize,
+        _name: String,
+        _hair_color: usize,
+        _hair_style: usize,
+        _start_job: usize,
+        _sex: Sex,
+    ) -> impl CharacterServerPacket {
+        EmptyCharServerPacket {}
+    }
+
+    fn delete_character(&self, _character_id: CharacterId, _email: String) -> impl CharacterServerPacket {
+        EmptyCharServerPacket {}
+    }
+
+    fn switch_character_slot(&self, _origin_slot: usize, _destination_slot: usize) -> impl CharacterServerPacket {
+        EmptyCharServerPacket {}
+    }
+}
+
+pub trait MapPacketFactory: Clone + Send + 'static {
+    fn map_server_login(
+        &self,
+        _account_id: AccountId,
+        _character_id: CharacterId,
+        _login_id1: u32,
+        _client_tick: ClientTick,
+        _sex: Sex,
+    ) -> impl MapServerPacket {
+        EmptyMapServerPacket {}
+    }
+    fn map_loaded(&self) -> impl MapServerPacket {
+        EmptyMapServerPacket {}
+    }
+    fn request_client_tick(&self, _client_tick: ClientTick) -> impl MapServerPacket {
+        EmptyMapServerPacket {}
+    }
+    fn respawn(&self) -> impl MapServerPacket {
+        EmptyMapServerPacket {}
+    }
+
+    fn log_out(&self) -> impl MapServerPacket {
+        EmptyMapServerPacket {}
+    }
+
+    fn player_move(&self, _position: WorldPosition) -> impl MapServerPacket {
+        EmptyMapServerPacket {}
+    }
+
+    fn warp_to_map(&self, _map_name: String, _position: TilePosition) -> impl MapServerPacket {
+        EmptyMapServerPacket {}
+    }
+
+    fn entity_details(&self, _entity_id: EntityId) -> impl MapServerPacket {
+        EmptyMapServerPacket {}
+    }
+
+    fn player_attack(&self, _entity_id: EntityId) -> impl MapServerPacket {
+        EmptyMapServerPacket {}
+    }
+
+    fn send_chat_message(&self, _player_name: &str, _text: &str) -> impl MapServerPacket {
+        EmptyMapServerPacket {}
+    }
+
+    fn start_dialog(&self, _npc_id: EntityId) -> impl MapServerPacket {
+        EmptyMapServerPacket {}
+    }
+
+    fn next_dialog(&self, _npc_id: EntityId) -> impl MapServerPacket {
+        EmptyMapServerPacket {}
+    }
+
+    fn close_dialog(&self, _npc_id: EntityId) -> impl MapServerPacket {
+        EmptyMapServerPacket {}
+    }
+
+    fn choose_dialog_option(&self, _npc_id: EntityId, _option: i8) -> impl MapServerPacket {
+        EmptyMapServerPacket {}
+    }
+
+    fn request_item_equip(&self, _item_index: InventoryIndex, _equip_position: EquipPosition) -> impl MapServerPacket {
+        EmptyMapServerPacket {}
+    }
+
+    fn request_item_unequip(&self, _item_index: InventoryIndex) -> impl MapServerPacket {
+        EmptyMapServerPacket {}
+    }
+
+    fn cast_skill(&self, _skill_id: SkillId, _skill_level: SkillLevel, _entity_id: EntityId) -> impl MapServerPacket {
+        EmptyMapServerPacket {}
+    }
+
+    fn cast_ground_skill(&self, _skill_id: SkillId, _skill_level: SkillLevel, _target_position: TilePosition) -> impl MapServerPacket {
+        EmptyMapServerPacket {}
+    }
+
+    fn cast_channeling_skill(&self, _skill_id: SkillId, _skill_level: SkillLevel, _entity_id: EntityId) -> impl MapServerPacket {
+        EmptyMapServerPacket {}
+    }
+
+    fn stop_channeling_skill(&self, _skill_id: SkillId) -> impl MapServerPacket {
+        EmptyMapServerPacket {}
+    }
+
+    fn add_friend(&self, _name: String) -> impl MapServerPacket {
+        EmptyMapServerPacket {}
+    }
+
+    fn remove_friend(&self, _account_id: AccountId, _character_id: CharacterId) -> impl MapServerPacket {
+        EmptyMapServerPacket {}
+    }
+
+    fn reject_friend_request(&self, _account_id: AccountId, _character_id: CharacterId) -> impl MapServerPacket {
+        EmptyMapServerPacket {}
+    }
+
+    fn accept_friend_request(&self, _account_id: AccountId, _character_id: CharacterId) -> impl MapServerPacket {
+        EmptyMapServerPacket {}
+    }
+
+    fn set_hotkey_data(&self, _tab: HotbarTab, _index: HotbarSlot, _hotkey_data: HotkeyData) -> impl MapServerPacket {
+        EmptyMapServerPacket {}
+    }
+
+    fn select_buy_or_sell(&self, _shop_id: ShopId, _buy_or_sell: BuyOrSellOption) -> impl MapServerPacket {
+        EmptyMapServerPacket {}
+    }
+
+    fn purchase_items(&self, _items: Vec<BuyShopItemInformation>) -> impl MapServerPacket {
+        EmptyMapServerPacket {}
+    }
+
+    fn close_shop(&self) -> impl MapServerPacket {
+        EmptyMapServerPacket {}
+    }
+
+    fn sell_items(&self, _items: Vec<SoldItemInformation>) -> impl MapServerPacket {
+        EmptyMapServerPacket {}
+    }
+}

--- a/korangar-networking/src/packet_version/receiver_base.rs
+++ b/korangar-networking/src/packet_version/receiver_base.rs
@@ -1,0 +1,14 @@
+use crate::packet_version::{CharPacketHandlerRegister, LoginPacketHandlerRegister, MapPacketHandlerRegister};
+
+#[derive(Copy, Clone)]
+pub struct BaseLoginPacketReceiver;
+#[derive(Copy, Clone)]
+pub struct BaseCharPacketReceiver;
+#[derive(Copy, Clone)]
+pub struct BaseMapPacketReceiver;
+
+impl LoginPacketHandlerRegister for BaseLoginPacketReceiver {}
+
+impl CharPacketHandlerRegister for BaseCharPacketReceiver {}
+
+impl MapPacketHandlerRegister for BaseMapPacketReceiver {}

--- a/korangar-networking/src/packet_version/sender_base.rs
+++ b/korangar-networking/src/packet_version/sender_base.rs
@@ -1,0 +1,194 @@
+use ragnarok_packets::{
+    AccountId, Action, AddFriendPacket, BuyOrSellOption, BuyShopItemInformation, BuyShopItemsPacket, CharacterId,
+    CharacterServerLoginPacket, CharacterServerPacket, ChooseDialogOptionPacket, ClientTick, CloseDialogPacket, CloseShopPacket,
+    CreateCharacterPacket, DeleteCharacterPacket, EndUseSkillPacket, EntityId, EquipPosition, FriendRequestResponse,
+    FriendRequestResponsePacket, GlobalMessagePacket, HotbarSlot, HotbarTab, HotkeyData, InventoryIndex, LoginServerLoginPacket,
+    LoginServerPacket, MapLoadedPacket, MapServerLoginPacket, MapServerPacket, NextDialogPacket, RemoveFriendPacket, RequestActionPacket,
+    RequestCharacterListPacket, RequestDetailsPacket, RequestEquipItemPacket, RequestPlayerMovePacket, RequestServerTickPacket,
+    RequestUnequipItemPacket, RequestWarpToMapPacket, RestartPacket, RestartType, SelectBuyOrSellPacket, SelectCharacterPacket,
+    SellItemsPacket, SetHotkeyData2Packet, Sex, ShopId, SkillId, SkillLevel, SoldItemInformation, StartDialogPacket, StartUseSkillPacket,
+    SwitchCharacterSlotPacket, TilePosition, UseSkillAtIdPacket, UseSkillOnGroundPacket, WorldPosition,
+};
+
+use crate::{CharPacketFactory, LoginPacketFactory, LoginServerLoginData, MapPacketFactory};
+
+#[derive(Clone)]
+pub struct BaseLoginPacketFactory;
+
+#[derive(Clone)]
+pub struct BaseCharPacketFactory;
+
+#[derive(Clone)]
+pub struct BaseMapPacketFactory;
+
+impl LoginPacketFactory for BaseLoginPacketFactory {
+    fn login_server_login(&self, username: impl Into<String>, password: impl Into<String>) -> impl LoginServerPacket {
+        LoginServerLoginPacket::new(username.into(), password.into())
+    }
+}
+
+impl CharPacketFactory for BaseCharPacketFactory {
+    fn char_server_login(&self, login_data: &LoginServerLoginData) -> impl CharacterServerPacket {
+        CharacterServerLoginPacket::new(
+            login_data.account_id,
+            login_data.login_id1,
+            login_data.login_id2,
+            login_data.sex,
+        )
+    }
+
+    fn request_character_list(&self) -> impl CharacterServerPacket {
+        RequestCharacterListPacket::default()
+    }
+
+    fn select_character(&self, character_slot: usize) -> impl CharacterServerPacket {
+        SelectCharacterPacket::new(character_slot as u8)
+    }
+
+    fn create_character(
+        &self,
+        slot: usize,
+        name: String,
+        hair_color: usize,
+        hair_style: usize,
+        start_job: usize,
+        sex: Sex,
+    ) -> impl CharacterServerPacket {
+        CreateCharacterPacket::new(name, slot as u8, hair_color as u16, hair_style as u16, start_job as u16, sex)
+    }
+
+    fn delete_character(&self, character_id: CharacterId, _email: String) -> impl CharacterServerPacket {
+        let email = "a@a.com".to_string();
+        DeleteCharacterPacket::new(character_id, email)
+    }
+
+    fn switch_character_slot(&self, origin_slot: usize, destination_slot: usize) -> impl CharacterServerPacket {
+        SwitchCharacterSlotPacket::new(origin_slot as u16, destination_slot as u16)
+    }
+}
+
+impl MapPacketFactory for BaseMapPacketFactory {
+    fn map_server_login(
+        &self,
+        account_id: AccountId,
+        character_id: CharacterId,
+        login_id1: u32,
+        client_tick: ClientTick,
+        sex: Sex,
+    ) -> impl MapServerPacket {
+        MapServerLoginPacket::new(account_id, character_id, login_id1, client_tick, sex)
+    }
+
+    fn map_loaded(&self) -> impl MapServerPacket {
+        MapLoadedPacket::default()
+    }
+
+    fn request_client_tick(&self, client_tick: ClientTick) -> impl MapServerPacket {
+        RequestServerTickPacket::new(client_tick)
+    }
+
+    fn respawn(&self) -> impl MapServerPacket {
+        RestartPacket::new(RestartType::Respawn)
+    }
+
+    fn log_out(&self) -> impl MapServerPacket {
+        RestartPacket::new(RestartType::Disconnect)
+    }
+
+    fn player_move(&self, position: WorldPosition) -> impl MapServerPacket {
+        RequestPlayerMovePacket::new(position)
+    }
+
+    fn warp_to_map(&self, map_name: String, position: TilePosition) -> impl MapServerPacket {
+        RequestWarpToMapPacket::new(map_name, position)
+    }
+
+    fn entity_details(&self, entity_id: EntityId) -> impl MapServerPacket {
+        RequestDetailsPacket::new(entity_id)
+    }
+
+    fn player_attack(&self, entity_id: EntityId) -> impl MapServerPacket {
+        RequestActionPacket::new(entity_id, Action::Attack)
+    }
+
+    fn send_chat_message(&self, player_name: &str, text: &str) -> impl MapServerPacket {
+        let message = format!("{} : {}", player_name, text);
+        GlobalMessagePacket::new(message)
+    }
+
+    fn start_dialog(&self, npc_id: EntityId) -> impl MapServerPacket {
+        StartDialogPacket::new(npc_id)
+    }
+
+    fn next_dialog(&self, npc_id: EntityId) -> impl MapServerPacket {
+        NextDialogPacket::new(npc_id)
+    }
+
+    fn close_dialog(&self, npc_id: EntityId) -> impl MapServerPacket {
+        CloseDialogPacket::new(npc_id)
+    }
+
+    fn choose_dialog_option(&self, npc_id: EntityId, option: i8) -> impl MapServerPacket {
+        ChooseDialogOptionPacket::new(npc_id, option)
+    }
+
+    fn request_item_equip(&self, item_index: InventoryIndex, equip_position: EquipPosition) -> impl MapServerPacket {
+        RequestEquipItemPacket::new(item_index, equip_position)
+    }
+
+    fn request_item_unequip(&self, item_index: InventoryIndex) -> impl MapServerPacket {
+        RequestUnequipItemPacket::new(item_index)
+    }
+
+    fn cast_skill(&self, skill_id: SkillId, skill_level: SkillLevel, entity_id: EntityId) -> impl MapServerPacket {
+        UseSkillAtIdPacket::new(skill_level, skill_id, entity_id)
+    }
+
+    fn cast_ground_skill(&self, skill_id: SkillId, skill_level: SkillLevel, target_position: TilePosition) -> impl MapServerPacket {
+        UseSkillOnGroundPacket::new(skill_level, skill_id, target_position)
+    }
+
+    fn cast_channeling_skill(&self, skill_id: SkillId, skill_level: SkillLevel, entity_id: EntityId) -> impl MapServerPacket {
+        StartUseSkillPacket::new(skill_id, skill_level, entity_id)
+    }
+
+    fn stop_channeling_skill(&self, skill_id: SkillId) -> impl MapServerPacket {
+        EndUseSkillPacket::new(skill_id)
+    }
+
+    fn add_friend(&self, name: String) -> impl MapServerPacket {
+        AddFriendPacket::new(name)
+    }
+
+    fn remove_friend(&self, account_id: AccountId, character_id: CharacterId) -> impl MapServerPacket {
+        RemoveFriendPacket::new(account_id, character_id)
+    }
+
+    fn reject_friend_request(&self, account_id: AccountId, character_id: CharacterId) -> impl MapServerPacket {
+        FriendRequestResponsePacket::new(account_id, character_id, FriendRequestResponse::Reject)
+    }
+
+    fn accept_friend_request(&self, account_id: AccountId, character_id: CharacterId) -> impl MapServerPacket {
+        FriendRequestResponsePacket::new(account_id, character_id, FriendRequestResponse::Accept)
+    }
+
+    fn set_hotkey_data(&self, tab: HotbarTab, index: HotbarSlot, hotkey_data: HotkeyData) -> impl MapServerPacket {
+        SetHotkeyData2Packet::new(tab, index, hotkey_data)
+    }
+
+    fn select_buy_or_sell(&self, shop_id: ShopId, buy_or_sell: BuyOrSellOption) -> impl MapServerPacket {
+        SelectBuyOrSellPacket::new(shop_id, buy_or_sell)
+    }
+
+    fn purchase_items(&self, items: Vec<BuyShopItemInformation>) -> impl MapServerPacket {
+        BuyShopItemsPacket::new(items)
+    }
+
+    fn close_shop(&self) -> impl MapServerPacket {
+        CloseShopPacket::new()
+    }
+
+    fn sell_items(&self, items: Vec<SoldItemInformation>) -> impl MapServerPacket {
+        SellItemsPacket { items }
+    }
+}

--- a/korangar/src/inventory/hotbar.rs
+++ b/korangar/src/inventory/hotbar.rs
@@ -1,5 +1,5 @@
 use korangar_interface::element::StateElement;
-use korangar_networking::NetworkingSystem;
+use korangar_networking::{CharPacketFactory, LoginPacketFactory, MapPacketFactory, NetworkingSystem};
 use ragnarok_packets::handler::PacketCallback;
 use ragnarok_packets::{HotbarSlot, HotbarTab, HotkeyData};
 use rust_state::RustState;
@@ -18,9 +18,16 @@ impl Hotbar {
     }
 
     /// Update the slot and notify the map server.
-    pub fn update_slot<Callback>(&mut self, networking_system: &mut NetworkingSystem<Callback>, slot: HotbarSlot, skill: Skill)
-    where
+    pub fn update_slot<Callback, L, C, M>(
+        &mut self,
+        networking_system: &mut NetworkingSystem<Callback, L, C, M>,
+        slot: HotbarSlot,
+        skill: Skill,
+    ) where
         Callback: PacketCallback + Send,
+        L: LoginPacketFactory,
+        C: CharPacketFactory,
+        M: MapPacketFactory,
     {
         let _ = networking_system.set_hotkey_data(HotbarTab(0), slot, HotkeyData {
             is_skill: true as u8,
@@ -32,13 +39,16 @@ impl Hotbar {
     }
 
     /// Swap two slots in the hotbar and notify the map server.
-    pub fn swap_slot<Callback>(
+    pub fn swap_slot<Callback, L, C, M>(
         &mut self,
-        networking_system: &mut NetworkingSystem<Callback>,
+        networking_system: &mut NetworkingSystem<Callback, L, C, M>,
         source_slot: HotbarSlot,
         destination_slot: HotbarSlot,
     ) where
         Callback: PacketCallback + Send,
+        L: LoginPacketFactory,
+        C: CharPacketFactory,
+        M: MapPacketFactory,
     {
         if source_slot != destination_slot {
             let first = self.skills[source_slot.0 as usize].take();
@@ -76,9 +86,12 @@ impl Hotbar {
     }
 
     /// Clear the slot and notify the map server.
-    pub fn clear_slot<Callback>(&mut self, networking_system: &mut NetworkingSystem<Callback>, slot: HotbarSlot)
+    pub fn clear_slot<Callback, L, C, M>(&mut self, networking_system: &mut NetworkingSystem<Callback, L, C, M>, slot: HotbarSlot)
     where
         Callback: PacketCallback + Send,
+        L: LoginPacketFactory,
+        C: CharPacketFactory,
+        M: MapPacketFactory,
     {
         let _ = networking_system.set_hotkey_data(HotbarTab(0), slot, HotkeyData::UNBOUND);
 

--- a/ragnarok-packets/src/lib.rs
+++ b/ragnarok-packets/src/lib.rs
@@ -36,6 +36,10 @@ pub trait Packet: std::fmt::Debug + Send + Clone + 'static {
     /// The header of the Packet.
     const HEADER: PacketHeader;
 
+    fn header(&self) -> PacketHeader {
+        Self::HEADER
+    }
+
     /// Read packet **without the header**. To read the packet with the header,
     /// use [`PacketExt::packet_from_bytes`].
     fn payload_from_bytes<Meta>(byte_reader: &mut ByteReader<Meta>) -> ConversionResult<Self>;
@@ -3110,3 +3114,25 @@ pub enum SellItemsResult {
 pub struct SellItemsResultPacket {
     pub result: SellItemsResult,
 }
+
+/// Empty packets, used by methods which require returning an `impl
+/// LoginServerPacket`, or `impl CharServerPacket` or `impl MapServerPacket`
+/// Some method might return no packet to send depending on the version of the
+/// game.
+#[derive(Debug, Clone, Packet)]
+#[cfg_attr(feature = "interface", derive(rust_state::RustState, korangar_interface::element::StateElement))]
+#[header(0x0)]
+pub struct EmptyLoginServerPacket {}
+impl LoginServerPacket for EmptyLoginServerPacket {}
+
+#[derive(Debug, Clone, Packet)]
+#[cfg_attr(feature = "interface", derive(rust_state::RustState, korangar_interface::element::StateElement))]
+#[header(0x0)]
+pub struct EmptyCharServerPacket {}
+impl CharacterServerPacket for EmptyCharServerPacket {}
+
+#[derive(Debug, Clone, Packet)]
+#[cfg_attr(feature = "interface", derive(rust_state::RustState, korangar_interface::element::StateElement))]
+#[header(0x0)]
+pub struct EmptyMapServerPacket {}
+impl MapServerPacket for EmptyMapServerPacket {}


### PR DESCRIPTION
This is a proposal for #306 
This proposal provides to korangar capability to handle different packets versions, leveraging existing handler mecanism.
For packet emission, a new `factory` concept has been added.

# Goals
Goals achieved by this proposal:
- Korangar is unaware of packet version
- There at the moment no condition on packet version
- Korangar is now extensible by any 3rd party developer who want to use its own packet version. Support of a specific version of packet can be done in an external crate, one can maintain its own crate of packet handling and inject its implementation in korangar main without any changes.
- Minimize maintenance effort in korangar 
- Avoid impacting korangar compile time
- Avoid impacting korangar binary size
- For now there is no feature flags, customization is achieved via dependency injection

# Packet Factory
The concept of factory is to map game data into packet ready to be sent to the wire.
Factory are traits to be implemented to emit packet.

The "downside" of this approach is that between 2 specific versions, factory code will duplicated at a high percentage depending on the versions gap, but IMO it is not an issue.

# Questions

## Packet handler
Should packet handler be registered for a specific version only?

In my proposal I kept handling of existing packets as it was in `NetworkingSystem`, with a mecanism to inject a `register` which can be used to register additional handler.
With the approach describe above we can encounter `DuplicateHandlerError`, this was the case with `CharacterListPacket` which had a `noop` handler register, but in my example i want to handle this packet as it is sent by the server in my specific version.


Thus i am not sure if I should go further in the approach and instead of allowing registering additionnal packet handler, packet handler should be defined for each versions (as for factory) and finding something to share handler between versions.

## Injection
In my commit the injection of packet factory and handler register is done in korangar main.
What would be cool would be to expose `Client` structure as public in `korangar` crate, so a 3rd party developer would have only few line of code to use it manage it own version of the game. 

# Next step
I would like to implement packets for the version supported by rust-ro, I was thinking to do that in a dedicated crate "korangar-packet-20120307" (on my own space?).
I don't know if packets should be added in `ragnarok-packets` crate, as it may slow down compilation time, is it an issue? I think this is the place for packets

# Side notes
Existing design and code was a pleasure to work with, I like the way networking and packets were implemented.
The packet handler mecanism is more elegant than the one I have implemented in rust-ro.