### PR TITLE
Implement shader based shadows for solid rectangles

### DIFF
--- a/korangar/src/graphics/instruction.rs
+++ b/korangar/src/graphics/instruction.rs
@@ -182,6 +182,7 @@ pub enum InterfaceRectangleInstruction {
         screen_clip: ScreenClip,
         color: Color,
         corner_diameter: CornerDiameter,
+        shadow_offset: Vector2<f32>,
     },
     Sprite {
         screen_position: ScreenPosition,

--- a/korangar/src/graphics/passes/interface/rectangle.rs
+++ b/korangar/src/graphics/passes/interface/rectangle.rs
@@ -34,9 +34,9 @@ struct InstanceData {
     screen_size: [f32; 2],
     texture_position: [f32; 2],
     texture_size: [f32; 2],
+    shadow_offset: [f32; 2],
     rectangle_type: u32,
     texture_index: i32,
-    padding: [u32; 2],
 }
 
 pub(crate) struct InterfaceRectangleDrawer {
@@ -272,6 +272,7 @@ impl Prepare for InterfaceRectangleDrawer {
                         screen_clip,
                         color,
                         corner_diameter,
+                        shadow_offset,
                     } => {
                         self.instance_data.push(InstanceData {
                             color: color.components_linear(),
@@ -281,9 +282,9 @@ impl Prepare for InterfaceRectangleDrawer {
                             screen_size: (*screen_size).into(),
                             texture_position: [0.0, 0.0],
                             texture_size: [1.0, 1.0],
+                            shadow_offset: (*shadow_offset).into(),
                             rectangle_type: 0,
                             texture_index: 0,
-                            padding: Default::default(),
                         });
                     }
                     InterfaceRectangleInstruction::Sprite {
@@ -316,9 +317,9 @@ impl Prepare for InterfaceRectangleDrawer {
                             screen_size: (*screen_size).into(),
                             texture_position: [0.0, 0.0],
                             texture_size: [1.0, 1.0],
+                            shadow_offset: [0.0, 0.0],
                             rectangle_type,
                             texture_index,
-                            padding: Default::default(),
                         });
                     }
                     InterfaceRectangleInstruction::Sdf {
@@ -348,9 +349,9 @@ impl Prepare for InterfaceRectangleDrawer {
                             screen_size: (*screen_size).into(),
                             texture_position: [0.0, 0.0],
                             texture_size: [1.0, 1.0],
+                            shadow_offset: [0.0, 0.0],
                             rectangle_type: 3,
                             texture_index,
-                            padding: Default::default(),
                         });
                     }
                     InterfaceRectangleInstruction::Text {
@@ -369,9 +370,9 @@ impl Prepare for InterfaceRectangleDrawer {
                             screen_size: (*screen_size).into(),
                             texture_position: (*texture_position).into(),
                             texture_size: (*texture_size).into(),
+                            shadow_offset: [0.0, 0.0],
                             rectangle_type: 4,
                             texture_index: 0,
-                            padding: Default::default(),
                         });
                     }
                 }
