### PR TITLE
Rework the library API

### DIFF
--- a/korangar/src/inventory/mod.rs
+++ b/korangar/src/inventory/mod.rs
@@ -12,7 +12,7 @@ pub use self::hotbar::{Hotbar, HotbarPathExt};
 pub use self::skills::{Skill, SkillTree, SkillTreePathExt};
 use crate::graphics::Texture;
 use crate::loaders::AsyncLoader;
-use crate::world::{Library, ResourceMetadata};
+use crate::world::ResourceMetadata;
 
 #[derive(Default, RustState, StateElement)]
 pub struct Inventory {
@@ -22,14 +22,14 @@ pub struct Inventory {
 }
 
 impl Inventory {
-    pub fn fill(&mut self, async_loader: &AsyncLoader, library: &Library, items: Vec<InventoryItem<NoMetadata>>) {
+    pub fn fill(&mut self, async_loader: &AsyncLoader, items: Vec<InventoryItem<NoMetadata>>) {
         self.items = items
             .into_iter()
-            .map(|item| library.load_inventory_item_metadata(async_loader, item))
+            .map(|item| async_loader.request_inventory_item_metadata_load(item))
             .collect();
     }
 
-    pub fn add_item(&mut self, async_loader: &AsyncLoader, library: &Library, item: InventoryItem<NoMetadata>) {
+    pub fn add_item(&mut self, async_loader: &AsyncLoader, item: InventoryItem<NoMetadata>) {
         if let Some(found_item) = self.items.iter_mut().find(|inventory_item| inventory_item.index == item.index) {
             let InventoryItemDetails::Regular { amount, .. } = &mut found_item.details else {
                 panic!();
@@ -41,7 +41,7 @@ impl Inventory {
 
             *amount += added_amount;
         } else {
-            let item = library.load_inventory_item_metadata(async_loader, item);
+            let item = async_loader.request_inventory_item_metadata_load(item);
 
             self.items.push(item);
         }

--- a/korangar/src/loaders/map/mod.rs
+++ b/korangar/src/loaders/map/mod.rs
@@ -22,7 +22,7 @@ use self::water_plane::generate_water_plane;
 use super::error::LoadError;
 use crate::graphics::{BindlessSupport, Buffer, ModelVertex, TextureSet};
 use crate::loaders::{GameFileLoader, ModelLoader, TextureLoader, TextureSetBuilder, VideoLoader, split_mesh_by_texture};
-use crate::world::{Library, LightSourceKey, Lighting, Model, SubMesh, Video};
+use crate::world::{Library, LightSourceKey, Lighting, MapSkyData, Model, SubMesh, Video};
 use crate::{EffectSourceExt, LightSourceExt, Map, Object, ObjectKey, SoundSourceExt};
 
 pub const GROUND_TILE_SIZE: f32 = 10.0;
@@ -85,7 +85,7 @@ impl MapLoader {
         let mut map_data: MapData = parse_generic_data(&map_file_name, &self.game_file_loader)?;
 
         // TODO: NHA Implement sky rendering
-        let _map_sky_data = library.get_map_sky_data_from_resource_file(&resource_file);
+        let _map_sky_data = library.get::<MapSkyData>(&resource_file);
 
         let ground_file = format!("data\\{}", map_data.ground_file);
         let ground_data: GroundData = parse_generic_data(&ground_file, &self.game_file_loader)?;

--- a/korangar/src/main.rs
+++ b/korangar/src/main.rs
@@ -1487,12 +1487,12 @@ impl Client {
                 NetworkEvent::SetInventory { items } => {
                     self.client_state
                         .follow_mut(client_state().inventory())
-                        .fill(&self.async_loader, &self.library, items);
+                        .fill(&self.async_loader, items);
                 }
                 NetworkEvent::IventoryItemAdded { item } => {
                     self.client_state
                         .follow_mut(client_state().inventory())
-                        .add_item(&self.async_loader, &self.library, item);
+                        .add_item(&self.async_loader, item);
 
                     // TODO: Update the selling items. If you pick up an item
                     // that you already have the sell window
@@ -1701,7 +1701,7 @@ impl Client {
 
                     *self.client_state.follow_mut(client_state().shop_items()) = items
                         .into_iter()
-                        .map(|item| self.library.load_shop_item_metadata(&self.async_loader, item))
+                        .map(|item| self.async_loader.request_shop_item_metadata_load(item))
                         .collect();
 
                     self.interface

--- a/korangar/src/world/entity/mod.rs
+++ b/korangar/src/world/entity/mod.rs
@@ -29,7 +29,7 @@ use crate::renderer::GameInterfaceRenderer;
 use crate::renderer::MarkerRenderer;
 use crate::state::ClientState;
 use crate::state::theme::{InterfaceThemeType, WorldTheme};
-use crate::world::{ActionEvent, AnimationData, AnimationState, Camera, Library, MAX_WALK_PATH_SIZE, Map, PathFinder};
+use crate::world::{ActionEvent, AnimationData, AnimationState, Camera, JobIdentity, Library, MAX_WALK_PATH_SIZE, Map, PathFinder};
 #[cfg(feature = "debug")]
 use crate::world::{MarkerIdentifier, SubMesh};
 #[cfg(feature = "debug")]
@@ -352,9 +352,9 @@ fn get_entity_part_files(library: &Library, entity_type: EntityType, job_id: usi
             player_body_path(sex_sprite_path, job_id),
             player_head_path(sex_sprite_path, head_id),
         ],
-        EntityType::Npc => vec![format!("npc\\{}", library.get_job_identity_from_id(job_id))],
-        EntityType::Monster => vec![format!("몬스터\\{}", library.get_job_identity_from_id(job_id))],
-        EntityType::Warp | EntityType::Hidden => vec![format!("npc\\{}", library.get_job_identity_from_id(job_id))], // TODO: change
+        EntityType::Npc => vec![format!("npc\\{}", library.get::<JobIdentity>(job_id).to_string())],
+        EntityType::Monster => vec![format!("몬스터\\{}", library.get::<JobIdentity>(job_id).to_string())],
+        EntityType::Warp | EntityType::Hidden => vec![format!("npc\\{}", library.get::<JobIdentity>(job_id).to_string())], // TODO: change
     }
 }
 

--- a/korangar/src/world/library/item_info.rs
+++ b/korangar/src/world/library/item_info.rs
@@ -1,0 +1,63 @@
+use hashbrown::HashMap;
+use korangar_loaders::FileLoader;
+use mlua::Lua;
+use ragnarok_packets::ItemId;
+
+use super::{ItemName, ItemResource, Library, Table, fix_encoding};
+use crate::loaders::GameFileLoader;
+
+#[derive(Debug, Clone)]
+pub struct ItemInfo {
+    pub(super) identified_name: ItemName,
+    pub(super) unidentified_name: ItemName,
+    pub(super) identified_resource: ItemResource,
+    pub(super) unidentified_resource: ItemResource,
+}
+
+impl Table for ItemInfo {
+    type Key<'a> = ItemId;
+    type Storage = HashMap<ItemId, ItemInfo>;
+
+    fn load(game_file_loader: &GameFileLoader) -> mlua::Result<Self::Storage> {
+        let state = Lua::new();
+
+        let data = game_file_loader
+            .get("data\\luafiles514\\lua files\\datainfo\\iteminfo.lub")
+            .unwrap();
+        state.load(&data).exec()?;
+
+        let globals = state.globals();
+        let mut result = HashMap::new();
+
+        if let Ok(table) = globals.get::<mlua::Table>("tbl") {
+            for (item_id, item_table) in table.pairs::<u32, mlua::Table>().flatten() {
+                let info = ItemInfo {
+                    identified_name: ItemName::from_option(item_table.get("identifiedDisplayName").ok().map(fix_encoding)),
+                    unidentified_name: ItemName::from_option(item_table.get("unidentifiedDisplayName").ok().map(fix_encoding)),
+                    identified_resource: ItemResource::from_option(item_table.get("identifiedResourceName").ok().map(fix_encoding)),
+                    unidentified_resource: ItemResource::from_option(item_table.get("unidentifiedResourceName").ok().map(fix_encoding)),
+                };
+
+                result.insert(ItemId(item_id), info);
+            }
+        }
+
+        let compacted = HashMap::from_iter(result);
+
+        Ok(compacted)
+    }
+
+    fn try_get<'a, 'b>(library: &'a Library, key: Self::Key<'b>) -> Option<&'a Self> {
+        library.item_info_table.get(&key)
+    }
+
+    fn get<'a, 'b>(library: &'a Library, key: Self::Key<'b>) -> &'a Self {
+        static DEFAULT: ItemInfo = ItemInfo {
+            identified_name: ItemName::not_found_value(),
+            unidentified_name: ItemName::not_found_value(),
+            identified_resource: ItemResource::not_found_value(),
+            unidentified_resource: ItemResource::not_found_value(),
+        };
+        Self::try_get(library, key).unwrap_or(&DEFAULT)
+    }
+}

--- a/korangar/src/world/library/item_name.rs
+++ b/korangar/src/world/library/item_name.rs
@@ -1,0 +1,61 @@
+use std::borrow::Cow;
+use std::fmt::{Display, Formatter};
+
+use ragnarok_packets::ItemId;
+
+use super::item_info::ItemInfo;
+use super::{Library, Table};
+use crate::loaders::GameFileLoader;
+
+static DEFAULT_STRING: &str = "NOTFOUND";
+static DEFAULT_VALUE: ItemName = ItemName(Cow::Borrowed(DEFAULT_STRING));
+
+#[derive(Debug, Clone, Copy)]
+pub struct ItemNameKey {
+    pub item_id: ItemId,
+    pub is_identified: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct ItemName(Cow<'static, str>);
+
+impl Display for ItemName {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl ItemName {
+    pub(super) const fn not_found_value() -> Self {
+        ItemName(Cow::Borrowed(DEFAULT_STRING))
+    }
+
+    pub(super) fn from_option(value: Option<String>) -> Self {
+        match value {
+            Some(s) => ItemName(Cow::Owned(s)),
+            None => ItemName::not_found_value(),
+        }
+    }
+}
+
+impl Table for ItemName {
+    type Key<'a> = ItemNameKey;
+    type Storage = ();
+
+    fn load(_game_file_loader: &GameFileLoader) -> mlua::Result<Self::Storage> {
+        Ok(())
+    }
+
+    fn try_get<'a, 'b>(library: &'a Library, key: Self::Key<'b>) -> Option<&'a Self> {
+        let item_info = ItemInfo::try_get(library, key.item_id)?;
+        Some(if key.is_identified {
+            &item_info.identified_name
+        } else {
+            &item_info.unidentified_name
+        })
+    }
+
+    fn get<'a, 'b>(library: &'a Library, key: Self::Key<'b>) -> &'a Self {
+        Self::try_get(library, key).unwrap_or(&DEFAULT_VALUE)
+    }
+}

--- a/korangar/src/world/library/item_resource.rs
+++ b/korangar/src/world/library/item_resource.rs
@@ -1,0 +1,61 @@
+use std::borrow::Cow;
+use std::fmt::{Display, Formatter};
+
+use ragnarok_packets::ItemId;
+
+use super::item_info::ItemInfo;
+use super::{Library, Table};
+use crate::loaders::GameFileLoader;
+
+static DEFAULT_STRING: &str = "사과"; // Apple
+static DEFAULT_VALUE: ItemResource = ItemResource(Cow::Borrowed(DEFAULT_STRING));
+
+#[derive(Debug, Clone, Copy)]
+pub struct ItemResourceKey {
+    pub item_id: ItemId,
+    pub is_identified: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct ItemResource(Cow<'static, str>);
+
+impl Display for ItemResource {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl ItemResource {
+    pub(super) const fn not_found_value() -> Self {
+        ItemResource(Cow::Borrowed(DEFAULT_STRING))
+    }
+
+    pub(super) fn from_option(value: Option<String>) -> Self {
+        match value {
+            Some(s) => ItemResource(Cow::Owned(s)),
+            None => ItemResource::not_found_value(),
+        }
+    }
+}
+
+impl Table for ItemResource {
+    type Key<'a> = ItemResourceKey;
+    type Storage = ();
+
+    fn load(_game_file_loader: &GameFileLoader) -> mlua::Result<Self::Storage> {
+        Ok(())
+    }
+
+    fn try_get<'a, 'b>(library: &'a Library, key: Self::Key<'b>) -> Option<&'a Self> {
+        let item_info = ItemInfo::try_get(library, key.item_id)?;
+        Some(if key.is_identified {
+            &item_info.identified_resource
+        } else {
+            &item_info.unidentified_resource
+        })
+    }
+
+    fn get<'a, 'b>(library: &'a Library, key: Self::Key<'b>) -> &'a Self {
+        Self::try_get(library, key).unwrap_or(&DEFAULT_VALUE)
+    }
+}

--- a/korangar/src/world/library/job_identity.rs
+++ b/korangar/src/world/library/job_identity.rs
@@ -1,0 +1,85 @@
+use std::borrow::Cow;
+use std::fmt::{Display, Formatter};
+
+use hashbrown::HashMap;
+use korangar_loaders::FileLoader;
+use mlua::Lua;
+
+use super::{Library, Table};
+use crate::loaders::GameFileLoader;
+
+pub struct JobIdentity(Cow<'static, str>);
+
+impl Display for JobIdentity {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl Table for JobIdentity {
+    type Key<'a> = usize;
+    type Storage = HashMap<usize, JobIdentity>;
+
+    fn load(game_file_loader: &GameFileLoader) -> mlua::Result<Self::Storage> {
+        let state = Lua::new();
+
+        let data = game_file_loader
+            .get("data\\luafiles514\\lua files\\datainfo\\jobidentity.lub")
+            .unwrap();
+        state.load(&data).exec()?;
+
+        let data = game_file_loader
+            .get("data\\luafiles514\\lua files\\datainfo\\npcidentity.lub")
+            .unwrap();
+        state.load(&data).exec()?;
+
+        let globals = state.globals();
+        let mut result = HashMap::new();
+
+        if let Ok(jobtbl) = globals.get::<mlua::Table>("jobtbl") {
+            for (key, value) in jobtbl.pairs::<String, usize>().flatten() {
+                let cleaned_key = if let Some(end) = key.strip_prefix("JT_G_") {
+                    end.to_string()
+                } else {
+                    key[3..].to_string()
+                };
+
+                result.insert(value, JobIdentity(cleaned_key.into()));
+            }
+        }
+
+        if let Ok(jttbl) = globals.get::<mlua::Table>("JTtbl") {
+            for (key, value) in jttbl.pairs::<String, usize>().flatten() {
+                let cleaned_key = if let Some(end) = key.strip_prefix("JT_G_") {
+                    end.to_string()
+                } else if key.starts_with("JT_C1_")
+                    || key.starts_with("JT_C2_")
+                    || key.starts_with("JT_C3_")
+                    || key.starts_with("JT_C4_")
+                    || key.starts_with("JT_C5_")
+                {
+                    key[6..].to_string()
+                } else {
+                    key[3..].to_string()
+                };
+
+                let cleaned_key = cleaned_key.replace("CHONCHON", "chocho");
+
+                result.insert(value, JobIdentity(cleaned_key.into()));
+            }
+        }
+
+        let compacted = HashMap::from_iter(result);
+
+        Ok(compacted)
+    }
+
+    fn try_get<'a, 'b>(library: &'a Library, key: Self::Key<'b>) -> Option<&'a Self> {
+        library.job_identity_table.get(&key)
+    }
+
+    fn get<'a, 'b>(library: &'a Library, key: Self::Key<'b>) -> &'a Self {
+        static DEFAULT: JobIdentity = JobIdentity(Cow::Borrowed("1_f_maria"));
+        Self::try_get(library, key).unwrap_or(&DEFAULT)
+    }
+}

--- a/korangar/src/world/library/map_sky_data.rs
+++ b/korangar/src/world/library/map_sky_data.rs
@@ -1,0 +1,119 @@
+use hashbrown::HashMap;
+use korangar_loaders::FileLoader;
+use mlua::{Lua, Value};
+
+use super::{Library, Table};
+use crate::graphics::Color;
+use crate::loaders::GameFileLoader;
+
+#[allow(unused)]
+#[derive(Debug, Clone)]
+pub struct MapSkyData {
+    old_cloud_effect: Option<usize>,
+    bg_color: Option<Color>,
+    bg_fog: bool,
+    star_effect: bool,
+    cloud_effect: Vec<CloudEffect>,
+}
+
+#[allow(unused)]
+#[derive(Debug, Clone)]
+pub struct CloudEffect {
+    num: usize,
+    cull_dist: usize,
+    color: Color,
+    size: usize,
+    size_extra: usize,
+    expand_rate: f32,
+    alpha_inc_time: usize,
+    alpha_inc_time_extra: usize,
+    alpha_inc_speed: usize,
+    alpha_dec_time: usize,
+    alpha_dec_time_extra: usize,
+    alpha_dec_speed: f32,
+    height: usize,
+    height_extra: usize,
+}
+
+impl Table for MapSkyData {
+    type Key<'a> = &'a str;
+    type Storage = HashMap<String, MapSkyData>;
+
+    fn load(game_file_loader: &GameFileLoader) -> mlua::Result<Self::Storage> {
+        let map_sky_data_table = match game_file_loader.get("data\\luafiles514\\lua files\\mapskydata\\mapskydata.lub") {
+            Ok(data) => {
+                let state = Lua::new();
+                state.load(&data).exec()?;
+
+                let globals = state.globals();
+                let mut result = HashMap::new();
+
+                if let Ok(table) = globals.get::<mlua::Table>("MapSkyData") {
+                    for (map_rsw, map_sky_data_table) in table.pairs::<String, mlua::Table>().flatten() {
+                        let resource_name = map_rsw.strip_suffix(".rsw").unwrap_or(&map_rsw).to_string();
+                        let map_sky_data = Self::parse_map_sky_data(&map_sky_data_table);
+                        result.insert(resource_name, map_sky_data);
+                    }
+                }
+
+                HashMap::from_iter(result)
+            }
+            Err(_) => HashMap::new(),
+        };
+
+        Ok(map_sky_data_table)
+    }
+
+    fn try_get<'a, 'b>(library: &'a Library, key: Self::Key<'b>) -> Option<&'a Self> {
+        library.map_sky_data_table.get(key)
+    }
+
+    fn get<'a, 'b>(library: &'a Library, key: Self::Key<'b>) -> &'a Self {
+        static DEFAULT: MapSkyData = MapSkyData {
+            old_cloud_effect: None,
+            bg_color: None,
+            bg_fog: false,
+            star_effect: false,
+            cloud_effect: vec![],
+        };
+        Self::try_get(library, key).unwrap_or(&DEFAULT)
+    }
+}
+
+impl MapSkyData {
+    fn parse_map_sky_data(table: &mlua::Table) -> MapSkyData {
+        let mut cloud_effect = Vec::new();
+
+        if let Ok(Value::Table(cloud_effect_table)) = table.get("Cloud_Effect") {
+            let _ = cloud_effect_table.for_each(|_key: usize, value: mlua::Table| {
+                let effect = CloudEffect {
+                    num: value.get("Num").unwrap_or_default(),
+                    cull_dist: value.get("CullDist").unwrap_or_default(),
+                    color: value.get("Color").unwrap_or_default(),
+                    size: value.get("Size").unwrap_or_default(),
+                    size_extra: value.get("Size_Extra").unwrap_or_default(),
+                    expand_rate: value.get("Expand_Rate").unwrap_or_default(),
+                    alpha_inc_time: value.get("Alpha_Inc_Time").unwrap_or_default(),
+                    alpha_inc_time_extra: value.get("Alpha_Inc_Time_Extra").unwrap_or_default(),
+                    alpha_inc_speed: value.get("Alpha_Inc_Speed").unwrap_or_default(),
+                    alpha_dec_time: value.get("Alpha_Dec_Time").unwrap_or_default(),
+                    alpha_dec_time_extra: value.get("Alpha_Dec_Time_Extra").unwrap_or_default(),
+                    alpha_dec_speed: value.get("Alpha_Dec_Speed").unwrap_or_default(),
+                    height: value.get("Height").unwrap_or_default(),
+                    height_extra: value.get("Height_Extra").unwrap_or_default(),
+                };
+                cloud_effect.push(effect);
+
+                Ok(())
+            });
+        }
+
+        MapSkyData {
+            old_cloud_effect: table.get::<[usize; 1]>("Old_Cloud_Effect").ok().map(|effect| effect[0]),
+            bg_color: table.get("BG_Color").ok(),
+            bg_fog: table.get("BG_Fog").unwrap_or(false),
+            star_effect: table.get("Star_Effect").unwrap_or(false),
+            cloud_effect,
+        }
+    }
+}

--- a/korangar/src/world/library/mod.rs
+++ b/korangar/src/world/library/mod.rs
@@ -1,276 +1,57 @@
-use std::sync::Arc;
+mod item_info;
+mod item_name;
+mod item_resource;
+mod job_identity;
+mod map_sky_data;
 
 use encoding_rs::EUC_KR;
-use hashbrown::HashMap;
-use korangar_loaders::FileLoader;
-use korangar_networking::{InventoryItem, NoMetadata, ShopItem};
-use mlua::{Lua, Value};
-use ragnarok_packets::ItemId;
 
-use crate::graphics::{Color, Texture};
-use crate::loaders::{AsyncLoader, GameFileLoader, ImageType, ItemLocation};
-
-#[derive(Debug, Clone)]
-pub struct ResourceMetadata {
-    pub texture: Option<Arc<Texture>>,
-    pub name: String,
-}
-
-#[derive(Debug, Clone)]
-struct ItemInfo {
-    identified_name: Option<String>,
-    unidentified_name: Option<String>,
-    identified_resource: Option<String>,
-    unidentified_resource: Option<String>,
-}
-
-#[allow(unused)]
-#[derive(Debug, Clone)]
-pub struct MapSkyData {
-    old_cloud_effect: Option<usize>,
-    bg_color: Option<Color>,
-    bg_fog: bool,
-    star_effect: bool,
-    cloud_effect: Vec<CloudEffect>,
-}
-
-#[allow(unused)]
-#[derive(Debug, Clone)]
-pub struct CloudEffect {
-    num: usize,
-    cull_dist: usize,
-    color: Color,
-    size: usize,
-    size_extra: usize,
-    expand_rate: f32,
-    alpha_inc_time: usize,
-    alpha_inc_time_extra: usize,
-    alpha_inc_speed: usize,
-    alpha_dec_time: usize,
-    alpha_dec_time_extra: usize,
-    alpha_dec_speed: f32,
-    height: usize,
-    height_extra: usize,
-}
+pub use self::item_info::ItemInfo;
+pub use self::item_name::{ItemName, ItemNameKey};
+pub use self::item_resource::{ItemResource, ItemResourceKey};
+pub use self::job_identity::JobIdentity;
+pub use self::map_sky_data::MapSkyData;
+use crate::loaders::GameFileLoader;
 
 pub struct Library {
-    job_identity_table: HashMap<usize, String>,
-    item_table: HashMap<ItemId, ItemInfo>,
-    map_sky_data_table: HashMap<String, MapSkyData>,
+    job_identity_table: <JobIdentity as Table>::Storage,
+    item_info_table: <ItemInfo as Table>::Storage,
+    map_sky_data_table: <MapSkyData as Table>::Storage,
 }
 
 impl Library {
     pub fn new(game_file_loader: &GameFileLoader) -> mlua::Result<Self> {
-        let state = Lua::new();
-
-        let data = game_file_loader
-            .get("data\\luafiles514\\lua files\\datainfo\\jobidentity.lub")
-            .unwrap();
-        state.load(&data).exec()?;
-
-        let data = game_file_loader
-            .get("data\\luafiles514\\lua files\\datainfo\\npcidentity.lub")
-            .unwrap();
-        state.load(&data).exec()?;
-
-        let job_identity_table = Self::load_job_identity_table(&state)?;
-
-        let state = Lua::new();
-
-        let data = game_file_loader
-            .get("data\\luafiles514\\lua files\\datainfo\\iteminfo.lub")
-            .unwrap();
-        state.load(&data).exec()?;
-
-        let item_table = Self::load_item_table(&state)?;
-
-        let map_sky_data_table = match game_file_loader.get("data\\luafiles514\\lua files\\mapskydata\\mapskydata.lub") {
-            Ok(data) => {
-                let state = Lua::new();
-                state.load(&data).exec()?;
-                Self::load_map_sky_data_table(&state)?
-            }
-            Err(_) => HashMap::new(),
-        };
+        let job_identity_table = JobIdentity::load(game_file_loader)?;
+        let item_info_table = ItemInfo::load(game_file_loader)?;
+        let map_sky_data_table = MapSkyData::load(game_file_loader)?;
 
         Ok(Self {
             job_identity_table,
-            item_table,
+            item_info_table,
             map_sky_data_table,
         })
     }
 
-    pub fn load_job_identity_table(state: &Lua) -> mlua::Result<HashMap<usize, String>> {
-        let globals = state.globals();
-        let mut result = HashMap::new();
-
-        if let Ok(jobtbl) = globals.get::<mlua::Table>("jobtbl") {
-            for (key, value) in jobtbl.pairs::<String, usize>().flatten() {
-                let cleaned_key = if let Some(end) = key.strip_prefix("JT_G_") {
-                    end.to_string()
-                } else {
-                    key[3..].to_string()
-                };
-
-                result.insert(value, cleaned_key);
-            }
-        }
-
-        if let Ok(jttbl) = globals.get::<mlua::Table>("JTtbl") {
-            for (key, value) in jttbl.pairs::<String, usize>().flatten() {
-                let cleaned_key = if let Some(end) = key.strip_prefix("JT_G_") {
-                    end.to_string()
-                } else if key.starts_with("JT_C1_")
-                    || key.starts_with("JT_C2_")
-                    || key.starts_with("JT_C3_")
-                    || key.starts_with("JT_C4_")
-                    || key.starts_with("JT_C5_")
-                {
-                    key[6..].to_string()
-                } else {
-                    key[3..].to_string()
-                };
-
-                let cleaned_key = cleaned_key.replace("CHONCHON", "chocho");
-
-                result.insert(value, cleaned_key);
-            }
-        }
-
-        let compacted = HashMap::from_iter(result);
-
-        Ok(compacted)
+    #[inline(always)]
+    pub fn get<T: Table>(&self, key: T::Key<'_>) -> &T {
+        T::get(self, key)
     }
+}
 
-    fn load_item_table(state: &Lua) -> mlua::Result<HashMap<ItemId, ItemInfo>> {
-        let globals = state.globals();
-        let mut result = HashMap::new();
+/// Trait for data that can be stored in a table and retrieved using a key.
+pub trait Table {
+    type Key<'a>;
+    type Storage;
 
-        if let Ok(table) = globals.get::<mlua::Table>("tbl") {
-            for (item_id, item_table) in table.pairs::<u32, mlua::Table>().flatten() {
-                let info = ItemInfo {
-                    identified_name: item_table.get("identifiedDisplayName").ok().map(fix_encoding),
-                    unidentified_name: item_table.get("unidentifiedDisplayName").ok().map(fix_encoding),
-                    identified_resource: item_table.get("identifiedResourceName").ok().map(fix_encoding),
-                    unidentified_resource: item_table.get("unidentifiedResourceName").ok().map(fix_encoding),
-                };
+    fn load(game_file_loader: &GameFileLoader) -> mlua::Result<Self::Storage>;
 
-                result.insert(ItemId(item_id), info);
-            }
-        }
+    fn try_get<'a, 'b>(library: &'a Library, key: Self::Key<'b>) -> Option<&'a Self>
+    where
+        Self: Sized;
 
-        let compacted = HashMap::from_iter(result);
-
-        Ok(compacted)
-    }
-
-    fn load_map_sky_data_table(state: &Lua) -> mlua::Result<HashMap<String, MapSkyData>> {
-        let globals = state.globals();
-        let mut result = HashMap::new();
-
-        if let Ok(table) = globals.get::<mlua::Table>("MapSkyData") {
-            for (map_rsw, map_sky_data_table) in table.pairs::<String, mlua::Table>().flatten() {
-                let resource_name = map_rsw.strip_suffix(".rsw").unwrap_or(&map_rsw).to_string();
-                let map_sky_data = Self::parse_map_sky_data(&map_sky_data_table);
-                result.insert(resource_name, map_sky_data);
-            }
-        }
-
-        let compacted = HashMap::from_iter(result);
-
-        Ok(compacted)
-    }
-
-    fn parse_map_sky_data(table: &mlua::Table) -> MapSkyData {
-        let mut cloud_effect = Vec::new();
-
-        if let Ok(Value::Table(cloud_effect_table)) = table.get("Cloud_Effect") {
-            let _ = cloud_effect_table.for_each(|_key: usize, value: mlua::Table| {
-                let effect = CloudEffect {
-                    num: value.get("Num").unwrap_or_default(),
-                    cull_dist: value.get("CullDist").unwrap_or_default(),
-                    color: value.get("Color").unwrap_or_default(),
-                    size: value.get("Size").unwrap_or_default(),
-                    size_extra: value.get("Size_Extra").unwrap_or_default(),
-                    expand_rate: value.get("Expand_Rate").unwrap_or_default(),
-                    alpha_inc_time: value.get("Alpha_Inc_Time").unwrap_or_default(),
-                    alpha_inc_time_extra: value.get("Alpha_Inc_Time_Extra").unwrap_or_default(),
-                    alpha_inc_speed: value.get("Alpha_Inc_Speed").unwrap_or_default(),
-                    alpha_dec_time: value.get("Alpha_Dec_Time").unwrap_or_default(),
-                    alpha_dec_time_extra: value.get("Alpha_Dec_Time_Extra").unwrap_or_default(),
-                    alpha_dec_speed: value.get("Alpha_Dec_Speed").unwrap_or_default(),
-                    height: value.get("Height").unwrap_or_default(),
-                    height_extra: value.get("Height_Extra").unwrap_or_default(),
-                };
-                cloud_effect.push(effect);
-
-                Ok(())
-            });
-        }
-
-        MapSkyData {
-            old_cloud_effect: table.get::<[usize; 1]>("Old_Cloud_Effect").ok().map(|effect| effect[0]),
-            bg_color: table.get("BG_Color").ok(),
-            bg_fog: table.get("BG_Fog").unwrap_or(false),
-            star_effect: table.get("Star_Effect").unwrap_or(false),
-            cloud_effect,
-        }
-    }
-
-    pub fn get_job_identity_from_id(&self, job_id: usize) -> &str {
-        self.job_identity_table
-            .get(&job_id)
-            .map(|name| name.as_str())
-            .unwrap_or("1_f_maria")
-    }
-
-    fn get_item_name_from_id(&self, item_id: ItemId, is_identified: bool) -> &str {
-        match is_identified {
-            true => self.item_table.get(&item_id).and_then(|info| info.identified_name.as_deref()),
-            false => self.item_table.get(&item_id).and_then(|info| info.unidentified_name.as_deref()),
-        }
-        .unwrap_or("NOTFOUND")
-    }
-
-    fn get_item_resource_from_id(&self, item_id: ItemId, is_identified: bool) -> &str {
-        match is_identified {
-            true => self.item_table.get(&item_id).and_then(|info| info.identified_resource.as_deref()),
-            false => self.item_table.get(&item_id).and_then(|info| info.unidentified_resource.as_deref()),
-        }
-        .unwrap_or("사과") // Apple
-    }
-
-    pub fn get_map_sky_data_from_resource_file(&self, resource_file: &str) -> Option<&MapSkyData> {
-        self.map_sky_data_table.get(resource_file)
-    }
-
-    pub fn load_inventory_item_metadata(
-        &self,
-        async_loader: &AsyncLoader,
-        item: InventoryItem<NoMetadata>,
-    ) -> InventoryItem<ResourceMetadata> {
-        let is_identified = item.is_identified();
-
-        let resource_name = self.get_item_resource_from_id(item.item_id, is_identified);
-        let full_path = format!("유저인터페이스\\item\\{resource_name}.bmp");
-        let texture = async_loader.request_item_sprite_load(ItemLocation::Inventory, item.item_id, &full_path, ImageType::Color);
-        let name = self.get_item_name_from_id(item.item_id, is_identified).to_string();
-
-        let metadata = ResourceMetadata { texture, name };
-
-        InventoryItem { metadata, ..item }
-    }
-
-    pub fn load_shop_item_metadata(&self, async_loader: &AsyncLoader, item: ShopItem<NoMetadata>) -> ShopItem<ResourceMetadata> {
-        let resource_name = self.get_item_resource_from_id(item.item_id, true);
-        let full_path = format!("유저인터페이스\\item\\{resource_name}.bmp");
-        let texture = async_loader.request_item_sprite_load(ItemLocation::Shop, item.item_id, &full_path, ImageType::Color);
-        let name = self.get_item_name_from_id(item.item_id, true).to_string();
-
-        let metadata = ResourceMetadata { texture, name };
-
-        ShopItem { metadata, ..item }
-    }
+    fn get<'a, 'b>(library: &'a Library, key: Self::Key<'b>) -> &'a Self
+    where
+        Self: Sized;
 }
 
 fn fix_encoding(broken: String) -> String {

--- a/korangar/src/world/mod.rs
+++ b/korangar/src/world/mod.rs
@@ -13,6 +13,8 @@ mod pathing;
 mod sound;
 mod video;
 
+use std::sync::Arc;
+
 pub use self::action::*;
 pub use self::animation::*;
 pub use self::cameras::*;
@@ -27,6 +29,7 @@ pub use self::particles::*;
 pub use self::pathing::*;
 pub use self::sound::*;
 pub use self::video::*;
+use crate::graphics::Texture;
 
 pub struct ResourceSetBuffer<K> {
     visible: Vec<K>,
@@ -57,4 +60,10 @@ impl<K> ResourceSet<'_, K> {
     pub(super) fn iterate_visible(&self) -> std::slice::Iter<'_, K> {
         self.visible.iter()
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct ResourceMetadata {
+    pub texture: Option<Arc<Texture>>,
+    pub name: String,
 }


### PR DESCRIPTION
We only have now one typed function. The items in the library have their own file, that only need to implement the Table trait to properly provide all needed functionality.

We currently don't expose try_get(), since it's not used and I don't want to check in dead code. But since the traits implement all try_get() we could add it later easily if needed.