### PR TITLE
Update rav1d to fix aarch64 builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3173,8 +3173,7 @@ checksum = "f93e7e49bb0bf967717f7bd674458b3d6b0c5f48ec7e3038166026a69fc22223"
 [[package]]
 name = "rav1d"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1932f060d5e7bd49dc9f8b272c1dc5e9ce0ffe141c28be900265d3989b36c9ed"
+source = "git+https://github.com/memorysafety/rav1d.git?rev=c8019327ff0aa4c097475fa5f679561ea3abd983#c8019327ff0aa4c097475fa5f679561ea3abd983"
 dependencies = [
  "assert_matches",
  "atomig",
@@ -3822,23 +3821,22 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn 2.0.106",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ ragnarok-formats = { path = "ragnarok-formats" }
 ragnarok-macros = { path = "ragnarok-macros" }
 ragnarok-packets = { path = "ragnarok-packets" }
 rand_aes = { version = "0.5", default-features = false }
-rav1d = "1"
+rav1d = { version = "1", git = "https://github.com/memorysafety/rav1d.git", rev = "c8019327ff0aa4c097475fa5f679561ea3abd983" }
 rayon = "1"
 reqwest = "0.12"
 ron = "0.10"

--- a/korangar-video/src/lib.rs
+++ b/korangar-video/src/lib.rs
@@ -19,8 +19,8 @@ use rav1d::include::dav1d::data::*;
 use rav1d::include::dav1d::dav1d::*;
 pub use rav1d::include::dav1d::headers;
 use rav1d::include::dav1d::picture::*;
-use rav1d::src::lib::*;
-use rav1d::src::send_sync_non_null::SendSyncNonNull;
+use rav1d::send_sync_non_null::SendSyncNonNull;
+use rav1d::*;
 
 const fn dav1d_err(errno: c_int) -> c_int {
     if libc::EPERM < 0 { errno } else { -errno }


### PR DESCRIPTION
With the current v1.1 from crates.io we get a compilation error when activating ASM (which is activated by default).

Using the current HEAD from GitHub fixes the compilation.