### PR TITLE
Fix directional shadows on Metal

### DIFF
--- a/korangar/src/graphics/mod.rs
+++ b/korangar/src/graphics/mod.rs
@@ -1249,7 +1249,7 @@ impl GlobalContext {
                 entries: &[
                     BindGroupLayoutEntry {
                         binding: 0,
-                        visibility: ShaderStages::all(),
+                        visibility: ShaderStages::VERTEX_FRAGMENT | ShaderStages::COMPUTE,
                         ty: BindingType::Buffer {
                             ty: BufferBindingType::Uniform,
                             has_dynamic_offset: false,
@@ -1335,7 +1335,7 @@ impl GlobalContext {
                 entries: &[
                     BindGroupLayoutEntry {
                         binding: 0,
-                        visibility: ShaderStages::all(),
+                        visibility: ShaderStages::FRAGMENT,
                         ty: BindingType::Buffer {
                             ty: BufferBindingType::Uniform,
                             has_dynamic_offset: false,
@@ -1444,7 +1444,7 @@ impl GlobalContext {
                 entries: &[
                     BindGroupLayoutEntry {
                         binding: 0,
-                        visibility: ShaderStages::all(),
+                        visibility: ShaderStages::COMPUTE,
                         ty: BindingType::Buffer {
                             ty: BufferBindingType::Uniform,
                             has_dynamic_offset: false,
@@ -1514,7 +1514,7 @@ impl GlobalContext {
                 entries: &[
                     BindGroupLayoutEntry {
                         binding: 0,
-                        visibility: ShaderStages::all(),
+                        visibility: ShaderStages::VERTEX_FRAGMENT,
                         ty: BindingType::Buffer {
                             ty: BufferBindingType::Uniform,
                             has_dynamic_offset: false,


### PR DESCRIPTION
This fixed the issue we face since WGPU 28.
It seems that using `ShaderStages::all()` on the
uniforms for the directional shadows led Metal
to always read "zero" from those uniform buffers.

Tightening the permissions fixed this issue.
I can't say what exactly broke in the WGPU layer
for this odd behavior.