### PR TITLE
Use lld linker under windows to fix compilation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,3 +4,6 @@ rustflags = ["-C", "target-feature=+aes,+avx,+avx2,+cmpxchg16b,+fma,+sse3,+ssse3
 
 [target.'cfg(target_arch="aarch64")']
 rustflags = ["-C", "target-feature=+aes"]
+
+[target.x86_64-pc-windows-msvc]
+linker = "rust-lld.exe"


### PR DESCRIPTION
MSVC linker has, especially with the debug build, problems to link korangar properly