### PR TITLE
Fixe the S3-FIFO bug

### DIFF
--- a/korangar-util/src/container/simple_cache.rs
+++ b/korangar-util/src/container/simple_cache.rs
@@ -310,13 +310,16 @@ impl<K: Clone + Eq + Hash, V: Cacheable> SimpleCache<K, V> {
 
             if tail.freq > 1 {
                 let size = tail.size;
+
+                while self.main_count >= self.max_main_count || self.main_size.saturating_add(size) > self.max_main_size {
+                    self.evict_m();
+                }
+
                 self.main_fifo.push_back(tail_key);
                 self.main_count += 1;
                 self.main_size += size;
 
-                while self.main_count > self.max_main_count || self.main_size > self.max_main_size {
-                    self.evict_m();
-                }
+                return;
             } else {
                 let _ = self.values.remove(&tail_key).unwrap();
 


### PR DESCRIPTION
The S3-FIFO algorithm is wrongly documented in the official and current version of the paper. There were no errata, but on a blog post there was a sidenote about this issue. Very frustrating.

The old code did essentially promote the whole small FIFO once the small FIFO got full. This change makes sure that there is only one promotion or eviction in the small FIFO.