### PR TITLE
Reduce shadow memory usage and better clamp planes

### DIFF
--- a/korangar/src/graphics/mod.rs
+++ b/korangar/src/graphics/mod.rs
@@ -627,7 +627,7 @@ impl GlobalContext {
 
         shadow_factory.new_attachment(
             "directional shadow map",
-            TextureFormat::Depth32Float,
+            TextureFormat::Depth16Unorm,
             AttachmentTextureType::DepthAttachment,
         )
     }

--- a/korangar/src/world/cameras/directional_shadow.rs
+++ b/korangar/src/world/cameras/directional_shadow.rs
@@ -3,8 +3,8 @@ use cgmath::{EuclideanSpace, InnerSpace, Matrix4, Point3, Transform, Vector2, Ve
 use super::Camera;
 use crate::graphics::orthographic_reverse_lh;
 
-const FAR_PLANE: f32 = 500.0;
-const NEAR_PLANE: f32 = -500.0;
+const FAR_PLANE: f32 = 600.0;
+const NEAR_PLANE: f32 = -150.0;
 const MAX_BOUNDS: f32 = 200.0;
 const FOCUS_POINT_OFFSET: f32 = 50.0;
 const ORIGIN: Point3<f32> = Point3::new(0.0, 0.0, 0.0);


### PR DESCRIPTION
Using Depth16Unorm uses only half of the memory for the directional shadow map. This improves performance especially with soft shadows. I clamped the shadows a bit more, so that we get some more precision. But the current precision is more than fine for the artwork and viewpoint of RO.