### PR TITLE
Use cpu target x86-64-v3 instead of hand rolled target features

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,5 @@
-# Steam Hardware survey: https://store.steampowered.com/hwsurvey/Steam-Hardware-Software-Survey-Welcome-to-Steam
 [target.'cfg(target_arch="x86_64")']
-rustflags = ["-C", "target-feature=+aes,+avx,+avx2,+cmpxchg16b,+fma,+sse3,+ssse3,+sse4.1,+sse4.2"]
+rustflags = ["-C", "target_cpu=x86-64-v3", "-C", "target-feature=+aes"]
 
 [target.'cfg(target_arch="aarch64")']
 rustflags = ["-C", "target-feature=+aes"]


### PR DESCRIPTION
 - AMD CPUs since 2011 (Excavator)
 - Intel CPUs since 2013 (Haswell)
 
 https://en.wikipedia.org/wiki/X86-64#Microarchitecture_levels
 
 On linux the supported level can be checked with:
 
 `/lib64/ld-linux-x86-64.so.2 --help`