### PR TITLE
Add problem matchers and improve pipeline

### DIFF
--- a/.github/workflows/build-matchers.json
+++ b/.github/workflows/build-matchers.json
@@ -1,0 +1,15 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "rust-compiler",
+            "pattern": [
+                {
+                    "regexp": "^(?:\\x1B\\[[0-9;]*[a-zA-Z])*(warning|warn|error)(\\[(\\S*)\\])?(?:\\x1B\\[[0-9;]*[a-zA-Z])*: (.*?)(?:\\x1B\\[[0-9;]*[a-zA-Z])*$",
+                    "severity": 1,
+                    "message": 4,
+                    "code": 3
+                },
+            ]
+        }
+    ]
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,14 @@
 on:
   push:
+    branches: [ main ]
   pull_request:
     branches:
       - main
+
+# Cancel previous jobs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 name: Build
 
@@ -19,6 +25,9 @@ jobs:
 
       - name: Install build dependencies
         run: sudo apt install libasound2-dev nasm
+
+      - name: Add problem matchers
+        run: echo "::add-matcher::.github/workflows/build-matchers.json"
 
       - name: Build Korangar (release)
         run: cargo build

--- a/.github/workflows/formatting-matchers.json
+++ b/.github/workflows/formatting-matchers.json
@@ -1,0 +1,15 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "rust-formatter",
+            "pattern": [
+                {
+                    "regexp": "^(Diff in (\\S+)):(\\d+):",
+                    "message": 1,
+                    "file": 2,
+                    "line": 3
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -1,8 +1,14 @@
 on:
   push:
+    branches: [ main ]
   pull_request:
     branches:
       - main
+
+# Cancel previous jobs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 name: Formatting
 
@@ -19,6 +25,9 @@ jobs:
 
       - name: Add Rustfmt
         run: rustup component add rustfmt
+
+      - name: Add problem matchers
+        run: echo "::add-matcher::.github/workflows/formatting-matchers.json"
 
       - name: Check formatting
         run: cargo fmt --all --check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,14 @@
 on:
   push:
+    branches: [ main ]
   pull_request:
     branches:
       - main
+
+# Cancel previous jobs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 name: Lint
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,14 @@
 on:
   push:
+    branches: [ main ]
   pull_request:
     branches:
       - main
+
+# Cancel previous jobs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 name: Tests
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 # [Korangar](https://github.com/vE5li/korangar)
 
-[![Build](https://github.com/ve5li/korangar/workflows/Build/badge.svg)](https://github.com/ve5li/korangar/actions?query=workflow%3ABuild)
-[![Tests](https://github.com/ve5li/korangar/workflows/Tests/badge.svg)](https://github.com/ve5li/korangar/actions?query=workflow%3ATests)
+[![Build](https://github.com/ve5li/korangar/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/ve5li/korangar/actions?query=workflow%3ABuild)
+[![Tests](https://github.com/ve5li/korangar/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/ve5li/korangar/actions?query=workflow%3ATests)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Discord](https://img.shields.io/discord/1010572689536204931?label=discord)](https://discord.gg/2CqRZsvKja)
 


### PR DESCRIPTION
Add GitHub problem matchers to show compiler and formatting errors in the PR.

Also includes changes to the jobs:
- Only run jobs once per PR instead of twice
- Cancel old jobs when new ones are started

Use the badge from the main branch in the README.