### PR TITLE
Improve user experience

### DIFF
--- a/korangar/src/loaders/archive/native/mod.rs
+++ b/korangar/src/loaders/archive/native/mod.rs
@@ -34,7 +34,13 @@ impl Archive for NativeArchive {
     fn from_path(path: &Path) -> Self {
         #[cfg(feature = "debug")]
         let timer = Timer::new_dynamic(format!("load game data from {}", path.display().magenta()));
-        let mut file = File::open(path).unwrap();
+
+        let mut file = match File::open(path) {
+            Ok(file) => file,
+            Err(error) => {
+                panic!("Unable to find archive {path:?}, does the file exist in the `archive` directory?\nError: {error:?}");
+            }
+        };
 
         let mut file_header_buffer = vec![0u8; Header::size_in_bytes()];
         file.read_exact(&mut file_header_buffer).unwrap();

--- a/korangar/src/main.rs
+++ b/korangar/src/main.rs
@@ -296,6 +296,25 @@ fn main() {
         init_tls_rand();
     });
 
+    // Check if korangar is in the correct working directory and if not, try to
+    // correct it.
+    // NOTE: This check might be temporary or feature gated in the future.
+    time_phase!("adjust working directory", {
+        if !std::fs::metadata("archive").is_ok_and(|metadata| metadata.is_dir()) {
+            #[cfg(feature = "debug")]
+            print_debug!(
+                "[{}] failed to find archive directory, attempting to change working directory {}",
+                "warning".yellow(),
+                "korangar".magenta()
+            );
+
+            if let Err(_error) = std::env::set_current_dir("korangar") {
+                #[cfg(feature = "debug")]
+                print_debug!("[{}] failed to change working directory: {:?}", "error".red(), _error);
+            }
+        }
+    });
+
     let args: Vec<String> = std::env::args().collect();
     let sync_cache = args.len() > 1 && &args[1] == "sync-cache";
 

--- a/korangar/src/main.rs
+++ b/korangar/src/main.rs
@@ -416,7 +416,7 @@ struct Client {
 
 impl Client {
     fn init(sync_cache: bool) -> Option<Self> {
-        time_phase!("load settings", {
+        time_phase!("load graphics settings", {
             let picker_value = Arc::new(AtomicU64::new(0));
             let input_system = InputSystem::new(picker_value.clone());
             let graphics_settings = GraphicsSettings::new();
@@ -2057,7 +2057,7 @@ impl Client {
                 InputEvent::SetTime { day_seconds } => self.game_timer.set_day_timer(day_seconds),
                 #[cfg(feature = "debug")]
                 InputEvent::OpenThemeInspectorWindow => {
-                    // TODO: Themporary value
+                    // TODO: Temporary value
                     self.interface.open_state_window(client_state().menu_theme())
                 }
                 #[cfg(feature = "debug")]

--- a/korangar/src/settings/audio.rs
+++ b/korangar/src/settings/audio.rs
@@ -38,8 +38,17 @@ impl AudioSettings {
     pub fn save(&self) {
         #[cfg(feature = "debug")]
         print_debug!("saving audio settings to {}", Self::FILE_NAME.magenta());
+
         let data = ron::ser::to_string_pretty(self, PrettyConfig::new()).unwrap();
-        std::fs::write(Self::FILE_NAME, data).expect("unable to write file");
+
+        if let Err(_error) = std::fs::write(Self::FILE_NAME, data) {
+            #[cfg(feature = "debug")]
+            print_debug!(
+                "failed to save audio settings to {}: {}",
+                Self::FILE_NAME.magenta(),
+                _error.to_string().red()
+            );
+        }
     }
 }
 

--- a/korangar/src/settings/graphic.rs
+++ b/korangar/src/settings/graphic.rs
@@ -49,7 +49,7 @@ impl GraphicsSettings {
     pub fn new() -> Self {
         Self::load().unwrap_or_else(|| {
             #[cfg(feature = "debug")]
-            print_debug!("failed to load graphics configuration from {}", Self::FILE_NAME.magenta());
+            print_debug!("failed to load graphics settings from {}", Self::FILE_NAME.magenta());
 
             Default::default()
         })
@@ -57,7 +57,7 @@ impl GraphicsSettings {
 
     pub fn load() -> Option<Self> {
         #[cfg(feature = "debug")]
-        print_debug!("loading graphics configuration from {}", Self::FILE_NAME.magenta());
+        print_debug!("loading graphics settings from {}", Self::FILE_NAME.magenta());
 
         std::fs::read_to_string(Self::FILE_NAME)
             .ok()
@@ -66,10 +66,18 @@ impl GraphicsSettings {
 
     pub fn save(&self) {
         #[cfg(feature = "debug")]
-        print_debug!("saving graphics configuration to {}", Self::FILE_NAME.magenta());
+        print_debug!("saving graphics settings to {}", Self::FILE_NAME.magenta());
 
         let data = ron::ser::to_string_pretty(self, PrettyConfig::new()).unwrap();
-        std::fs::write(Self::FILE_NAME, data).expect("unable to write file");
+
+        if let Err(_error) = std::fs::write(Self::FILE_NAME, data) {
+            #[cfg(feature = "debug")]
+            print_debug!(
+                "failed to save graphics settings to {}: {}",
+                Self::FILE_NAME.magenta(),
+                _error.to_string().red()
+            );
+        }
     }
 }
 

--- a/korangar/src/settings/interface.rs
+++ b/korangar/src/settings/interface.rs
@@ -29,7 +29,7 @@ impl InterfaceSettings {
     pub fn new() -> Self {
         Self::load().unwrap_or_else(|| {
             #[cfg(feature = "debug")]
-            print_debug!("failed to load graphics configuration from {}", Self::FILE_NAME.magenta());
+            print_debug!("failed to load interface settings from {}", Self::FILE_NAME.magenta());
 
             Default::default()
         })
@@ -37,7 +37,7 @@ impl InterfaceSettings {
 
     pub fn load() -> Option<Self> {
         #[cfg(feature = "debug")]
-        print_debug!("loading graphics configuration from {}", Self::FILE_NAME.magenta());
+        print_debug!("loading interface settings from {}", Self::FILE_NAME.magenta());
 
         std::fs::read_to_string(Self::FILE_NAME)
             .ok()
@@ -46,10 +46,18 @@ impl InterfaceSettings {
 
     pub fn save(&self) {
         #[cfg(feature = "debug")]
-        print_debug!("saving graphics configuration to {}", Self::FILE_NAME.magenta());
+        print_debug!("saving interface settings to {}", Self::FILE_NAME.magenta());
 
         let data = ron::ser::to_string_pretty(self, PrettyConfig::new()).unwrap();
-        std::fs::write(Self::FILE_NAME, data).expect("unable to write file");
+
+        if let Err(_error) = std::fs::write(Self::FILE_NAME, data) {
+            #[cfg(feature = "debug")]
+            print_debug!(
+                "failed to save interface settings to {}: {}",
+                Self::FILE_NAME.magenta(),
+                _error.to_string().red()
+            );
+        }
     }
 }
 

--- a/korangar/src/settings/login.rs
+++ b/korangar/src/settings/login.rs
@@ -78,7 +78,15 @@ impl LoginSettings {
         print_debug!("saving login settings to {}", Self::FILE_NAME.magenta());
 
         let data = ron::ser::to_string_pretty(self, PrettyConfig::new()).unwrap();
-        std::fs::write(Self::FILE_NAME, data).expect("unable to write file");
+
+        if let Err(_error) = std::fs::write(Self::FILE_NAME, data) {
+            #[cfg(feature = "debug")]
+            print_debug!(
+                "failed to save login settings to {}: {}",
+                Self::FILE_NAME.magenta(),
+                _error.to_string().red()
+            );
+        }
     }
 }
 

--- a/korangar/src/state/localization/mod.rs
+++ b/korangar/src/state/localization/mod.rs
@@ -200,7 +200,15 @@ impl Localization {
         print_debug!("saving to file {}", file_name.magenta());
 
         let data = ron::ser::to_string_pretty(self, PrettyConfig::new()).unwrap();
-        std::fs::write(file_name, data).expect("unable to write file");
+
+        if let Err(_error) = std::fs::write(&file_name, data) {
+            #[cfg(feature = "debug")]
+            print_debug!(
+                "failed to save language to {}: {}",
+                file_name.magenta(),
+                _error.to_string().red()
+            );
+        }
 
         #[cfg(feature = "debug")]
         timer.stop();


### PR DESCRIPTION
This PR does three things:
- Automatically adjust the working directory from the root of the repository to the `korangar` subdirectory if no `archive` directory is found
- In case an archive is not found, show the file name and a custom error message 
- Show errors instead of crashing if settings or language files can not be written