@@ -398,6 +399,7 @@ impl Prepare for InterfaceRectangleDrawer {
                         screen_clip,
                         color,
                         corner_diameter,
+                        shadow_offset,
                     } => {
                         self.instance_data.push(InstanceData {
                             color: color.components_linear(),
@@ -407,9 +409,9 @@ impl Prepare for InterfaceRectangleDrawer {
                             screen_size: (*screen_size).into(),
                             texture_position: [0.0, 0.0],
                             texture_size: [1.0, 1.0],
+                            shadow_offset: (*shadow_offset).into(),
                             rectangle_type: 0,
                             texture_index: 0,
-                            padding: Default::default(),
                         });
                     }
 
@@ -432,9 +434,9 @@ impl Prepare for InterfaceRectangleDrawer {
                             screen_size: (*screen_size).into(),
                             texture_position: [0.0, 0.0],
                             texture_size: [1.0, 1.0],
+                            shadow_offset: [0.0, 0.0],
                             rectangle_type,
                             texture_index: 0,
-                            padding: Default::default(),
                         });
                     }
                     InterfaceRectangleInstruction::Sdf {
@@ -453,9 +455,9 @@ impl Prepare for InterfaceRectangleDrawer {
                             screen_size: (*screen_size).into(),
                             texture_position: [0.0, 0.0],
                             texture_size: [1.0, 1.0],
+                            shadow_offset: [0.0, 0.0],
                             rectangle_type: 3,
                             texture_index: 0,
-                            padding: Default::default(),
                         });
                     }
                     InterfaceRectangleInstruction::Text {
@@ -474,9 +476,9 @@ impl Prepare for InterfaceRectangleDrawer {
                             screen_size: (*screen_size).into(),
                             texture_position: (*texture_position).into(),
                             texture_size: (*texture_size).into(),
+                            shadow_offset: [0.0, 0.0],
                             rectangle_type: 4,
                             texture_index: 0,
-                            padding: Default::default(),
                         });
                     }
                 }

--- a/korangar/src/graphics/passes/interface/shader/rectangle.wgsl
+++ b/korangar/src/graphics/passes/interface/shader/rectangle.wgsl
@@ -26,6 +26,7 @@ struct InstanceData {
     screen_size: vec2<f32>,
     texture_position: vec2<f32>,
     texture_size: vec2<f32>,
+    shadow_offset: vec2<f32>,
     rectangle_type: u32,
     texture_index: i32,
 }
@@ -52,18 +53,29 @@ const EDGE_VALUE: f32 = 0.5;
 /// We use a pxrange of 6 px when creating MSDFs.
 const PXRANGE: f32 = 6.0;
 
+const SHADOW_ALPHA: f32 = 0.75;
+const SHADOW_COLOR: vec3<f32> = vec3<f32>(0.0, 0.0, 0.0);
+
 @vertex
 fn vs_main(
     @builtin(vertex_index) vertex_index: u32,
     @builtin(instance_index) instance_index: u32,
 ) -> VertexOutput {
     let instance = instance_data[instance_index];
-    let vertex = vertex_data(vertex_index);
+    var vertex = vertex_data(vertex_index);
 
     let pixel_size = vec2<f32>(1.0 / f32(global_uniforms.interface_size.x), 1.0 / f32(global_uniforms.interface_size.y));
     let size_adjustment = select(vec2<f32>(0.0), (BREATHING_ROOM * 2.0) * pixel_size, any(instance.corner_diameter != vec4<f32>(0.0)));
+    let shadow_offset = instance.shadow_offset * pixel_size;
 
-    let adjusted_size = instance.screen_size + size_adjustment;
+    var adjusted_size = instance.screen_size + size_adjustment;
+
+    let shadow_expansion = vec2<f32>(
+        select(0.0, abs(shadow_offset.x), (instance.shadow_offset.x > 0.0 && vertex.x > 0.5) || (instance.shadow_offset.x < 0.0 && vertex.x < 0.5)),
+        select(0.0, abs(shadow_offset.y), (instance.shadow_offset.y > 0.0 && vertex.y < -0.5) || (instance.shadow_offset.y < 0.0 && vertex.y > -0.5))
+    );
+    adjusted_size += shadow_expansion;
+
     let clip_size = adjusted_size * 2.0;
     let position = screen_to_clip_space(instance.screen_position) + vertex.xy * clip_size;
 
@@ -113,13 +125,26 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
         default: {}
     }
 
-    return rectangle_with_rounded_edges(
-        instance.corner_diameter,
-        instance.screen_position,
-        instance.screen_size,
-        input.fragment_position,
-        color
-    );
+    if (instance.rectangle_type == 0u && any(instance.shadow_offset != vec2<f32>(0.0))) {
+        // Solid rectangle with shadow.
+        return render_rectangle_with_shadow(
+            instance.corner_diameter,
+            instance.screen_position,
+            instance.screen_size,
+            input.fragment_position,
+            color,
+            instance.shadow_offset,
+        );
+    } else {
+        // All other shadowless rectangles.
+        return rectangle_with_rounded_edges(
+            instance.corner_diameter,
+            instance.screen_position,
+            instance.screen_size,
+            input.fragment_position,
+            color,
+        );
+    }
 }
 
 fn calculate_msdf(
@@ -135,6 +160,97 @@ fn calculate_msdf(
     return color * saturate(distance * screen_px_range + EDGE_VALUE);
 }
 
+fn calculate_rounded_rectangle_alpha(
+    pixel_position: vec2<f32>,
+    rectangle_origin: vec2<f32>,
+    rectangle_size: vec2<f32>,
+    corner_radii: vec4<f32>
+) -> f32 {
+    // Calculate position relative to rectangle center.
+    let half_size = rectangle_size * 0.5;
+    let rectangle_center = rectangle_origin + half_size;
+    let relative_position = pixel_position - rectangle_center;
+
+    // Determine which corner diameter to use based on the quadrant this fragment is in.
+    let is_right = relative_position.x > 0.0;
+    let is_bottom = relative_position.y > 0.0;
+    let radii_pair = select(corner_radii.xy, corner_radii.zw, is_bottom);
+    let corner_diameter = select(radii_pair.x, radii_pair.y, is_right);
+
+    if (corner_diameter == 0.0) {
+        // No rounded corners - simple bounds check.
+        return f32(abs(relative_position.x) <= half_size.x &&
+                   abs(relative_position.y) <= half_size.y);
+    }
+
+    // Calculate SDF distance for rounded corners.
+    let distance = rectangle_sdf(relative_position, half_size, corner_diameter);
+    var alpha = step(0.0, -distance);
+
+    // Multi-sample for anti-aliasing at edges.
+    if (abs(distance) <= BORDER_THRESHOLD) {
+        var total = alpha;
+        for (var index = 0u; index < 8u; index++) {
+            let offset = SAMPLE_OFFSETS[index];
+            let sample_distance = rectangle_sdf(relative_position + offset, half_size, corner_diameter);
+            total += step(0.0, -sample_distance);
+        }
+        alpha = total * (1.0 / 9.0);
+    }
+
+    return alpha;
+}
+
+fn render_rectangle_with_shadow(
+    corner_radii: vec4<f32>,
+    screen_position: vec2<f32>,
+    screen_size: vec2<f32>,
+    fragment_position: vec2<f32>,
+    color: vec4<f32>,
+    shadow_offset: vec2<f32>,
+) -> vec4<f32> {
+    let interface_size = vec2<f32>(global_uniforms.interface_size);
+    let pixel_position = fragment_position * interface_size;
+
+    let main_origin = (screen_position * interface_size) - vec2<f32>(BREATHING_ROOM);
+    let main_size = (screen_size * interface_size) + vec2<f32>(BREATHING_ROOM * 2.0);
+
+    let main_alpha = calculate_rounded_rectangle_alpha(
+        pixel_position,
+        main_origin,
+        main_size,
+        corner_radii
+    );
+
+
+    if (main_alpha >= 1.0) {
+        // If fully inside main rectangle.
+        return color;
+    }
+
+    let shadow_origin = (screen_position * interface_size) + shadow_offset - vec2<f32>(BREATHING_ROOM);
+    let shadow_size = (screen_size * interface_size) + vec2<f32>(BREATHING_ROOM * 2.0);
+
+    let shadow_alpha = calculate_rounded_rectangle_alpha(
+        pixel_position,
+        shadow_origin,
+        shadow_size,
+        corner_radii
+    );
+
+    let shadow_color = vec4<f32>(SHADOW_COLOR, SHADOW_ALPHA * shadow_alpha);
+
+    if (main_alpha > 0.0) {
+        // Main rectangle partially or fully covers this pixel.
+        let main_contrib = color * main_alpha;
+        let shadow_contrib = shadow_color * (1.0 - main_alpha);
+        return main_contrib + shadow_contrib;
+    } else {
+        // Only shadow visible at this pixel.
+        return shadow_color;
+    }
+}
+
 fn rectangle_with_rounded_edges(
     corner_radii: vec4<f32>,
     screen_position: vec2<f32>,
@@ -148,39 +264,16 @@ fn rectangle_with_rounded_edges(
 
     // Convert normalized screen space coordinates to pixel space.
     let interface_size = vec2<f32>(global_uniforms.interface_size);
-    let position = fragment_position * interface_size;
+    let pixel_position = fragment_position * interface_size;
     let origin = (screen_position * interface_size) - vec2<f32>(BREATHING_ROOM);
     let size = (screen_size * interface_size) + vec2<f32>(BREATHING_ROOM * 2.0);
 
-    // Calculate position relative to rectangle center.
-    let half_size = size * 0.5;
-    let rectangle_center = origin + half_size;
-    let relative_position = position - rectangle_center;
-
-    // Determine which corner diameter to use based on the quadrant this fragment is in.
-    let is_right = relative_position.x > 0.0;
-    let is_bottom = relative_position.y > 0.0;
-    let radii_pair = select(corner_radii.xy, corner_radii.zw, is_bottom);
-    let corner_diameter = select(radii_pair.x, radii_pair.y, is_right);
-
-    if (corner_diameter == 0.0) {
-        return color;
-    }
-
-    // We multi-sample the edges of a rectangle to get the best possible anti-aliasing.
-    let distance = rectangle_sdf(relative_position, half_size, corner_diameter);
-
-    var alpha: f32 = step(0.0, -distance);
-
-    if (abs(distance) <= BORDER_THRESHOLD) {
-        var total = alpha;
-        for (var index = 0u; index < 8u; index++) {
-            let offset = SAMPLE_OFFSETS[index];
-            let sample_distance = rectangle_sdf(relative_position + offset, half_size, corner_diameter);
-            total += step(0.0, -sample_distance);
-        }
-        alpha = total * (1.0 / 9.0);
-    }
+    let alpha = calculate_rounded_rectangle_alpha(
+        pixel_position,
+        origin,
+        size,
+        corner_radii
+    );
 
     return color * alpha;
 }

--- a/korangar/src/graphics/passes/interface/shader/rectangle_bindless.wgsl
+++ b/korangar/src/graphics/passes/interface/shader/rectangle_bindless.wgsl
@@ -26,6 +26,7 @@ struct InstanceData {
     screen_size: vec2<f32>,
     texture_position: vec2<f32>,
     texture_size: vec2<f32>,
+    shadow_offset: vec2<f32>,
     rectangle_type: u32,
     texture_index: i32,
 }
@@ -44,11 +45,16 @@ struct VertexOutput {
 @group(1) @binding(1) var msdf_font_map: texture_2d<f32>;
 @group(1) @binding(2) var textures: binding_array<texture_2d<f32>>;
 
+// Because of how sampling works, we need to add a bit breathing room
+// for the SDF function and then need to compensate for it.
 const BREATHING_ROOM = 0.5;
 const BORDER_THRESHOLD = 2.0;
 const EDGE_VALUE: f32 = 0.5;
 /// We use a pxrange of 6 px when creating MSDFs.
 const PXRANGE: f32 = 6.0;
+
+const SHADOW_ALPHA: f32 = 0.75;
+const SHADOW_COLOR: vec3<f32> = vec3<f32>(0.0, 0.0, 0.0);
 
 @vertex
 fn vs_main(
@@ -56,12 +62,20 @@ fn vs_main(
     @builtin(instance_index) instance_index: u32,
 ) -> VertexOutput {
     let instance = instance_data[instance_index];
-    let vertex = vertex_data(vertex_index);
+    var vertex = vertex_data(vertex_index);
 
     let pixel_size = vec2<f32>(1.0 / f32(global_uniforms.interface_size.x), 1.0 / f32(global_uniforms.interface_size.y));
     let size_adjustment = select(vec2<f32>(0.0), (BREATHING_ROOM * 2.0) * pixel_size, any(instance.corner_diameter != vec4<f32>(0.0)));
+    let shadow_offset = instance.shadow_offset * pixel_size;
 
-    let adjusted_size = instance.screen_size + size_adjustment;
+    var adjusted_size = instance.screen_size + size_adjustment;
+
+    let shadow_expansion = vec2<f32>(
+        select(0.0, abs(shadow_offset.x), (instance.shadow_offset.x > 0.0 && vertex.x > 0.5) || (instance.shadow_offset.x < 0.0 && vertex.x < 0.5)),
+        select(0.0, abs(shadow_offset.y), (instance.shadow_offset.y > 0.0 && vertex.y < -0.5) || (instance.shadow_offset.y < 0.0 && vertex.y > -0.5))
+    );
+    adjusted_size += shadow_expansion;
+
     let clip_size = adjusted_size * 2.0;
     let position = screen_to_clip_space(instance.screen_position) + vertex.xy * clip_size;
 
@@ -112,13 +126,26 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
         default: {}
     }
 
-    return rectangle_with_rounded_edges(
-        instance.corner_diameter,
-        instance.screen_position,
-        instance.screen_size,
-        input.fragment_position,
-        color
-    );
+    if (instance.rectangle_type == 0u && any(instance.shadow_offset != vec2<f32>(0.0))) {
+        // Solid rectangle with shadow.
+        return render_rectangle_with_shadow(
+            instance.corner_diameter,
+            instance.screen_position,
+            instance.screen_size,
+            input.fragment_position,
+            color,
+            instance.shadow_offset,
+        );
+    } else {
+        // All other shadowless rectangles.
+        return rectangle_with_rounded_edges(
+            instance.corner_diameter,
+            instance.screen_position,
+            instance.screen_size,
+            input.fragment_position,
+            color,
+        );
+    }
 }
 
 fn calculate_msdf(
@@ -134,6 +161,97 @@ fn calculate_msdf(
     return color * saturate(distance * screen_px_range + EDGE_VALUE);
 }
 
+fn calculate_rounded_rectangle_alpha(
+    pixel_position: vec2<f32>,
+    rectangle_origin: vec2<f32>,
+    rectangle_size: vec2<f32>,
+    corner_radii: vec4<f32>
+) -> f32 {
+    // Calculate position relative to rectangle center.
+    let half_size = rectangle_size * 0.5;
+    let rectangle_center = rectangle_origin + half_size;
+    let relative_position = pixel_position - rectangle_center;
+
+    // Determine which corner diameter to use based on the quadrant this fragment is in.
+    let is_right = relative_position.x > 0.0;
+    let is_bottom = relative_position.y > 0.0;
+    let radii_pair = select(corner_radii.xy, corner_radii.zw, is_bottom);
+    let corner_diameter = select(radii_pair.x, radii_pair.y, is_right);
+
+    if (corner_diameter == 0.0) {
+        // No rounded corners - simple bounds check.
+        return f32(abs(relative_position.x) <= half_size.x &&
+                   abs(relative_position.y) <= half_size.y);
+    }
+
+    // Calculate SDF distance for rounded corners.
+    let distance = rectangle_sdf(relative_position, half_size, corner_diameter);
+    var alpha = step(0.0, -distance);
+
+    // Multi-sample for anti-aliasing at edges.
+    if (abs(distance) <= BORDER_THRESHOLD) {
+        var total = alpha;
+        for (var index = 0u; index < 8u; index++) {
+            let offset = SAMPLE_OFFSETS[index];
+            let sample_distance = rectangle_sdf(relative_position + offset, half_size, corner_diameter);
+            total += step(0.0, -sample_distance);
+        }
+        alpha = total * (1.0 / 9.0);
+    }
+
+    return alpha;
+}
+
+fn render_rectangle_with_shadow(
+    corner_radii: vec4<f32>,
+    screen_position: vec2<f32>,
+    screen_size: vec2<f32>,
+    fragment_position: vec2<f32>,
+    color: vec4<f32>,
+    shadow_offset: vec2<f32>,
+) -> vec4<f32> {
+    let interface_size = vec2<f32>(global_uniforms.interface_size);
+    let pixel_position = fragment_position * interface_size;
+
+    let main_origin = (screen_position * interface_size) - vec2<f32>(BREATHING_ROOM);
+    let main_size = (screen_size * interface_size) + vec2<f32>(BREATHING_ROOM * 2.0);
+
+    let main_alpha = calculate_rounded_rectangle_alpha(
+        pixel_position,
+        main_origin,
+        main_size,
+        corner_radii
+    );
+
+
+    if (main_alpha >= 1.0) {
+        // If fully inside main rectangle.
+        return color;
+    }
+
+    let shadow_origin = (screen_position * interface_size) + shadow_offset - vec2<f32>(BREATHING_ROOM);
+    let shadow_size = (screen_size * interface_size) + vec2<f32>(BREATHING_ROOM * 2.0);
+
+    let shadow_alpha = calculate_rounded_rectangle_alpha(
+        pixel_position,
+        shadow_origin,
+        shadow_size,
+        corner_radii
+    );
+
+    let shadow_color = vec4<f32>(SHADOW_COLOR, SHADOW_ALPHA * shadow_alpha);
+
+    if (main_alpha > 0.0) {
+        // Main rectangle partially or fully covers this pixel.
+        let main_contrib = color * main_alpha;
+        let shadow_contrib = shadow_color * (1.0 - main_alpha);
+        return main_contrib + shadow_contrib;
+    } else {
+        // Only shadow visible at this pixel.
+        return shadow_color;
+    }
+}
+
 fn rectangle_with_rounded_edges(
     corner_radii: vec4<f32>,
     screen_position: vec2<f32>,
@@ -147,39 +265,16 @@ fn rectangle_with_rounded_edges(
 
     // Convert normalized screen space coordinates to pixel space.
     let interface_size = vec2<f32>(global_uniforms.interface_size);
-    let position = fragment_position * interface_size;
+    let pixel_position = fragment_position * interface_size;
     let origin = (screen_position * interface_size) - vec2<f32>(BREATHING_ROOM);
     let size = (screen_size * interface_size) + vec2<f32>(BREATHING_ROOM * 2.0);
 
-    // Calculate position relative to rectangle center.
-    let half_size = size * 0.5;
-    let rectangle_center = origin + half_size;
-    let relative_position = position - rectangle_center;
-
-    // Determine which corner diameter to use based on the quadrant this fragment is in.
-    let is_right = relative_position.x > 0.0;
-    let is_bottom = relative_position.y > 0.0;
-    let radii_pair = select(corner_radii.xy, corner_radii.zw, is_bottom);
-    let corner_diameter = select(radii_pair.x, radii_pair.y, is_right);
-
-    if (corner_diameter == 0.0) {
-        return color;
-    }
-
-    // We multi-sample the edges of a rectangle to get the best possible anti-aliasing.
-    let distance = rectangle_sdf(relative_position, half_size, corner_diameter);
-
-    var alpha: f32 = step(0.0, -distance);
-
-    if (abs(distance) <= BORDER_THRESHOLD) {
-        var total = alpha;
-        for (var index = 0u; index < 8u; index++) {
-            let offset = SAMPLE_OFFSETS[index];
-            let sample_distance = rectangle_sdf(relative_position + offset, half_size, corner_diameter);
-            total += step(0.0, -sample_distance);
-        }
-        alpha = total * (1.0 / 9.0);
-    }
+    let alpha = calculate_rounded_rectangle_alpha(
+        pixel_position,
+        origin,
+        size,
+        corner_radii
+    );
 
     return color * alpha;
 }

--- a/korangar/src/renderer/interface.rs
+++ b/korangar/src/renderer/interface.rs
@@ -1,7 +1,7 @@
 use std::cell::{Ref, RefCell};
 use std::sync::Arc;
 
-use cgmath::EuclideanSpace;
+use cgmath::{EuclideanSpace, Vector2, Zero};
 #[cfg(feature = "debug")]
 use korangar_interface::InterfaceFrame;
 #[cfg(feature = "debug")]
@@ -204,15 +204,21 @@ impl InterfaceRenderer {
                     screen_clip: ScreenClip::unbound(),
                     color: Color::rgba_u8(255, 0, 0, 90),
                     corner_diameter: CornerDiameter::default(),
+                    shadow_offset: Vector2::zero(),
                 });
             }
 
             return;
         }
 
+        // TODO: Let the interface define this offset.
+        //let mut shadow_offset = Vector2::new(10.0, 10.0);
+        let mut shadow_offset = Vector2::new(0.0, 0.0);
+
         if self.high_quality_interface {
             screen_clip = screen_clip * 2.0;
             corner_diameter = corner_diameter * 2.0;
+            shadow_offset *= 2.0;
         }
 
         let screen_position = position / self.window_size;
@@ -230,6 +236,7 @@ impl InterfaceRenderer {
                 screen_clip,
                 color: Color::rgba(1.0 - brightness, 1.0 - brightness, 1.0 - brightness, 0.6),
                 corner_diameter: CornerDiameter::default(),
+                shadow_offset,
             });
 
             return;
@@ -243,6 +250,7 @@ impl InterfaceRenderer {
             screen_clip,
             color,
             corner_diameter,
+            shadow_offset,
         });
     }
 
@@ -315,6 +323,7 @@ impl InterfaceRenderer {
                             screen_clip: ScreenClip::unbound(),
                             color: Color::rgba_u8(255, 0, 0, 150),
                             corner_diameter: CornerDiameter::default(),
+                            shadow_offset: Vector2::zero(),
                         });
                     }
 
@@ -339,6 +348,7 @@ impl InterfaceRenderer {
                         screen_clip: ScreenClip::unbound(),
                         color: Color::rgba_u8(0, 255, 255, 150),
                         corner_diameter: CornerDiameter::default(),
+                        shadow_offset: Vector2::zero(),
                     });
 
                     return;
@@ -429,6 +439,7 @@ impl SpriteRenderer for InterfaceRenderer {
                     screen_clip: ScreenClip::unbound(),
                     color: Color::rgba_u8(255, 0, 0, 150),
                     corner_diameter: CornerDiameter::default(),
+                    shadow_offset: Vector2::zero(),
                 });
             }
 
@@ -451,6 +462,7 @@ impl SpriteRenderer for InterfaceRenderer {
                 screen_clip: ScreenClip::unbound(),
                 color: Color::rgba_u8(255, 0, 255, 100),
                 corner_diameter: CornerDiameter::default(),
+                shadow_offset: Vector2::zero(),
             });
 
             return;
@@ -488,6 +500,7 @@ impl SpriteRenderer for InterfaceRenderer {
                     screen_clip: ScreenClip::unbound(),
                     color: Color::rgba_u8(255, 0, 0, 100),
                     corner_diameter: CornerDiameter::default(),
+                    shadow_offset: Vector2::zero(),
                 });
             }
 
@@ -510,6 +523,7 @@ impl SpriteRenderer for InterfaceRenderer {
                 screen_clip: ScreenClip::unbound(),
                 color: Color::rgba_u8(255, 255, 0, 150),
                 corner_diameter: CornerDiameter::default(),
+                shadow_offset: Vector2::zero(),
             });
 
             return;


### PR DESCRIPTION
The shadow is defined by its offset from the main rectangle. This only implements the GPU side of the code. The interface / theme integration still needs to be done.

<img width="484" height="703" alt="grafik" src="https://github.com/user-attachments/assets/45357771-a77a-4e1e-bd2a-83ba5a53894a" />
